### PR TITLE
feat: add aws bedrock support

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -44,7 +44,15 @@
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 
 # ===================================================
-# Option 2: Third-party LLM via API Proxy
+# Option 2: AWS Bedrock (Bearer Token)
+# ===================================================
+# Use Claude via AWS Bedrock with bearer token authentication.
+# CLAUDE_CODE_USE_BEDROCK=1
+# ANTHROPIC_BEDROCK_BASE_URL=https://bedrock-runtime.us-east-1.amazonaws.com
+# AWS_BEARER_TOKEN_BEDROCK=your_bearer_token_here
+
+# ===================================================
+# Option 3: Third-party LLM via API Proxy
 # ===================================================
 # Uncomment ONE provider block below. All require a proxy
 # (one-api / new-api / LiteLLM) that accepts Anthropic API

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "smart-perfetto-backend",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.63",
         "@types/better-sqlite3": "^7.6.13",
@@ -16,6 +16,7 @@
         "@types/uuid": "^9.0.8",
         "axios": "^1.13.2",
         "better-sqlite3": "^12.5.0",
+        "commander": "^14.0.2",
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
@@ -28,6 +29,9 @@
         "uuid": "^9.0.1",
         "zod": "^4.3.6"
       },
+      "bin": {
+        "smartperfetto": "dist/cli-user/bin.js"
+      },
       "devDependencies": {
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
@@ -37,7 +41,6 @@
         "@types/multer": "^2.0.0",
         "@types/supertest": "^6.0.3",
         "chalk": "^5.6.2",
-        "commander": "^14.0.2",
         "glob": "^13.0.0",
         "jest": "^30.2.0",
         "supertest": "^7.2.2",
@@ -3538,7 +3541,6 @@
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/backend/src/agentv3/claudeConfig.ts
+++ b/backend/src/agentv3/claudeConfig.ts
@@ -89,6 +89,71 @@ export function resolveEffort(config: ClaudeAgentConfig, sceneType?: SceneType):
   return config.effort;
 }
 
