### PR TITLE
fix(linux): support glibc systems and IPv6-disabled hosts

### DIFF
--- a/backend/src/agent/scene/sceneStage3Summarizer.ts
+++ b/backend/src/agent/scene/sceneStage3Summarizer.ts
@@ -18,7 +18,7 @@
  */
 
 import { query as sdkQuery } from '@anthropic-ai/claude-agent-sdk';
-import { createSdkEnv, loadClaudeConfig } from '../../agentv3/claudeConfig';
+import { createSdkEnv, getSdkBinaryOption, loadClaudeConfig } from '../../agentv3/claudeConfig';
 import {
   DisplayedScene,
   SceneAnalysisJob,
@@ -62,6 +62,7 @@ export async function runStage3Summary(
         stderr: (data: string) => {
           console.warn(`[SceneStage3Summarizer] SDK stderr: ${data.trimEnd()}`);
         },
+        ...getSdkBinaryOption(),
       },
     });
 

--- a/backend/src/agentv3/claudeConfig.ts
+++ b/backend/src/agentv3/claudeConfig.ts
@@ -269,6 +269,18 @@ export function createQuickConfig(baseConfig: ClaudeAgentConfig): ClaudeAgentCon
  * When no providerId is given, uses the active provider from providerManager.
  * Falls back to raw process.env when no provider is configured.
  */
+
+/**
+ * Returns pathToClaudeCodeExecutable when CLAUDE_BINARY_PATH is set.
+ * Needed on Linux glibc systems where the SDK auto-selects the musl binary
+ * (tried first) but musl libc is absent. Point to the glibc variant:
+ *   CLAUDE_BINARY_PATH=<repo>/backend/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude
+ */
+export function getSdkBinaryOption(): { pathToClaudeCodeExecutable?: string } {
+  const p = process.env.CLAUDE_BINARY_PATH;
+  return p ? { pathToClaudeCodeExecutable: p } : {};
+}
+
 export function createSdkEnv(sessionOverrideProviderId?: string): Record<string, string | undefined> {
   const env = { ...process.env };
 

--- a/backend/src/agentv3/claudeRuntime.ts
+++ b/backend/src/agentv3/claudeRuntime.ts
@@ -34,6 +34,7 @@ import {
   createQuickConfig,
   createSdkEnv,
   explainClaudeRuntimeError,
+  getSdkBinaryOption,
   loadClaudeConfig,
   resolveEffort,
   resolveRuntimeConfig,
@@ -226,6 +227,10 @@ function sdkQueryWithRetry(
   } = {},
 ): SdkQueryHandle {
   const { maxRetries = 2, baseDelayMs = 2000, emitUpdate, outputLanguage = loadClaudeConfig().outputLanguage } = options;
+  const binaryOpt = getSdkBinaryOption();
+  const mergedParams = binaryOpt.pathToClaudeCodeExecutable
+    ? { ...params, options: { ...params.options, ...binaryOpt } }
+    : params;
 
   // Tracks the Query instance currently being iterated so `close()` can
   // forward termination to the underlying SDK subprocess across retries.
@@ -239,7 +244,7 @@ function sdkQueryWithRetry(
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       if (closed) return;
       try {
-        currentQuery = sdkQuery(params);
+        currentQuery = sdkQuery(mergedParams);
         // Yield all messages from the stream
         for await (const msg of currentQuery) {
           if (closed) return;

--- a/backend/src/agentv3/claudeVerifier.ts
+++ b/backend/src/agentv3/claudeVerifier.ts
@@ -18,7 +18,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { query as sdkQuery } from '@anthropic-ai/claude-agent-sdk';
-import { createSdkEnv } from './claudeConfig';
+import { createSdkEnv, getSdkBinaryOption } from './claudeConfig';
 import type { Finding, StreamingUpdate } from '../agent/types';
 import type { VerificationResult, VerificationIssue, AnalysisPlanV3, Hypothesis } from './types';
 import { expectedToolNames } from './types';
@@ -814,6 +814,7 @@ ${conclusionPreview}${truncationNote}
         stderr: (data: string) => {
           console.warn(`[ClaudeVerifier] SDK stderr: ${data.trimEnd()}`);
         },
+        ...getSdkBinaryOption(),
       },
     });
 

--- a/backend/src/agentv3/queryComplexityClassifier.ts
+++ b/backend/src/agentv3/queryComplexityClassifier.ts
@@ -15,7 +15,7 @@
  */
 
 import { query as sdkQuery } from '@anthropic-ai/claude-agent-sdk';
-import { createSdkEnv, type ClaudeAgentConfig } from './claudeConfig';
+import { createSdkEnv, getSdkBinaryOption, type ClaudeAgentConfig } from './claudeConfig';
 import { loadPromptTemplate, renderTemplate } from './strategyLoader';
 import type { ComplexityClassifierInput, QueryComplexity } from './types';
 
@@ -156,6 +156,7 @@ async function classifyWithHaiku(
       stderr: (data: string) => {
         console.warn(`[ComplexityClassifier] SDK stderr: ${data.trimEnd()}`);
       },
+      ...getSdkBinaryOption(),
     },
   });
 

