### PR TITLE
docs(runtime): clarify provider proxy diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,19 @@ CLAUDE_LIGHT_MODEL=your-light-model
 
 Known proxy options include [one-api](https://github.com/songquanpeng/one-api), [new-api](https://github.com/Calcium-Ion/new-api), and [LiteLLM](https://github.com/BerriAI/litellm). The selected model must support streaming and tool/function calling reliably. See [backend/.env.example](backend/.env.example) for provider examples and tuning options.
 
+> Note: provider switchers such as CC Switch, Codex CLI, Gemini CLI, and OpenCode manage their own CLI configuration files and login state. SmartPerfetto does not automatically read those CLI credentials. The web and CLI analysis paths currently use the Claude Agent SDK runtime; use `ANTHROPIC_BASE_URL` when connecting third-party providers such as MiMo, DeepSeek, OpenAI, Kimi, or MiniMax.
+
+If your Claude Code subscription quota is unavailable, or if you want to evaluate a third-party model, prefer the proxy path:
+
+```bash
+ANTHROPIC_BASE_URL=http://localhost:3000
+ANTHROPIC_API_KEY=sk-proxy-xxx
+CLAUDE_MODEL=your-provider-main-model
+CLAUDE_LIGHT_MODEL=your-provider-light-model
+```
+
+Restart the backend after changing provider settings. `GET /health` returns `aiEngine.providerMode` and `aiEngine.diagnostics` so you can confirm whether the runtime is using Anthropic direct access, AWS Bedrock, or an Anthropic-compatible proxy.
+
 ### Turn Budgets
 
 SmartPerfetto has separate turn budgets for fast and full analysis:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -147,6 +147,19 @@ CLAUDE_LIGHT_MODEL=your-light-model
 
 常见代理包括 [one-api](https://github.com/songquanpeng/one-api)、[new-api](https://github.com/Calcium-Ion/new-api) 和 [LiteLLM](https://github.com/BerriAI/litellm)。选择的模型需要稳定支持流式输出和 tool/function calling。完整厂商示例和调优参数见 [backend/.env.example](backend/.env.example)。
 
+> 注意：CC Switch、Codex CLI、Gemini CLI、OpenCode 等工具可以管理各自 CLI 的 provider 配置，但 SmartPerfetto 后端当前不会自动读取这些 CLI 的登录态或配置文件。Web 和 CLI 分析路径默认使用 Claude Agent SDK；接入 MiMo、DeepSeek、OpenAI、Kimi、MiniMax 等第三方模型时，请通过 `ANTHROPIC_BASE_URL` 暴露 Anthropic Messages 兼容接口。
+
+如果 Claude Code 订阅额度用尽，或希望验证第三方模型，可以优先使用代理方式：
+
+```bash
+ANTHROPIC_BASE_URL=http://localhost:3000
+ANTHROPIC_API_KEY=sk-proxy-xxx
+CLAUDE_MODEL=your-provider-main-model
+CLAUDE_LIGHT_MODEL=your-provider-light-model
+```
+
+修改配置后需要重启后端。`GET /health` 会返回 `aiEngine.providerMode` 和 `aiEngine.diagnostics`，用于确认当前是 Anthropic 直连、AWS Bedrock 还是 Anthropic 兼容代理。
+
 ### 轮次预算
 
 SmartPerfetto 区分 fast 和 full 两套轮次预算：

--- a/backend/src/agentv3/__tests__/claudeConfig.test.ts
+++ b/backend/src/agentv3/__tests__/claudeConfig.test.ts
@@ -3,15 +3,50 @@
 // This file is part of SmartPerfetto. See LICENSE for details.
 
 import { afterEach, describe, expect, it } from '@jest/globals';
-import { createQuickConfig, loadClaudeConfig } from '../claudeConfig';
+import {
+  createQuickConfig,
+  explainClaudeRuntimeError,
+  getClaudeRuntimeDiagnostics,
+  loadClaudeConfig,
+} from '../claudeConfig';
 
 const ORIGINAL_QUICK_MAX_TURNS = process.env.CLAUDE_QUICK_MAX_TURNS;
+const ORIGINAL_ANTHROPIC_BASE_URL = process.env.ANTHROPIC_BASE_URL;
+const ORIGINAL_ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+const ORIGINAL_CLAUDE_MODEL = process.env.CLAUDE_MODEL;
+const ORIGINAL_CLAUDE_LIGHT_MODEL = process.env.CLAUDE_LIGHT_MODEL;
+const ORIGINAL_CLAUDE_CODE_USE_BEDROCK = process.env.CLAUDE_CODE_USE_BEDROCK;
 
 afterEach(() => {
   if (ORIGINAL_QUICK_MAX_TURNS === undefined) {
     delete process.env.CLAUDE_QUICK_MAX_TURNS;
   } else {
     process.env.CLAUDE_QUICK_MAX_TURNS = ORIGINAL_QUICK_MAX_TURNS;
+  }
+  if (ORIGINAL_ANTHROPIC_BASE_URL === undefined) {
+    delete process.env.ANTHROPIC_BASE_URL;
+  } else {
+    process.env.ANTHROPIC_BASE_URL = ORIGINAL_ANTHROPIC_BASE_URL;
+  }
+  if (ORIGINAL_ANTHROPIC_API_KEY === undefined) {
+    delete process.env.ANTHROPIC_API_KEY;
+  } else {
+    process.env.ANTHROPIC_API_KEY = ORIGINAL_ANTHROPIC_API_KEY;
+  }
+  if (ORIGINAL_CLAUDE_MODEL === undefined) {
+    delete process.env.CLAUDE_MODEL;
+  } else {
+    process.env.CLAUDE_MODEL = ORIGINAL_CLAUDE_MODEL;
+  }
+  if (ORIGINAL_CLAUDE_LIGHT_MODEL === undefined) {
+    delete process.env.CLAUDE_LIGHT_MODEL;
+  } else {
+    process.env.CLAUDE_LIGHT_MODEL = ORIGINAL_CLAUDE_LIGHT_MODEL;
+  }
+  if (ORIGINAL_CLAUDE_CODE_USE_BEDROCK === undefined) {
+    delete process.env.CLAUDE_CODE_USE_BEDROCK;
+  } else {
+    process.env.CLAUDE_CODE_USE_BEDROCK = ORIGINAL_CLAUDE_CODE_USE_BEDROCK;
   }
 });
 
@@ -37,5 +72,50 @@ describe('createQuickConfig', () => {
     const config = createQuickConfig(loadClaudeConfig({ maxTurns: 30 }));
 
     expect(config.maxTurns).toBe(5);
+  });
+});
+
+describe('getClaudeRuntimeDiagnostics', () => {
+  it('reports Anthropic-compatible proxy mode', () => {
+    process.env.ANTHROPIC_BASE_URL = 'http://localhost:3000';
+    process.env.ANTHROPIC_API_KEY = 'sk-test';
+    process.env.CLAUDE_MODEL = 'mimo-main';
+    process.env.CLAUDE_LIGHT_MODEL = 'mimo-light';
+
+    const diagnostics = getClaudeRuntimeDiagnostics();
+
+    expect(diagnostics.runtime).toBe('claude-agent-sdk');
+    expect(diagnostics.providerMode).toBe('anthropic_compatible_proxy');
+    expect(diagnostics.model).toBe('mimo-main');
+    expect(diagnostics.lightModel).toBe('mimo-light');
+    expect(diagnostics.configured).toBe(true);
+    expect(diagnostics.credentialSources).toContain('anthropic_compatible_proxy');
+  });
+
+  it('reports unconfigured mode when no credential source is set', () => {
+    delete process.env.ANTHROPIC_BASE_URL;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.CLAUDE_CODE_USE_BEDROCK;
+
+    const diagnostics = getClaudeRuntimeDiagnostics();
+
+    expect(diagnostics.providerMode).toBe('unconfigured');
+    expect(diagnostics.configured).toBe(false);
+  });
+});
+
+describe('explainClaudeRuntimeError', () => {
+  it('adds provider guidance for quota/auth failures', () => {
+    const message = explainClaudeRuntimeError("You're out of extra usage");
+
+    expect(message).toContain("You're out of extra usage");
+    expect(message).toContain('ANTHROPIC_BASE_URL');
+    expect(message).toContain('CC Switch');
+  });
+
+  it('leaves unrelated errors unchanged', () => {
+    const message = 'trace processor failed';
+
+    expect(explainClaudeRuntimeError(message)).toBe(message);
   });
 });

