### PR TITLE
feat(enterprise): validate provider snapshot on resume

### DIFF
--- a/backend/src/agentOpenAI/openAiRuntime.ts
+++ b/backend/src/agentOpenAI/openAiRuntime.ts
@@ -600,6 +600,7 @@ export class OpenAIRuntime extends EventEmitter implements IOrchestrator {
       sdkSessionId: sessionEntry?.lastResponseId,
       agentRuntimeKind: 'openai-agents-sdk',
       agentRuntimeProviderId: sessionFields.agentRuntimeProviderId,
+      agentRuntimeProviderSnapshotHash: sessionFields.agentRuntimeProviderSnapshotHash,
       openAIHistory: sessionEntry?.history,
       openAILastResponseId: sessionEntry?.lastResponseId,
       openAIRunState: sessionEntry?.runState,

--- a/backend/src/agentv3/claudeRuntime.ts
+++ b/backend/src/agentv3/claudeRuntime.ts
@@ -1919,6 +1919,7 @@ export class ClaudeRuntime extends EventEmitter implements IOrchestrator {
       sdkSessionId,
       agentRuntimeKind: 'claude-agent-sdk',
       agentRuntimeProviderId: sessionFields.agentRuntimeProviderId,
+      agentRuntimeProviderSnapshotHash: sessionFields.agentRuntimeProviderSnapshotHash,
 
       // Artifacts
       artifacts: artifactStore?.serialize(),

--- a/backend/src/agentv3/sessionStateSnapshot.ts
+++ b/backend/src/agentv3/sessionStateSnapshot.ts
@@ -135,6 +135,12 @@ export interface SessionStateSnapshot {
    * the current active Provider Manager profile during restoration.
    */
   agentRuntimeProviderId?: string | null;
+  /**
+   * Non-secret hash of the provider/runtime configuration that created the SDK
+   * session. Resume may only reuse sdkSessionId when this still matches the
+   * current resolved provider snapshot.
+   */
+  agentRuntimeProviderSnapshotHash?: string | null;
   /** OpenAI Agents SDK history for cross-restart multi-turn continuation. */
   openAIHistory?: unknown[];
   /** Last provider response ID from the OpenAI Agents SDK run. */
@@ -172,6 +178,8 @@ export interface SessionFieldsForSnapshot {
   hypotheses: any[];
   /** Provider profile that supplied runtime credentials for this turn; null means env/default fallback. */
   agentRuntimeProviderId?: string | null;
+  /** Non-secret hash of the resolved provider/runtime configuration. */
+  agentRuntimeProviderSnapshotHash?: string | null;
   runSequence: number;
   conversationOrdinal: number;
 }

--- a/backend/src/assistant/application/__tests__/agentAnalyzeSessionService.test.ts
+++ b/backend/src/assistant/application/__tests__/agentAnalyzeSessionService.test.ts
@@ -7,6 +7,7 @@ import os from 'os';
 import path from 'path';
 import type { SessionLogger } from '../../../services/sessionLogger';
 import { resetProviderService } from '../../../services/providerManager';
+import { resolveProviderRuntimeSnapshot } from '../../../services/providerManager/providerSnapshot';
 import {
   AgentAnalyzeSessionService,
   AnalyzeSessionPreparationError,
@@ -19,6 +20,8 @@ const mockCreateAgentOrchestrator = jest.fn((_input: unknown) => ({
   analyze: jest.fn(),
   on: jest.fn(),
   off: jest.fn(),
+  cleanupSession: jest.fn(),
+  restoreFromSnapshot: jest.fn(),
 }));
 
 jest.mock('../../../agentRuntime', () => ({
@@ -56,6 +59,10 @@ function createSession(sessionId: string, traceId: string): AnalyzeManagedSessio
     conversationSteps: [],
     runSequence: 0,
   };
+}
+
+function providerSnapshotHash(providerId: string | null): string {
+  return resolveProviderRuntimeSnapshot(getProviderService(), providerId).snapshotHash;
 }
 
 function createRestoredContext() {
@@ -187,6 +194,7 @@ describe('AgentAnalyzeSessionService session continuity', () => {
 
     expect(prepared.isNewSession).toBe(true);
     expect(prepared.session.providerId).toBe(provider.id);
+    expect(prepared.session.providerSnapshotHash).toBe(providerSnapshotHash(provider.id));
     expect(mockCreateAgentOrchestrator).toHaveBeenCalledWith(
       expect.objectContaining({ providerId: provider.id }),
     );
@@ -201,9 +209,66 @@ describe('AgentAnalyzeSessionService session continuity', () => {
 
     expect(prepared.isNewSession).toBe(true);
     expect(prepared.session.providerId).toBeNull();
+    expect(prepared.session.providerSnapshotHash).toBe(providerSnapshotHash(null));
     expect(mockCreateAgentOrchestrator).toHaveBeenCalledWith(
       expect.objectContaining({ providerId: null }),
     );
+  });
+
+  test('refreshes an in-memory SDK session when the pinned provider snapshot changed', () => {
+    const provider = getProviderService().create({
+      name: 'OpenAI Provider',
+      category: 'official',
+      type: 'openai',
+      models: { primary: 'gpt-provider-model', light: 'gpt-provider-light' },
+      connection: {
+        agentRuntime: 'openai-agents-sdk',
+        openaiBaseUrl: 'https://api.example.test/v1',
+        openaiApiKey: 'sk-provider-openai',
+      },
+    });
+    const originalHash = providerSnapshotHash(provider.id);
+    const oldOrchestrator = {
+      analyze: jest.fn(),
+      on: jest.fn(),
+      off: jest.fn(),
+      cleanupSession: jest.fn(),
+    };
+    const existing = createSession('agent-session-1', 'trace-1');
+    existing.orchestrator = oldOrchestrator as any;
+    existing.providerId = provider.id;
+    existing.providerSnapshotHash = originalHash;
+    existing.conversationSteps.push({
+      eventId: 'evt-1',
+      ordinal: 1,
+      phase: 'progress',
+      role: 'agent',
+      text: 'previous context',
+      timestamp: Date.now(),
+    });
+    assistantAppService.setSession(existing.sessionId, existing);
+
+    getProviderService().update(provider.id, {
+      models: { primary: 'gpt-provider-model-v2' },
+    });
+    const nextHash = providerSnapshotHash(provider.id);
+
+    const prepared = service.prepareSession({
+      traceId: 'trace-1',
+      query: 'new follow-up question',
+      requestedSessionId: existing.sessionId,
+      options: {},
+    });
+
+    expect(nextHash).not.toBe(originalHash);
+    expect(prepared.isNewSession).toBe(false);
+    expect(prepared.sessionId).toBe(existing.sessionId);
+    expect(prepared.session.orchestrator).not.toBe(oldOrchestrator);
+    expect(prepared.session.providerId).toBe(provider.id);
+    expect(prepared.session.providerSnapshotHash).toBe(nextHash);
+    expect(prepared.session.providerSnapshotChanged).toBe(true);
+    expect(prepared.session.conversationSteps).toHaveLength(1);
+    expect(oldOrchestrator.cleanupSession).toHaveBeenCalledWith(existing.sessionId);
   });
 
   test('reuses an in-memory session with its pinned provider when active provider changed elsewhere', () => {
@@ -315,6 +380,81 @@ describe('AgentAnalyzeSessionService session continuity', () => {
       expect(prepError.code).toBe('PROVIDER_NOT_FOUND');
       expect(prepError.httpStatus).toBe(404);
     }
+  });
+
+  test('keeps persisted conversation context but skips SDK snapshot restore when provider hash changed', () => {
+    const provider = getProviderService().create({
+      name: 'OpenAI Provider',
+      category: 'official',
+      type: 'openai',
+      models: { primary: 'gpt-provider-model', light: 'gpt-provider-light' },
+      connection: {
+        agentRuntime: 'openai-agents-sdk',
+        openaiBaseUrl: 'https://api.example.test/v1',
+        openaiApiKey: 'sk-provider-openai',
+      },
+    });
+    const originalHash = providerSnapshotHash(provider.id);
+    getProviderService().update(provider.id, {
+      connection: { openaiBaseUrl: 'https://api.changed.example.test/v1' },
+    });
+    const nextHash = providerSnapshotHash(provider.id);
+
+    sessionPersistenceService.getSession.mockReturnValue({
+      id: 'persisted-1',
+      traceId: 'trace-1',
+      question: 'q',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      metadata: {
+        tenantId: 'tenant-a',
+        workspaceId: 'workspace-a',
+        userId: 'user-a',
+      },
+      messages: [],
+    });
+    sessionPersistenceService.loadSessionContext.mockReturnValue(createRestoredContext());
+    sessionPersistenceService.loadSessionStateSnapshot.mockReturnValue({
+      version: 1,
+      snapshotTimestamp: Date.now(),
+      sessionId: 'persisted-1',
+      traceId: 'trace-1',
+      conversationSteps: [],
+      queryHistory: [],
+      conclusionHistory: [],
+      agentDialogue: [],
+      agentResponses: [],
+      dataEnvelopes: [],
+      hypotheses: [],
+      analysisNotes: [],
+      analysisPlan: null,
+      planHistory: [],
+      uncertaintyFlags: [],
+      agentRuntimeKind: 'openai-agents-sdk',
+      agentRuntimeProviderId: provider.id,
+      agentRuntimeProviderSnapshotHash: originalHash,
+      sdkSessionId: 'sdk-response-old',
+      openAILastResponseId: 'sdk-response-old',
+      runSequence: 0,
+      conversationOrdinal: 0,
+    });
+
+    const prepared = service.prepareSession({
+      traceId: 'trace-1',
+      query: 'follow-up',
+      requestedSessionId: 'persisted-1',
+      options: {},
+    });
+
+    const restoredOrchestrator = mockCreateAgentOrchestrator.mock.results[0]?.value as any;
+    expect(nextHash).not.toBe(originalHash);
+    expect(prepared.isNewSession).toBe(false);
+    expect(prepared.sessionId).toBe('persisted-1');
+    expect(prepared.session.providerId).toBe(provider.id);
+    expect(prepared.session.providerSnapshotHash).toBe(nextHash);
+    expect(prepared.session.providerSnapshotChanged).toBe(true);
+    expect(prepared.session.tenantId).toBe('tenant-a');
+    expect(restoredOrchestrator.restoreFromSnapshot).not.toHaveBeenCalled();
   });
 
   test('restores a persisted env-fallback session without reading the active provider', () => {

--- a/backend/src/assistant/application/agentAnalyzeSessionService.ts
+++ b/backend/src/assistant/application/agentAnalyzeSessionService.ts
@@ -10,6 +10,8 @@ import {
 } from '../../agent';
 import { createAgentOrchestrator } from '../../agentRuntime';
 import { getProviderService } from '../../services/providerManager';
+import { resolveProviderRuntimeSnapshot } from '../../services/providerManager/providerSnapshot';
+import type { AgentRuntimeKind } from '../../services/providerManager';
 import { getTraceProcessorService } from '../../services/traceProcessorService';
 import {
   type EnhancedSessionContext,
@@ -67,6 +69,10 @@ export interface AnalyzeManagedSession extends ManagedAssistantSession {
   userId?: string;
   /** Provider Manager profile used for this SDK session. null means env/default fallback is pinned. */
   providerId?: string | null;
+  /** Non-secret ProviderSnapshot hash used to decide whether SDK session state can be reused. */
+  providerSnapshotHash?: string | null;
+  providerSnapshotChanged?: boolean;
+  providerSnapshotChangeReason?: string;
   logger: SessionLogger;
   result?: AgentRuntimeAnalysisResult;
   hypotheses: Hypothesis[];
@@ -167,14 +173,35 @@ export class AgentAnalyzeSessionService<TSession extends AnalyzeManagedSession> 
     const sessionProviderId = explicitProviderId !== undefined
       ? explicitProviderId
       : activeProviderId ?? null;
+    const resolveProviderSnapshotHash = (
+      providerId: string | null,
+      runtimeOverride?: AgentRuntimeKind,
+    ) => resolveProviderRuntimeSnapshot(providerSvc, providerId, runtimeOverride).snapshotHash;
+    const sessionProviderSnapshotHash = resolveProviderSnapshotHash(sessionProviderId);
 
     if (requestedSessionId) {
       const existingSession = this.assistantAppService.getSession(requestedSessionId);
+      const liveSessionProviderId = existingSession && existingSession.traceId === traceId
+        ? explicitProviderId !== undefined
+          ? explicitProviderId
+          : existingSession.providerId ?? null
+        : sessionProviderId;
       const liveSessionProviderMismatch = Boolean(
         existingSession &&
         existingSession.traceId === traceId &&
         explicitProviderId !== undefined &&
         (existingSession.providerId ?? null) !== explicitProviderId,
+      );
+      const liveSessionProviderSnapshotHash = existingSession?.providerSnapshotHash
+        ? resolveProviderSnapshotHash(liveSessionProviderId)
+        : null;
+      const liveSessionProviderSnapshotMismatch = Boolean(
+        existingSession &&
+        existingSession.traceId === traceId &&
+        !liveSessionProviderMismatch &&
+        existingSession.providerSnapshotHash &&
+        liveSessionProviderSnapshotHash &&
+        existingSession.providerSnapshotHash !== liveSessionProviderSnapshotHash,
       );
       if (existingSession && existingSession.traceId === traceId) {
         if (liveSessionProviderMismatch) {
@@ -183,8 +210,45 @@ export class AgentAnalyzeSessionService<TSession extends AnalyzeManagedSession> 
             nextProviderId: sessionProviderId,
           });
           console.log(`[AgentRoutes] Provider changed for ${requestedSessionId}, creating a new agent session`);
+        } else if (liveSessionProviderSnapshotMismatch) {
+          const previousProviderSnapshotHash = existingSession.providerSnapshotHash;
+          if (existingSession.orchestratorUpdateHandler) {
+            existingSession.orchestrator.off('update', existingSession.orchestratorUpdateHandler);
+            existingSession.orchestratorUpdateHandler = undefined;
+          }
+          if (typeof existingSession.orchestrator.cleanupSession === 'function') {
+            existingSession.orchestrator.cleanupSession(existingSession.sessionId);
+          }
+          existingSession.orchestrator = createAgentOrchestrator({
+            traceProcessorService: getTraceProcessorService(),
+            providerId: liveSessionProviderId,
+          });
+          existingSession.providerId = liveSessionProviderId;
+          existingSession.providerSnapshotHash = liveSessionProviderSnapshotHash;
+          existingSession.providerSnapshotChanged = true;
+          existingSession.providerSnapshotChangeReason = 'provider_snapshot_hash_mismatch';
+          existingSession.runSequence = Number.isFinite(existingSession.runSequence)
+            ? Math.max(0, Math.floor(existingSession.runSequence as number))
+            : 0;
+          existingSession.logger.warn('AgentRoutes', 'Provider snapshot changed; starting a fresh SDK session', {
+            providerId: liveSessionProviderId,
+            previousProviderSnapshotHash,
+            nextProviderSnapshotHash: liveSessionProviderSnapshotHash,
+          });
+          existingSession.query = query;
+          existingSession.status = 'pending';
+          existingSession.lastActivityAt = Date.now();
+          console.log(`[AgentRoutes] Provider snapshot changed for ${requestedSessionId}, refreshed SDK session`);
+          return {
+            sessionId: requestedSessionId,
+            session: existingSession,
+            isNewSession: false,
+          };
         } else {
           existingSession.providerId ??= null;
+          existingSession.providerSnapshotHash ??= liveSessionProviderSnapshotHash;
+          existingSession.providerSnapshotChanged = false;
+          existingSession.providerSnapshotChangeReason = undefined;
           existingSession.runSequence = Number.isFinite(existingSession.runSequence)
             ? Math.max(0, Math.floor(existingSession.runSequence as number))
             : 0;
@@ -240,6 +304,18 @@ export class AgentAnalyzeSessionService<TSession extends AnalyzeManagedSession> 
               hint: 'This persisted session was created with a Provider Manager profile that no longer exists. Recreate the provider or start a new chat.',
             });
           }
+          const restoredProviderSnapshotHash = !snapshotProviderMismatch
+            ? resolveProviderSnapshotHash(
+                restoredProviderId,
+                restoredProviderId ? undefined : stateSnapshot?.agentRuntimeKind,
+              )
+            : null;
+          const snapshotProviderHashMismatch = Boolean(
+            !snapshotProviderMismatch &&
+            stateSnapshot?.agentRuntimeProviderSnapshotHash &&
+            restoredProviderSnapshotHash &&
+            stateSnapshot.agentRuntimeProviderSnapshotHash !== restoredProviderSnapshotHash,
+          );
 
           if (snapshotProviderMismatch) {
             console.log(
@@ -273,8 +349,16 @@ export class AgentAnalyzeSessionService<TSession extends AnalyzeManagedSession> 
             // Restore SDK runtime internal maps/state from the unified snapshot.
             // Mirrors the explicit /resume endpoint so both paths recover the
             // full agent state, not just SessionContext.
-            if (stateSnapshot && typeof restoredOrchestrator.restoreFromSnapshot === 'function') {
+            if (
+              stateSnapshot &&
+              !snapshotProviderHashMismatch &&
+              typeof restoredOrchestrator.restoreFromSnapshot === 'function'
+            ) {
               restoredOrchestrator.restoreFromSnapshot(requestedSessionId, traceId, stateSnapshot);
+            } else if (snapshotProviderHashMismatch) {
+              console.log(
+                `[AgentRoutes] Provider snapshot changed for ${requestedSessionId}, skipping SDK session restoration`
+              );
             }
 
             const restoredTurns = restoredContext.getAllTurns();
@@ -307,6 +391,13 @@ export class AgentAnalyzeSessionService<TSession extends AnalyzeManagedSession> 
               turnCount: restoredTurns.length,
               entityStoreStats: restoredContext.getEntityStore().getStats(),
             });
+            if (snapshotProviderHashMismatch) {
+              restoredLogger.warn('AgentRoutes', 'Provider snapshot changed; fresh SDK runtime will be used', {
+                providerId: restoredProviderId,
+                previousProviderSnapshotHash: stateSnapshot?.agentRuntimeProviderSnapshotHash,
+                nextProviderSnapshotHash: restoredProviderSnapshotHash,
+              });
+            }
 
             // Reconstruct query/conclusion history from persisted turns
             const restoredQueryHistory: Array<{ turn: number; query: string; timestamp: number }> = [];
@@ -345,6 +436,11 @@ export class AgentAnalyzeSessionService<TSession extends AnalyzeManagedSession> 
               workspaceId: persistedSession.metadata?.workspaceId,
               userId: persistedSession.metadata?.userId,
               providerId: restoredProviderId,
+              providerSnapshotHash: restoredProviderSnapshotHash ?? sessionProviderSnapshotHash,
+              providerSnapshotChanged: snapshotProviderHashMismatch || undefined,
+              providerSnapshotChangeReason: snapshotProviderHashMismatch
+                ? 'provider_snapshot_hash_mismatch'
+                : undefined,
               createdAt: persistedSession.createdAt,
               lastActivityAt: Date.now(),
               logger: restoredLogger,
@@ -415,6 +511,8 @@ export class AgentAnalyzeSessionService<TSession extends AnalyzeManagedSession> 
       traceId,
       query,
       providerId: sessionProviderId,
+      providerSnapshotHash: sessionProviderSnapshotHash,
+      providerSnapshotChanged: false,
       createdAt: Date.now(),
       lastActivityAt: Date.now(),
       logger,

--- a/backend/src/routes/agentResumeRoutes.ts
+++ b/backend/src/routes/agentResumeRoutes.ts
@@ -10,6 +10,7 @@ import { createAgentOrchestrator } from '../agentRuntime';
 import { createSessionLogger } from '../services/sessionLogger';
 import { SessionPersistenceService } from '../services/sessionPersistenceService';
 import { getProviderService } from '../services/providerManager';
+import { resolveProviderRuntimeSnapshot } from '../services/providerManager/providerSnapshot';
 import { requireRequestContext } from '../middleware/auth';
 import {
   isOwnedByContext,
@@ -116,12 +117,13 @@ export function registerAgentResumeRoutes(
 
       sessionContextManager.set(sessionId, effectiveTraceId, restoredContext);
 
+      const providerSvc = getProviderService();
       const snapshot = persistenceService.loadSessionStateSnapshot(sessionId);
       const snapshotProviderId = snapshot?.agentRuntimeProviderId;
       const restoredProviderId = snapshot
         ? snapshotProviderId ?? null
-        : getProviderService().getRawEffectiveProvider()?.id ?? null;
-      if (typeof snapshotProviderId === 'string' && !getProviderService().getRawProvider(snapshotProviderId)) {
+        : providerSvc.getRawEffectiveProvider()?.id ?? null;
+      if (typeof snapshotProviderId === 'string' && !providerSvc.getRawProvider(snapshotProviderId)) {
         return res.status(404).json({
           success: false,
           error: `Provider not found: ${snapshotProviderId}`,
@@ -129,6 +131,15 @@ export function registerAgentResumeRoutes(
           hint: 'This persisted session was created with a Provider Manager profile that no longer exists. Recreate the provider or start a new chat.',
         });
       }
+      const restoredProviderSnapshotHash = resolveProviderRuntimeSnapshot(
+        providerSvc,
+        restoredProviderId,
+        restoredProviderId ? undefined : snapshot?.agentRuntimeKind,
+      ).snapshotHash;
+      const providerSnapshotChanged = Boolean(
+        snapshot?.agentRuntimeProviderSnapshotHash &&
+        snapshot.agentRuntimeProviderSnapshotHash !== restoredProviderSnapshotHash,
+      );
       const orchestrator = createAgentOrchestrator({
         traceProcessorService: getTraceProcessorService(),
         providerId: restoredProviderId,
@@ -157,6 +168,13 @@ export function registerAgentResumeRoutes(
         entityStoreStats: restoredContext.getEntityStore().getStats(),
         turnCount: restoredContext.getAllTurns().length,
       });
+      if (providerSnapshotChanged) {
+        logger.warn('AgentRoutes', 'Provider snapshot changed; SDK session state will not be restored', {
+          providerId: restoredProviderId,
+          previousProviderSnapshotHash: snapshot?.agentRuntimeProviderSnapshotHash,
+          nextProviderSnapshotHash: restoredProviderSnapshotHash,
+        });
+      }
 
       const restoredTurns = restoredContext.getAllTurns();
       const latestTurn = restoredTurns.length > 0 ? restoredTurns[restoredTurns.length - 1] : null;
@@ -177,7 +195,7 @@ export function registerAgentResumeRoutes(
 
       // Unified snapshot restoration — all fields populated from single source
       // Restore ClaudeRuntime Maps (notes, plans, hypotheses, flags, artifacts, architecture, sdkSessionId)
-      if (snapshot && typeof orchestrator.restoreFromSnapshot === 'function') {
+      if (snapshot && !providerSnapshotChanged && typeof orchestrator.restoreFromSnapshot === 'function') {
         orchestrator.restoreFromSnapshot(sessionId, effectiveTraceId, snapshot);
         logger.info('AgentRoutes', 'ClaudeRuntime Maps restored from snapshot', {
           notes: snapshot.analysisNotes.length,
@@ -202,6 +220,11 @@ export function registerAgentResumeRoutes(
         workspaceId: owner.workspaceId,
         userId: owner.userId,
         providerId: restoredProviderId,
+        providerSnapshotHash: restoredProviderSnapshotHash,
+        providerSnapshotChanged: providerSnapshotChanged || undefined,
+        providerSnapshotChangeReason: providerSnapshotChanged
+          ? 'provider_snapshot_hash_mismatch'
+          : undefined,
         query: latestTurn?.query || persistedSession.question,
         createdAt: persistedSession.createdAt,
         lastActivityAt: Date.now(),
@@ -227,8 +250,11 @@ export function registerAgentResumeRoutes(
         sessionId,
         traceId: effectiveTraceId,
         status: 'completed',
-        message: 'Session restored from persistence',
+        message: providerSnapshotChanged
+          ? 'Session restored from persistence with a fresh SDK runtime because provider configuration changed'
+          : 'Session restored from persistence',
         restored: true,
+        providerSnapshotChanged: providerSnapshotChanged || undefined,
         observability: restoredRun
           ? {
               runId: restoredRun.runId,

--- a/backend/src/routes/agentRoutes.ts
+++ b/backend/src/routes/agentRoutes.ts
@@ -250,6 +250,10 @@ interface AnalysisSession {
   userId?: string;
   /** Provider Manager profile used for this SDK session. null means env/default fallback is pinned. */
   providerId?: string | null;
+  /** Non-secret ProviderSnapshot hash used to decide whether SDK session state can be reused. */
+  providerSnapshotHash?: string | null;
+  providerSnapshotChanged?: boolean;
+  providerSnapshotChangeReason?: string;
   /** Reference trace ID for comparison mode (dual-trace analysis) */
   referenceTraceId?: string;
   query: string;
@@ -912,8 +916,13 @@ router.post('/analyze', async (req, res) => {
     res.json({
       success: true,
       sessionId,
-      message: isNewSession ? 'Analysis started' : 'Continuing analysis (multi-turn)',
+      message: preparedSession?.providerSnapshotChanged
+        ? 'Provider configuration changed; continuing with a fresh SDK session'
+        : isNewSession
+          ? 'Analysis started'
+          : 'Continuing analysis (multi-turn)',
       isNewSession,
+      providerSnapshotChanged: preparedSession?.providerSnapshotChanged || undefined,
       architecture: 'agent-driven',
       runId: runContext.runId,
       requestId: runContext.requestId,

--- a/backend/src/services/persistAgentSession.ts
+++ b/backend/src/services/persistAgentSession.ts
@@ -63,6 +63,7 @@ export function persistAgentTurn(input: PersistAgentTurnInput): void {
           dataEnvelopes: session.dataEnvelopes || [],
           hypotheses: session.hypotheses || [],
           agentRuntimeProviderId: session.providerId,
+          agentRuntimeProviderSnapshotHash: session.providerSnapshotHash,
           runSequence: session.runSequence || 0,
           conversationOrdinal: session.conversationOrdinal || 0,
         })

--- a/backend/src/services/providerManager/__tests__/providerSnapshot.test.ts
+++ b/backend/src/services/providerManager/__tests__/providerSnapshot.test.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 Gracker (Chris)
+// This file is part of SmartPerfetto. See LICENSE for details.
+
+import { promises as fsp } from 'fs';
+import os from 'os';
+import path from 'path';
+import { ProviderService } from '../providerService';
+import { resolveProviderRuntimeSnapshot } from '../providerSnapshot';
+import type { ProviderCreateInput } from '../types';
+
+function makeTmpDir(): string {
+  return path.join(os.tmpdir(), `provider-snapshot-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+}
+
+describe('provider runtime snapshot hash', () => {
+  let dir: string;
+  let svc: ProviderService;
+
+  beforeEach(async () => {
+    dir = makeTmpDir();
+    await fsp.mkdir(dir, { recursive: true });
+    svc = new ProviderService(path.join(dir, 'providers.json'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(dir, { recursive: true, force: true });
+  });
+
+  const openAIProvider: ProviderCreateInput = {
+    name: 'OpenAI Provider',
+    category: 'official',
+    type: 'openai',
+    models: { primary: 'gpt-5.2', light: 'gpt-5.2-mini' },
+    connection: {
+      agentRuntime: 'openai-agents-sdk',
+      openaiBaseUrl: 'https://api.openai.example/v1',
+      openaiApiKey: 'sk-openai-secret-value',
+    },
+    tuning: {
+      fullPerTurnMs: 120000,
+      quickPerTurnMs: 30000,
+    },
+  };
+
+  it('is stable across activation-only metadata changes', () => {
+    const provider = svc.create(openAIProvider);
+    const before = resolveProviderRuntimeSnapshot(svc, provider.id).snapshotHash;
+
+    svc.activate(provider.id);
+
+    expect(resolveProviderRuntimeSnapshot(svc, provider.id).snapshotHash).toBe(before);
+  });
+
+  it('changes when resolved model or endpoint changes', () => {
+    const provider = svc.create(openAIProvider);
+    const before = resolveProviderRuntimeSnapshot(svc, provider.id).snapshotHash;
+
+    svc.update(provider.id, {
+      models: { primary: 'gpt-5.2-pro' },
+      connection: { openaiBaseUrl: 'https://api.changed.example/v1' },
+    });
+
+    expect(resolveProviderRuntimeSnapshot(svc, provider.id).snapshotHash).not.toBe(before);
+  });
+
+  it('changes when secret material changes without storing plaintext secret', () => {
+    const provider = svc.create(openAIProvider);
+    const before = resolveProviderRuntimeSnapshot(svc, provider.id);
+
+    svc.update(provider.id, {
+      connection: { openaiApiKey: 'sk-openai-secret-value-v2' },
+    });
+    const after = resolveProviderRuntimeSnapshot(svc, provider.id);
+
+    expect(after.snapshotHash).not.toBe(before.snapshotHash);
+    expect(JSON.stringify(before.snapshot)).not.toContain('sk-openai-secret-value');
+    expect(JSON.stringify(after.snapshot)).not.toContain('sk-openai-secret-value-v2');
+    expect(after.snapshot.environment.OPENAI_API_KEY).toBeUndefined();
+  });
+});

--- a/backend/src/services/providerManager/providerSnapshot.ts
+++ b/backend/src/services/providerManager/providerSnapshot.ts
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 Gracker (Chris)
+// This file is part of SmartPerfetto. See LICENSE for details.
+
+import crypto from 'crypto';
+import type { ProviderService } from './providerService';
+import type { AgentRuntimeKind, ProviderConfig, ProviderTuning } from './types';
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+export interface ProviderRuntimeSnapshot {
+  version: 1;
+  providerId: string | null;
+  providerType: ProviderConfig['type'] | 'env';
+  runtimeKind: AgentRuntimeKind;
+  resolvedModels: {
+    primary?: string;
+    light?: string;
+    subAgent?: string;
+  };
+  resolvedTimeouts: {
+    fullPerTurnMs?: number;
+    quickPerTurnMs?: number;
+    verifierTimeoutMs?: number;
+    classifierTimeoutMs?: number;
+  };
+  baseUrl?: string;
+  openaiProtocol?: string;
+  environment: Record<string, string>;
+  secretVersion: string;
+}
+
+export interface ProviderRuntimeSnapshotResolution {
+  snapshot: ProviderRuntimeSnapshot;
+  snapshotHash: string;
+}
+
+const SENSITIVE_CONNECTION_FIELDS: Array<keyof ProviderConfig['connection']> = [
+  'apiKey',
+  'claudeApiKey',
+  'claudeAuthToken',
+  'openaiApiKey',
+  'awsBearerToken',
+  'awsAccessKeyId',
+  'awsSecretAccessKey',
+  'awsSessionToken',
+];
+
+const SECRET_ENV_KEYS = [
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'OPENAI_API_KEY',
+  'AWS_BEARER_TOKEN_BEDROCK',
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+];
+
+const PROVIDER_RUNTIME_ENV_KEYS = [
+  'SMARTPERFETTO_AGENT_RUNTIME',
+  'CLAUDE_MODEL',
+  'CLAUDE_LIGHT_MODEL',
+  'CLAUDE_SUB_AGENT_MODEL',
+  'OPENAI_MODEL',
+  'OPENAI_LIGHT_MODEL',
+  'OPENAI_SUB_AGENT_MODEL',
+  'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_BEDROCK_BASE_URL',
+  'OPENAI_BASE_URL',
+  'OPENAI_AGENTS_PROTOCOL',
+  'CLAUDE_CODE_USE_BEDROCK',
+  'AWS_REGION',
+  'AWS_PROFILE',
+  'CLAUDE_CODE_USE_VERTEX',
+  'ANTHROPIC_VERTEX_PROJECT_ID',
+  'CLOUD_ML_REGION',
+  'CLAUDE_MAX_TURNS',
+  'CLAUDE_EFFORT',
+  'CLAUDE_MAX_BUDGET_USD',
+  'CLAUDE_FULL_PER_TURN_MS',
+  'CLAUDE_QUICK_PER_TURN_MS',
+  'CLAUDE_VERIFIER_TIMEOUT_MS',
+  'CLAUDE_CLASSIFIER_TIMEOUT_MS',
+  'CLAUDE_ENABLE_SUB_AGENTS',
+  'CLAUDE_ENABLE_VERIFICATION',
+  'OPENAI_MAX_TURNS',
+  'OPENAI_EFFORT',
+  'OPENAI_MAX_BUDGET_USD',
+  'OPENAI_FULL_PER_TURN_MS',
+  'OPENAI_QUICK_PER_TURN_MS',
+  'OPENAI_VERIFIER_TIMEOUT_MS',
+  'OPENAI_CLASSIFIER_TIMEOUT_MS',
+  'OPENAI_ENABLE_SUB_AGENTS',
+  'OPENAI_ENABLE_VERIFICATION',
+];
+
+type ResolvedTimeoutKey = keyof ProviderRuntimeSnapshot['resolvedTimeouts'];
+
+const TIMEOUT_KEYS: ResolvedTimeoutKey[] = [
+  'fullPerTurnMs',
+  'quickPerTurnMs',
+  'verifierTimeoutMs',
+  'classifierTimeoutMs',
+];
+
+function sha256Hex(value: string): string {
+  return crypto.createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function normalizeForJson(value: unknown): JsonValue | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => normalizeForJson(item))
+      .filter((item): item is JsonValue => item !== undefined);
+  }
+  if (typeof value === 'object') {
+    const out: { [key: string]: JsonValue } = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      const normalized = normalizeForJson((value as Record<string, unknown>)[key]);
+      if (normalized !== undefined) out[key] = normalized;
+    }
+    return out;
+  }
+  return undefined;
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(normalizeForJson(value));
+}
+
+function hashSecretEntries(entries: Array<[string, string | undefined]>): string {
+  const present = entries.filter((entry): entry is [string, string] => Boolean(entry[1]));
+  if (present.length === 0) return 'none';
+  return `sha256:${sha256Hex(canonicalJson(present))}`;
+}
+
+function pickEnv(env: Record<string, string | undefined>, keys: string[]): Record<string, string> {
+  const picked: Record<string, string> = {};
+  for (const key of keys) {
+    const value = env[key];
+    if (value !== undefined && value !== '') picked[key] = value;
+  }
+  return picked;
+}
+
+function parseRuntimeEnv(value: string | undefined): AgentRuntimeKind | undefined {
+  switch (value) {
+    case 'claude-agent-sdk':
+    case 'openai-agents-sdk':
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+function pickResolvedTimeouts(tuning?: ProviderTuning): ProviderRuntimeSnapshot['resolvedTimeouts'] {
+  const resolved: ProviderRuntimeSnapshot['resolvedTimeouts'] = {};
+  for (const key of TIMEOUT_KEYS) {
+    const value = tuning?.[key];
+    if (typeof value === 'number') resolved[key] = value;
+  }
+  return resolved;
+}
+
+function inferBaseUrl(runtimeKind: AgentRuntimeKind, env: Record<string, string>): string | undefined {
+  if (runtimeKind === 'openai-agents-sdk') {
+    return env.OPENAI_BASE_URL;
+  }
+  return env.ANTHROPIC_BASE_URL || env.ANTHROPIC_BEDROCK_BASE_URL;
+}
+
+function envRuntimeSnapshot(runtimeOverride?: AgentRuntimeKind): ProviderRuntimeSnapshot {
+  const runtimeKind = runtimeOverride
+    ?? parseRuntimeEnv(process.env.SMARTPERFETTO_AGENT_RUNTIME)
+    ?? 'claude-agent-sdk';
+  const env = pickEnv(process.env, [...PROVIDER_RUNTIME_ENV_KEYS, ...SECRET_ENV_KEYS]);
+  const timeoutPrefix = runtimeKind === 'openai-agents-sdk' ? 'OPENAI' : 'CLAUDE';
+  const resolvedTimeouts: ProviderRuntimeSnapshot['resolvedTimeouts'] = {};
+  const timeoutMap: Array<[keyof ProviderRuntimeSnapshot['resolvedTimeouts'], string]> = [
+    ['fullPerTurnMs', `${timeoutPrefix}_FULL_PER_TURN_MS`],
+    ['quickPerTurnMs', `${timeoutPrefix}_QUICK_PER_TURN_MS`],
+    ['verifierTimeoutMs', `${timeoutPrefix}_VERIFIER_TIMEOUT_MS`],
+    ['classifierTimeoutMs', `${timeoutPrefix}_CLASSIFIER_TIMEOUT_MS`],
+  ];
+  for (const [key, envKey] of timeoutMap) {
+    const value = env[envKey];
+    const parsed = value ? Number.parseInt(value, 10) : NaN;
+    if (Number.isFinite(parsed)) resolvedTimeouts[key] = parsed;
+  }
+
+  const modelPrefix = runtimeKind === 'openai-agents-sdk' ? 'OPENAI' : 'CLAUDE';
+  const nonSecretEnv = pickEnv(process.env, PROVIDER_RUNTIME_ENV_KEYS);
+  return {
+    version: 1,
+    providerId: null,
+    providerType: 'env',
+    runtimeKind,
+    resolvedModels: {
+      primary: env[`${modelPrefix}_MODEL`],
+      light: env[`${modelPrefix}_LIGHT_MODEL`],
+      subAgent: env[`${modelPrefix}_SUB_AGENT_MODEL`],
+    },
+    resolvedTimeouts,
+    baseUrl: inferBaseUrl(runtimeKind, nonSecretEnv),
+    openaiProtocol: runtimeKind === 'openai-agents-sdk' ? env.OPENAI_AGENTS_PROTOCOL : undefined,
+    environment: nonSecretEnv,
+    secretVersion: hashSecretEntries(SECRET_ENV_KEYS.map((key) => [key, process.env[key]])),
+  };
+}
+
+function providerSecretVersion(provider: ProviderConfig): string {
+  return hashSecretEntries(
+    SENSITIVE_CONNECTION_FIELDS.map((field) => [field, provider.connection[field] as string | undefined]),
+  );
+}
+
+function providerRuntimeSnapshot(
+  providerService: ProviderService,
+  provider: ProviderConfig,
+): ProviderRuntimeSnapshot {
+  const runtimeKind = providerService.resolveAgentRuntime(provider);
+  const env = providerService.getEnvForProvider(provider.id) ?? {};
+  const nonSecretEnv = pickEnv(env, PROVIDER_RUNTIME_ENV_KEYS);
+  return {
+    version: 1,
+    providerId: provider.id,
+    providerType: provider.type,
+    runtimeKind,
+    resolvedModels: {
+      primary: provider.models.primary,
+      light: provider.models.light,
+      subAgent: provider.models.subAgent,
+    },
+    resolvedTimeouts: pickResolvedTimeouts(provider.tuning),
+    baseUrl: inferBaseUrl(runtimeKind, nonSecretEnv),
+    openaiProtocol: runtimeKind === 'openai-agents-sdk'
+      ? providerService.resolveOpenAIProtocol(provider)
+      : undefined,
+    environment: nonSecretEnv,
+    secretVersion: providerSecretVersion(provider),
+  };
+}
+
+export function hashProviderRuntimeSnapshot(snapshot: ProviderRuntimeSnapshot): string {
+  return sha256Hex(canonicalJson(snapshot));
+}
+
+export function resolveProviderRuntimeSnapshot(
+  providerService: ProviderService,
+  providerId: string | null,
+  runtimeOverride?: AgentRuntimeKind,
+): ProviderRuntimeSnapshotResolution {
+  const snapshot = typeof providerId === 'string'
+    ? (() => {
+        const provider = providerService.getRawProvider(providerId);
+        if (!provider) throw new Error(`Provider not found: ${providerId}`);
+        return providerRuntimeSnapshot(providerService, provider);
+      })()
+    : envRuntimeSnapshot(runtimeOverride);
+  return {
+    snapshot,
+    snapshotHash: hashProviderRuntimeSnapshot(snapshot),
+  };
+}

--- a/docs/features/enterprise-multi-tenant/README.md
+++ b/docs/features/enterprise-multi-tenant/README.md
@@ -24,7 +24,7 @@
 - [x] 1.3 主线 C 第一批最小改动（详见 4.1，独立 PR，不与 lease 大重写混合）
 - [x] 1.4 前端 `windowId` 注入 + pending trace key 加 windowId（`ai_panel.ts` / `session_manager.ts` / `backend_uploader.ts`）
 - [x] 1.5 SSE 路径明确收敛到 `fetch + ReadableStream` + `Authorization: Bearer` + `Last-Event-ID` cursor replay
-- [ ] 1.6 `ProviderSnapshot` hash + resume 校验（`agentAnalyzeSessionService.prepareSession`），不再只比 `providerId`
+- [x] 1.6 `ProviderSnapshot` hash + resume 校验（`agentAnalyzeSessionService.prepareSession`），不再只比 `providerId`
 - [ ] 1.7 DB schema 最小切片：`organizations / workspaces / users / memberships / trace_assets / analysis_sessions / analysis_runs / agent_events / provider_snapshots`
 - [ ] 1.8 三用户 + 双窗口回归脚本（落到 `backend/src/scripts/`），覆盖 D1/D2
 


### PR DESCRIPTION
## Summary
- add non-secret ProviderSnapshot hash generation for Provider Manager and env fallback runtimes
- persist provider snapshot hash in runtime state snapshots and validate it in analyze/resume restore paths
- keep SmartPerfetto conversation context while starting a fresh SDK runtime when provider config changes under the same providerId
- mark enterprise multi-tenant README §0.1.6 complete

## Verification
- cd backend && npx jest src/services/providerManager/__tests__/providerSnapshot.test.ts src/assistant/application/__tests__/agentAnalyzeSessionService.test.ts --runInBand
- cd backend && npm run typecheck
- cd backend && npm run test:scene-trace-regression
- npm run verify:pr