--- a/backend/src/services/criticalPathAiSummary.ts
+++ b/backend/src/services/criticalPathAiSummary.ts
@@ -3,7 +3,7 @@
 // This file is part of SmartPerfetto. See LICENSE for details.
 
 import {type SDKMessage, type SDKResultSuccess, query as sdkQuery} from '@anthropic-ai/claude-agent-sdk';
-import {createSdkEnv, hasClaudeCredentials, loadClaudeConfig} from '../agentv3/claudeConfig';
+import {createSdkEnv, getSdkBinaryOption, hasClaudeCredentials, loadClaudeConfig} from '../agentv3/claudeConfig';
 import {redactObjectForLLM} from '../utils/llmPrivacy';
 import type {CriticalPathAnalysis} from './criticalPathAnalyzer';
 
@@ -289,6 +289,7 @@ export async function summarizeCriticalPathWithAi(
       stderr: (data: string) => {
         console.warn(`[CriticalPathAI] SDK stderr: ${data.trimEnd()}`);
       },
+      ...getSdkBinaryOption(),
     },
   });
 

--- a/backend/src/services/flamegraphAiSummary.ts
+++ b/backend/src/services/flamegraphAiSummary.ts
@@ -3,7 +3,7 @@
 // This file is part of SmartPerfetto. See LICENSE for details.
 
 import { type SDKMessage, type SDKResultSuccess, query as sdkQuery } from '@anthropic-ai/claude-agent-sdk';
-import { createSdkEnv, hasClaudeCredentials, loadClaudeConfig } from '../agentv3/claudeConfig';
+import { createSdkEnv, getSdkBinaryOption, hasClaudeCredentials, loadClaudeConfig } from '../agentv3/claudeConfig';
 import { redactObjectForLLM } from '../utils/llmPrivacy';
 import type { FlamegraphAiSummary, FlamegraphAnalysis } from './flamegraphTypes';
 
@@ -133,6 +133,7 @@ export async function summarizeFlamegraphWithAi(
       stderr: (data: string) => {
         console.warn(`[FlamegraphAI] SDK stderr: ${data.trimEnd()}`);
       },
+      ...getSdkBinaryOption(),
     },
   });
 

--- a/backend/src/services/workingTraceProcessor.ts
+++ b/backend/src/services/workingTraceProcessor.ts
@@ -27,6 +27,20 @@ export function getBundledTraceProcessorPath(): string {
   return path.resolve(__dirname, '../../../perfetto/out/ui/trace_processor_shell');
 }
 
+// Cached probe result: does the current binary support --http-additional-cors-origins?
+let _corsOriginsFlagSupported: boolean | undefined;
+function supportsCorsOriginsFlag(): boolean {
+  if (_corsOriginsFlagSupported !== undefined) return _corsOriginsFlagSupported;
+  try {
+    const binary = getTraceProcessorPath();
+    const help = execSync(`"${binary}" --help 2>&1 || true`, { encoding: 'utf-8', timeout: 5000 });
+    _corsOriginsFlagSupported = help.includes('additional-cors');
+  } catch {
+    _corsOriginsFlagSupported = false;
+  }
+  return _corsOriginsFlagSupported;
+}
+
 export function getUserTraceProcessorPath(): string {
   const home = process.env.SMARTPERFETTO_HOME && process.env.SMARTPERFETTO_HOME.trim()
     ? path.resolve(process.env.SMARTPERFETTO_HOME)
@@ -228,8 +242,9 @@ export class WorkingTraceProcessor extends EventEmitter implements TraceProcesso
       const args = [
         '--httpd',
         '--http-port', String(this.httpPort),
-        // Allow CORS from the Perfetto UI origin
-        '--http-additional-cors-origins', corsOrigins,
+        // Only pass --http-additional-cors-origins when supported (added after v47);
+        // older binaries (≤v47) don't enforce CORS and exit with code 1 on unknown flags.
+        ...(supportsCorsOriginsFlag() ? ['--http-additional-cors-origins', corsOrigins] : []),
         this.tracePath
       ];
 
@@ -280,7 +295,8 @@ export class WorkingTraceProcessor extends EventEmitter implements TraceProcesso
         }
 
         // Also check stderr for server ready message
