### PR TITLE
fix(start-dev.sh): replace sed -l with sed -u for Linux compatibility

### DIFF
--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -80,7 +80,7 @@ start_with_logs() {
   shift 3
 
   "$@" > >(
-    tee -a "$log_file" | sed -l "s/^/[$tag] /" | tee -a "$COMBINED_LOG"
+    tee -a "$log_file" | sed -u "s/^/[$tag] /" | tee -a "$COMBINED_LOG"
   ) 2>&1 &
   printf -v "$pid_var" '%s' "$!"
 }


### PR DESCRIPTION
## Summary
sed -l on Linux (GNU sed) expects a numeric argument (line length), causing the command to fail immediately. On macOS (BSD sed), -l means line-buffered output. This cross-platform incompatibility breaks the frontend startup script on Linux.

## Fix
Replace sed -l with sed -u (unbuffered), which works consistently on both Linux and macOS.

## Changed
- scripts/start-dev.sh: single line change (sed -l → sed -u)

## Ref
Fixes Gracker/SmartPerfetto#11