### PR TITLE
Handle max-turn SDK results without aborting SSE

### DIFF
--- a/backend/src/agentv3/__tests__/claudeSseBridge.test.ts
+++ b/backend/src/agentv3/__tests__/claudeSseBridge.test.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 Gracker (Chris)
+// This file is part of SmartPerfetto. See LICENSE for details.
+
+import { describe, expect, it } from '@jest/globals';
+import { createSseBridge } from '../claudeSseBridge';
+import type { StreamingUpdate } from '../../agent/types';
+
+describe('createSseBridge', () => {
+  it('does not emit a terminal error for SDK max-turn results', () => {
+    const updates: StreamingUpdate[] = [];
+    const bridge = createSseBridge((update) => updates.push(update));
+
+    bridge.handleMessage({
+      type: 'result',
+      subtype: 'error_max_turns',
+      errors: [],
+      num_turns: 84,
+    });
+
+    expect(updates.some(update => update.type === 'error')).toBe(false);
+    expect(updates).toContainEqual(expect.objectContaining({
+      type: 'progress',
+      content: expect.objectContaining({
+        phase: 'concluding',
+      }),
+    }));
+  });
+
+  it('still emits errors for non-recoverable SDK result failures', () => {
+    const updates: StreamingUpdate[] = [];
+    const bridge = createSseBridge((update) => updates.push(update));
+
+    bridge.handleMessage({
+      type: 'result',
+      subtype: 'error_during_execution',
+      errors: ['boom'],
+    });
+
+    expect(updates).toContainEqual(expect.objectContaining({
+      type: 'error',
+      content: expect.objectContaining({
+        message: 'Claude analysis error (error_during_execution): boom',
+        subtype: 'error_during_execution',
+      }),
+    }));
+  });
+});

--- a/backend/src/agentv3/claudeSseBridge.ts
+++ b/backend/src/agentv3/claudeSseBridge.ts
@@ -62,6 +62,12 @@ export interface SseBridge {
   getAccumulatedAnswer: () => string;
 }
 
+const RECOVERABLE_RESULT_SUBTYPES = new Set(['error_max_turns']);
+
+function isRecoverableResultSubtype(subtype: unknown): boolean {
+  return typeof subtype === 'string' && RECOVERABLE_RESULT_SUBTYPES.has(subtype);
+}
+
 /**
  * Creates a bridge function that translates Agent SDK messages into
  * SmartPerfetto StreamingUpdate events for SSE forwarding to the frontend.
@@ -269,6 +275,16 @@ export function createSseBridge(emit: UpdateEmitter): SseBridge {
         emit({
           type: 'conclusion',
           content: { conclusion: msg.result || '', durationMs: msg.duration_ms, turns: msg.num_turns, costUsd: msg.total_cost_usd },
+          timestamp: now,
+        });
+      } else if (isRecoverableResultSubtype(msg.subtype)) {
+        emit({
+          type: 'progress',
+          content: {
+            phase: 'concluding',
+            message: '分析达到轮次上限，正在整理已收集结果...',
+            subtype: msg.subtype,
+          },
           timestamp: now,
         });
       } else {


### PR DESCRIPTION
## Summary
  - Treat SDK `error_max_turns` as a recoverable result in the SSE bridge.
  - Emit a `concluding` progress update instead of a terminal `error`.
  - Add regression coverage for recoverable max-turn results and non-recoverable SDK failures.

## Root Cause
The SSE bridge emitted a terminal error as soon as the SDK returned `error_max_turns`, even though the runtime could still recover streamed answer tokens and continue conclusion/verification handling.

## Validation
- npm test -- --runInBand src/agentv3/__tests__/claudeSseBridge.test.ts
- npm run test:scene-trace-regression

<img width="2992" height="710" alt="img_v3_02117_a3cad379-1af7-49a0-b52c-3e20f78eebfg" src="https://github.com/user-attachments/assets/88bb8e7c-8ee3-4442-adca-f55e0892b05d" />