-        if (text.includes('Starting HTTP server') || text.includes('Trace loaded')) {
+        // v47+ prints "Starting RPC server"; older versions print "Starting HTTP server"
+        if (text.includes('Starting HTTP server') || text.includes('Starting RPC server') || text.includes('Trace loaded')) {
           setTimeout(() => {
             if (!resolved) {
               resolved = true;
@@ -300,9 +316,12 @@ export class WorkingTraceProcessor extends EventEmitter implements TraceProcesso
           }
         }
 
-        // Check for port in use error
+        // Check for port in use error — but ignore IPv6-only failures.
+        // On hosts with IPv6 disabled, trace_processor_shell prints
+        // "Failed to listen on IPv6 socket" while still serving on IPv4.
         if (text.includes('Failed to listen') || text.includes('Address already in use')) {
-          if (!resolved) {
+          const isIPv6Only = text.includes('[::') || text.includes('IPv6 socket');
+          if (!isIPv6Only && !resolved) {
             resolved = true;
             clearTimeout(timeout);
             reject(new Error(`PORT_IN_USE:${this.httpPort}`));


### PR DESCRIPTION
## Summary

Two independent fixes for Ubuntu 20.04 (glibc 2.31) deployments that currently prevent the backend from functioning at all.

### Fix 1: Claude Agent SDK musl binary fails on glibc systems

The SDK resolves Linux binaries in priority order: **musl first, then glibc**. On Ubuntu/Debian (glibc), the musl binary cannot be spawned because `/lib/ld-musl-x86_64.so.1` is absent, so every `sdkQuery` call throws:

```
Claude Code native binary not found at .../claude-agent-sdk-linux-x64-musl/claude.
Please ensure Claude Code is installed via native installer or specify a valid path
with options.pathToClaudeCodeExecutable.
```

**Changes:**
- Add `getSdkBinaryOption()` in `claudeConfig.ts`: reads `CLAUDE_BINARY_PATH` env var and returns `{ pathToClaudeCodeExecutable }` when set
- Inject into `sdkQueryWithRetry` in `claudeRuntime.ts` (covers 3 call sites)
- Spread `...getSdkBinaryOption()` into direct `sdkQuery` callers: `claudeVerifier`, `queryComplexityClassifier`, `criticalPathAiSummary`, `flamegraphAiSummary`, `sceneStage3Summarizer`

**Usage** (add to `backend/.env` on Ubuntu/Debian):
```
CLAUDE_BINARY_PATH=<repo>/backend/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude
```

---

### Fix 2: trace_processor_shell compatibility on older binaries and IPv6-disabled hosts

Three issues in `workingTraceProcessor.ts::startHttpServer()`:

**2a. `--http-additional-cors-origins` flag missing in older binaries**

Binaries ≤v47 exit with code 1 on unrecognized flags. `--http-additional-cors-origins` was added after v47. On Ubuntu 20.04, the project-pinned v54 prebuilt requires glibc 2.32+ (unavailable), so users must fall back to v47.

Fix: probe flag support once at startup via `--help` (`supportsCorsOriginsFlag()`), skip the flag when unsupported. Older binaries don't enforce CORS and remain functional without it.

**2b. `Starting RPC server` ready signal not recognized**

v47+ logs `[HTTP] Starting RPC server on localhost:PORT` as its ready signal, while the existing code only matches `Starting HTTP server`. This caused initialization to always time out on current binaries, forcing fallback to the 30s timeout path.

Fix: add `Starting RPC server` to the ready-detection check.

**2c. IPv6-disabled hosts falsely detected as PORT_IN_USE**

On hosts with IPv6 disabled (common in corporate/container environments), `trace_processor_shell` prints:
```
Failed to listen on IPv6 socket: "[::1]:9106" (errno: 99, Cannot assign requested address)
```
...while still serving correctly on IPv4 (`127.0.0.1:9106`). The previous code matched `"Failed to listen"` unconditionally and rejected with `PORT_IN_USE`, causing all 8 retry attempts to fail and leaving the frontend in WASM-only mode.

Fix: skip the PORT_IN_USE rejection when the error line contains `"[::"` or `"IPv6 socket"`.

## Test plan

- [ ] Verify `getSdkBinaryOption()` is a no-op when `CLAUDE_BINARY_PATH` is unset (existing behavior unchanged)
- [ ] On a glibc Linux system: set `CLAUDE_BINARY_PATH` to the glibc binary and confirm `sdkQuery` calls succeed
- [ ] On a host with IPv6 disabled: confirm trace loads successfully and backend switches engine to HTTP_RPC mode
- [ ] Confirm `npm run typecheck` passes (no new type errors)
- [ ] Confirm `npm run test:scene-trace-regression` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)