--- a/backend/src/agentv3/claudeConfig.ts
+++ b/backend/src/agentv3/claudeConfig.ts
@@ -162,6 +162,62 @@ export function hasClaudeCredentials(): boolean {
   );
 }
 
+export function getClaudeRuntimeDiagnostics() {
+  const bedrock = detectBedrock();
+  const credentialSources: string[] = [];
+  if (process.env.ANTHROPIC_API_KEY) credentialSources.push('anthropic_api_key');
+  if (process.env.ANTHROPIC_BASE_URL) credentialSources.push('anthropic_compatible_proxy');
+  if (bedrock.enabled) credentialSources.push(`bedrock:${bedrock.authMethod}`);
+
+  const providerMode = process.env.ANTHROPIC_BASE_URL
+    ? 'anthropic_compatible_proxy'
+    : bedrock.enabled
+      ? 'aws_bedrock'
+      : process.env.ANTHROPIC_API_KEY
+        ? 'anthropic_direct'
+        : 'unconfigured';
+
+  return {
+    runtime: 'claude-agent-sdk',
+    providerMode,
+    model: process.env.CLAUDE_MODEL || DEFAULT_MODEL,
+    lightModel: process.env.CLAUDE_LIGHT_MODEL || DEFAULT_LIGHT_MODEL,
+    configured: hasClaudeCredentials(),
+    credentialSources,
+    baseUrlConfigured: !!process.env.ANTHROPIC_BASE_URL,
+    bedrock: {
+      enabled: bedrock.enabled,
+      authMethod: bedrock.authMethod,
+      region: bedrock.region,
+      baseUrlConfigured: !!bedrock.baseUrl,
+    },
+    configHint: process.env.ANTHROPIC_BASE_URL
+      ? 'Using Anthropic-compatible proxy. Ensure the mapped model supports streaming and tool/function calling.'
+      : 'Set ANTHROPIC_API_KEY for Anthropic direct access, or ANTHROPIC_BASE_URL + ANTHROPIC_API_KEY for a third-party Anthropic-compatible proxy.',
+  };
+}
+
+export function explainClaudeRuntimeError(message: string): string {
+  const lower = message.toLowerCase();
+  const quotaOrAuth =
+    lower.includes('out of') ||
+    lower.includes('extra usage') ||
+    lower.includes('rate limit') ||
+    lower.includes('quota') ||
+    lower.includes('not logged in') ||
+    lower.includes('unauthorized') ||
+    lower.includes('401') ||
+    lower.includes('process exited with code 1');
+
+  if (!quotaOrAuth) return message;
+
+  return `${message}\n\n` +
+    'SmartPerfetto is currently using the Claude Agent SDK runtime. ' +
+    'If your Claude subscription/API quota is unavailable, configure an Anthropic-compatible proxy instead: ' +
+    'set ANTHROPIC_BASE_URL, ANTHROPIC_API_KEY, CLAUDE_MODEL, and CLAUDE_LIGHT_MODEL in backend/.env, then restart the backend. ' +
+    'Provider switchers such as CC Switch manage Claude Code/Codex/Gemini CLI configs, but SmartPerfetto does not automatically read Codex CLI or Gemini CLI credentials.';
+}
+
 /**
  * Check if ClaudeRuntime (agentv3) is the active orchestrator.
  * Defaults to true — agentv2 is deprecated. Set AI_SERVICE=deepseek to use legacy path.

--- a/backend/src/agentv3/claudeRuntime.ts
+++ b/backend/src/agentv3/claudeRuntime.ts
@@ -30,7 +30,14 @@ import {
   SDK_MAX_TURNS_SUBTYPE,
 } from './analysisTermination';
 import { extractFindingsFromText, extractFindingsFromSkillResult, mergeFindings } from './claudeFindingExtractor';
-import { loadClaudeConfig, resolveEffort, createSdkEnv, createQuickConfig, type ClaudeAgentConfig } from './claudeConfig';
+import {
+  createQuickConfig,
+  createSdkEnv,
+  explainClaudeRuntimeError,
+  loadClaudeConfig,
+  resolveEffort,
+  type ClaudeAgentConfig,
+} from './claudeConfig';
 import { detectFocusApps } from './focusAppDetector';
 import { classifyScene, type SceneType } from './sceneClassifier';
 import { classifyQueryComplexity } from './queryComplexityClassifier';
@@ -1264,7 +1271,7 @@ export class ClaudeRuntime extends EventEmitter implements IOrchestrator {
         terminationMessage,
       };
     } catch (error) {
-      const errMsg = (error as Error).message || 'Unknown error';
+      const errMsg = explainClaudeRuntimeError((error as Error).message || 'Unknown error');
       console.error('[ClaudeRuntime] Analysis failed:', errMsg);
 
       // P1-3: Preserve partial findings and generate partial conclusion on mid-stream errors
@@ -1625,7 +1632,7 @@ export class ClaudeRuntime extends EventEmitter implements IOrchestrator {
         terminationMessage,
       };
     } catch (error) {
-      const errMsg = (error as Error).message || 'Unknown error';
+      const errMsg = explainClaudeRuntimeError((error as Error).message || 'Unknown error');
       console.error('[ClaudeRuntime] Quick analysis failed:', errMsg);
       this.emitUpdate({ type: 'error', content: { message: `快速问答失败: ${errMsg}` }, timestamp: Date.now() });
       return {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -31,7 +31,11 @@ import {
   assertTraceAnalysisConfiguredForStartup,
   getTraceAnalysisConfigurationStatus,
 } from './services/traceAnalysisSkill';
-import { isClaudeCodeEnabled, hasClaudeCredentials } from './agentv3/claudeConfig';
+import {
+  getClaudeRuntimeDiagnostics,
+  hasClaudeCredentials,
+  isClaudeCodeEnabled,
+} from './agentv3/claudeConfig';
 import {
   getLegacyApiUsageSnapshot,
 } from './services/legacyApiTelemetry';
@@ -65,6 +69,7 @@ app.use(express.urlencoded({ extended: true, limit: serverConfig.bodyLimit }));
 // Health check endpoint
 app.get('/health', (req, res) => {
   const useAgentV3 = isClaudeCodeEnabled();
+  const claudeDiagnostics = getClaudeRuntimeDiagnostics();
   res.json({
     status: 'OK',
     timestamp: new Date().toISOString(),
@@ -76,10 +81,20 @@ app.get('/health', (req, res) => {
       model: useAgentV3
         ? (process.env.CLAUDE_MODEL || 'claude-sonnet-4-6')
         : (process.env.DEEPSEEK_MODEL || 'deepseek-chat'),
+      providerMode: useAgentV3 ? claudeDiagnostics.providerMode : 'deepseek_legacy',
       configured: useAgentV3
         ? hasClaudeCredentials()
         : !!process.env.DEEPSEEK_API_KEY,
       authRequired: !!process.env.SMARTPERFETTO_API_KEY,
+      diagnostics: useAgentV3
+        ? claudeDiagnostics
+        : {
+            runtime: 'agentv2',
+            providerMode: 'deepseek_legacy',
+            model: process.env.DEEPSEEK_MODEL || 'deepseek-chat',
+            configured: !!process.env.DEEPSEEK_API_KEY,
+            configHint: 'AI_SERVICE=deepseek uses the deprecated agentv2 fallback. New provider integrations should use agentv3 with an Anthropic-compatible proxy.',
+          },
     },
   });
 });

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -25,6 +25,34 @@ CLAUDE_LIGHT_MODEL=your-light-model
 
 模型必须稳定支持流式输出和 tool/function calling。代理层可以使用 one-api、new-api 或 LiteLLM。
 
+### 运行时与 Provider 诊断
+
+SmartPerfetto 当前不会自动读取 CC Switch、Codex CLI、Gemini CLI 或 OpenCode 的登录态。那些工具管理的是各自 CLI 的配置文件；SmartPerfetto 的 Web/CLI 分析路径默认仍由 Claude Agent SDK 驱动。
+
+接入 MiMo、DeepSeek、OpenAI、Kimi、MiniMax 等第三方模型时，请让代理层暴露 Anthropic Messages 兼容接口，然后配置：
+
+```bash
+ANTHROPIC_BASE_URL=http://localhost:3000
+ANTHROPIC_API_KEY=sk-proxy-xxx
+CLAUDE_MODEL=your-provider-main-model
+CLAUDE_LIGHT_MODEL=your-provider-light-model
+```
+
+修改 `.env` 后需要重启后端。可通过健康检查确认当前配置：
+
+```bash
+curl http://localhost:3000/health
+```
+
+响应中的 `aiEngine.providerMode` 会显示：
+
+| providerMode | 含义 |
+|---|---|
+| `anthropic_direct` | 使用 `ANTHROPIC_API_KEY` 直连 Anthropic |
+| `anthropic_compatible_proxy` | 使用 `ANTHROPIC_BASE_URL` 接入兼容代理 |
+| `aws_bedrock` | 使用 AWS Bedrock |
+| `unconfigured` | 尚未配置可用凭证 |
+
 ## 分析预算与超时
 
 慢模型或本地模型通常需要更长的 per-turn timeout：


### PR DESCRIPTION
Summary:
- add provider-mode diagnostics to /health for Claude Agent SDK, proxy, and Bedrock setups
- add actionable quota/auth guidance for Claude runtime failures
- document CC Switch/Codex/Gemini CLI boundaries and Anthropic-compatible proxy setup

Validation:
- npm test -- --runTestsByPath src/agentv3/__tests__/claudeConfig.test.ts
- npm run build
- git diff --check