### PR TITLE
fix(trace): ignore IPv6 listen warning in Docker

### DIFF
--- a/backend/src/services/__tests__/traceProcessorService.test.ts
+++ b/backend/src/services/__tests__/traceProcessorService.test.ts
@@ -22,7 +22,12 @@ import os from 'os';
 import { v4 as uuidv4 } from 'uuid';
 import { TraceProcessorService, TraceInfo, QueryResult } from '../traceProcessorService';
 import { PortPool, getPortPool, resetPortPool } from '../portPool';
-import { TraceProcessorFactory, WorkingTraceProcessor, killOrphanProcessors } from '../workingTraceProcessor';
+import {
+  TraceProcessorFactory,
+  WorkingTraceProcessor,
+  isFatalTraceProcessorListenFailure,
+  killOrphanProcessors,
+} from '../workingTraceProcessor';
 
 // =============================================================================
 // Test Environment Detection
@@ -82,6 +87,26 @@ function cleanupTempFile(filePath: string): void {
 // =============================================================================
 // Mock Setup for Unit Tests (no real trace_processor_shell)
 // =============================================================================
+
+describe('trace_processor startup stderr parsing', () => {
+  it('does not treat Docker IPv6 loopback listen failure as a port conflict', () => {
+    const stderr = '[567.342]       http_server.cc:83 Failed to listen on IPv6 socket: "[::1]:9187" (errno: 99, Cannot assign requested address)';
+
+    expect(isFatalTraceProcessorListenFailure(stderr)).toBe(false);
+  });
+
+  it('does not treat Windows errno 0 listen warning as a port conflict', () => {
+    const stderr = '[841.673]       http_server.cc:72 Failed to listen on IPv4 socket: "127.0.0.1:9800" (errno: 0, No error)';
+
+    expect(isFatalTraceProcessorListenFailure(stderr)).toBe(false);
+  });
+
+  it('treats non-IPv6 listen failures as a port conflict', () => {
+    const stderr = '[567.342]       http_server.cc:83 Failed to listen on 127.0.0.1:9187 (errno: 98, Address already in use)';
+
+    expect(isFatalTraceProcessorListenFailure(stderr)).toBe(true);
+  });
+});
 
 // Mock processor for unit tests
 class MockTraceProcessor {

--- a/backend/src/services/workingTraceProcessor.ts
+++ b/backend/src/services/workingTraceProcessor.ts
@@ -55,6 +55,24 @@ const CRITICAL_STDLIB_MODULES = [
   'android.binder',             // 22 skills,  6 TS refs — IPC/blocking analysis foundation
 ];
 
+export function isFatalTraceProcessorListenFailure(text: string): boolean {
+  if (!(text.includes('Failed to listen') || text.includes('Address already in use'))) {
+    return false;
+  }
+
+  // Docker/Linux containers commonly have IPv6 loopback disabled. Perfetto can
+  // still serve backend queries on 127.0.0.1, so this warning is not fatal.
+  if (text.includes('Failed to listen on IPv6 socket')) {
+    return false;
+  }
+
+  if (text.includes('errno: 0, No error')) {
+    return false;
+  }
+
+  return true;
+}
+
 /**
  * Kill all orphan trace_processor_shell processes.
  * This should be called at startup to clean up processes from previous runs.
@@ -301,7 +319,7 @@ export class WorkingTraceProcessor extends EventEmitter implements TraceProcesso
         }
 
         // Check for port in use error
-        if (text.includes('Failed to listen') || text.includes('Address already in use')) {
+        if (isFatalTraceProcessorListenFailure(text)) {
           if (!resolved) {
             resolved = true;
             clearTimeout(timeout);


### PR DESCRIPTION
<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
  <!-- Copyright (C) 2024-2026 Gracker (Chris) | SmartPerfetto -->

  ## Summary

  - Fix trace_processor HTTP-mode startup handling so non-fatal listen warnings do not get misclassified as `PORT_IN_USE`.
  - Treat Docker/Linux IPv6 loopback listen failure and Windows `errno: 0, No error` listen warning as recoverable when IPv4 HTTP
  server is ready.
  - Add regression coverage for non-fatal listen warnings and real port-conflict detection.

  ## Linked Issue

  N/A

  ## Change Type

  - [ ] feat (new capability)
  - [x] fix (bug fix, no API change)
  - [ ] refactor (internal cleanup, no behavior change)
  - [ ] docs (documentation only)
  - [ ] chore (build, CI, tooling, dependency updates)
  - [ ] skill / strategy (YAML skill or `.strategy.md` / `.template.md`)

  ## Affected Areas

  - [ ] `backend/src/agentv3/` (primary runtime: ClaudeRuntime, MCP server, verifier)
  - [ ] `backend/skills/` (YAML skills)
  - [ ] `backend/strategies/` (`*.strategy.md`, `*.template.md`, `knowledge-*`)
  - [ ] `perfetto/ui/src/plugins/com.smartperfetto.AIAssistant/` (frontend)
  - [ ] `scripts/` / `backend/scripts/` (tooling, generators)
  - [ ] `.github/workflows/` (CI)
  - [x] Tests only

  ## Done Conditions

  - [x] `npm run verify:pr` from repo root → green
  - [x] I included any extra targeted test command needed for this change in the test plan below
  - [ ] New `.ts` / `.yaml` / `.sh` / `.strategy.md` files carry SPDX AGPL v3 header

  ## Test Plan

  - `npm test -- --runInBand src/services/__tests__/traceProcessorService.test.ts`
  - `npm run typecheck`
  - `npm run build`
  - `npm run verify:pr` from repo root, verified in clean Linux Docker checkout after rebasing onto latest `origin/main`
  - `npm run verify:pr` included 6 canonical trace regression runs; all passed

  ## Risk / Rollback

  - Risk is limited to trace_processor startup stderr classification.
  - True port conflicts remain fatal through `Failed to listen` / `Address already in use` handling.
  - Rollback: revert this commit to restore the previous strict listen-error behavior.

  ## Notes for Reviewers

  - Root cause was trace_processor successfully starting IPv4 HTTP mode while also emitting a non-fatal IPv6 listen warning in Docker/
  Linux environments.
  - The previous parser treated that warning as fatal `PORT_IN_USE`, which caused trace analysis / AI backend connection flows to fail even though the processor was usable.