+export interface BedrockStatus {
+  enabled: boolean;
+  hasAuth: boolean;
+  authMethod?: 'bearer_token' | 'iam_credentials' | 'profile_or_chain';
+  region: string;
+  baseUrl?: string;
+  missing?: string[];
+}
+
+/**
+ * Detects whether AWS Bedrock is configured and whether its authentication
+ * credentials are complete. Supports three auth paths:
+ *   1. Bearer token: AWS_BEARER_TOKEN_BEDROCK
+ *   2. IAM credentials: AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY (+ optional AWS_SESSION_TOKEN)
+ *   3. AWS profile / default credential chain: AWS_PROFILE or implicit chain resolution
+ */
+export function detectBedrock(): BedrockStatus {
+  const enabled = Boolean(process.env.CLAUDE_CODE_USE_BEDROCK);
+  if (!enabled) return { enabled: false, hasAuth: false, region: 'us-east-1' };
+
+  const region = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-east-1';
+  const baseUrl = process.env.ANTHROPIC_BEDROCK_BASE_URL || undefined;
+
+  if (process.env.AWS_BEARER_TOKEN_BEDROCK) {
+    return { enabled: true, hasAuth: true, authMethod: 'bearer_token', region, baseUrl };
+  }
+
+  if (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) {
+    return { enabled: true, hasAuth: true, authMethod: 'iam_credentials', region, baseUrl };
+  }
+
+  if (process.env.AWS_PROFILE) {
+    return { enabled: true, hasAuth: true, authMethod: 'profile_or_chain', region, baseUrl };
+  }
+
+  // CLAUDE_CODE_USE_BEDROCK is set but no explicit credentials found.
+  // The SDK will still attempt the default AWS credential chain (EC2 metadata,
+  // ECS task role, ~/.aws/credentials, etc.), so we treat this as potentially valid.
+  const missing: string[] = [];
+  if (!process.env.AWS_BEARER_TOKEN_BEDROCK) missing.push('AWS_BEARER_TOKEN_BEDROCK');
+  if (!process.env.AWS_ACCESS_KEY_ID) missing.push('AWS_ACCESS_KEY_ID');
+  if (!process.env.AWS_PROFILE) missing.push('AWS_PROFILE');
+
+  return {
+    enabled: true,
+    hasAuth: true,
+    authMethod: 'profile_or_chain',
+    region,
+    baseUrl,
+    missing,
+  };
+}
+
+/**
+ * Returns true when any supported Claude credential source is present:
+ * direct API key, proxy base URL, or AWS Bedrock.
+ */
+export function hasClaudeCredentials(): boolean {
+  return !!(
+    process.env.ANTHROPIC_API_KEY ||
+    process.env.ANTHROPIC_BASE_URL ||
+    detectBedrock().enabled
+  );
+}
+
 /**
  * Check if ClaudeRuntime (agentv3) is the active orchestrator.
  * Defaults to true — agentv2 is deprecated. Set AI_SERVICE=deepseek to use legacy path.

--- a/backend/src/cli-user/bootstrap.ts
+++ b/backend/src/cli-user/bootstrap.ts
@@ -20,6 +20,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as dotenv from 'dotenv';
 import { computePaths, ensureLayout, type CliPaths } from './io/paths';
+import { hasClaudeCredentials } from '../agentv3/claudeConfig';
 
 export interface BootstrapOptions {
   envFile?: string;
@@ -139,13 +140,11 @@ function findBackendRoot(): string | null {
 }
 
 function assertLlmCredentials(): void {
-  const hasKey = Boolean(process.env.ANTHROPIC_API_KEY);
-  const hasProxy = Boolean(process.env.ANTHROPIC_BASE_URL);
-  if (hasKey || hasProxy) return;
+  if (hasClaudeCredentials()) return;
   throw new Error(
     [
       'Missing Claude credentials.',
-      'Set ANTHROPIC_API_KEY (or ANTHROPIC_BASE_URL for proxy setups) before running.',
+      'Set ANTHROPIC_API_KEY (or ANTHROPIC_BASE_URL for proxy, or envs for AWS Bedrock) before running.',
       'The CLI reads backend/.env by default; pass --env-file <path> to override.',
     ].join(' '),
   );

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -31,7 +31,7 @@ import {
   assertTraceAnalysisConfiguredForStartup,
   getTraceAnalysisConfigurationStatus,
 } from './services/traceAnalysisSkill';
-import { isClaudeCodeEnabled } from './agentv3/claudeConfig';
+import { isClaudeCodeEnabled, hasClaudeCredentials } from './agentv3/claudeConfig';
 import {
   getLegacyApiUsageSnapshot,
 } from './services/legacyApiTelemetry';
@@ -77,7 +77,7 @@ app.get('/health', (req, res) => {
         ? (process.env.CLAUDE_MODEL || 'claude-sonnet-4-6')
         : (process.env.DEEPSEEK_MODEL || 'deepseek-chat'),
       configured: useAgentV3
-        ? !!process.env.ANTHROPIC_API_KEY
+        ? hasClaudeCredentials()
         : !!process.env.DEEPSEEK_API_KEY,
       authRequired: !!process.env.SMARTPERFETTO_API_KEY,
     },


### PR DESCRIPTION
<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
<!-- Copyright (C) 2024-2026 Gracker (Chris) | SmartPerfetto -->

## Summary

<!-- 1-3 bullet points: what changed and why. -->

-
-

## Linked Issue

<!-- Link a GitHub issue if applicable, e.g., Fixes #123 -->

## Change Type

<!-- Check all that apply -->

- [ ] feat (new capability)
- [ ] fix (bug fix, no API change)
- [ ] refactor (internal cleanup, no behavior change)
- [ ] docs (documentation only)
- [ ] chore (build, CI, tooling, dependency updates)
- [ ] skill / strategy (YAML skill or `.strategy.md` / `.template.md`)

## Affected Areas

<!-- Check all that apply — helps reviewers route attention -->

- [ ] `backend/src/agentv3/` (primary runtime: ClaudeRuntime, MCP server, verifier)
- [ ] `backend/skills/` (YAML skills)
- [ ] `backend/strategies/` (`*.strategy.md`, `*.template.md`, `knowledge-*`)
- [ ] `perfetto/ui/src/plugins/com.smartperfetto.AIAssistant/` (frontend)
- [ ] `scripts/` / `backend/scripts/` (tooling, generators)
- [ ] `.github/workflows/` (CI)
- [ ] Tests only

## Done Conditions

<!-- All code changes must satisfy these. Check after running. -->

- [ ] `cd backend && npx tsc --noEmit` → 0 errors
- [ ] `cd backend && npm run test:scene-trace-regression` → all 6 canonical traces pass
- [ ] `cd backend && npm run test:core` → green (if tests were added / modified)
- [ ] `cd backend && npm run validate:skills` → passes (for YAML skill changes)
- [ ] `cd backend && npm run validate:strategies` → passes (for strategy changes)
- [ ] New `.ts` / `.yaml` / `.sh` / `.strategy.md` files carry SPDX AGPL v3 header

## Test Plan

<!-- How did you verify this change? What would a reviewer run? -->

-

## Risk / Rollback

<!-- What could break? How do we back this out if it ships wrong? -->

-

## Notes for Reviewers

<!-- Anything else: design decisions, tradeoffs considered, follow-up work -->

-
