### PR TITLE
feat(enterprise): add minimal tenant schema

### DIFF
--- a/backend/src/services/__tests__/enterpriseSchema.test.ts
+++ b/backend/src/services/__tests__/enterpriseSchema.test.ts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 Gracker (Chris)
+// This file is part of SmartPerfetto. See LICENSE for details.
+
+import Database from 'better-sqlite3';
+import {
+  applyEnterpriseMinimalSchema,
+  ENTERPRISE_MINIMAL_SCHEMA_TABLES,
+} from '../enterpriseSchema';
+
+function tableNames(db: Database.Database): Set<string> {
+  const rows = db.prepare<unknown[], { name: string }>(`
+    SELECT name FROM sqlite_master WHERE type = 'table'
+  `).all();
+  return new Set(rows.map(row => row.name));
+}
+
+function columnNames(db: Database.Database, table: string): Set<string> {
+  const rows = db.prepare<unknown[], { name: string }>(`PRAGMA table_info(${table})`).all();
+  return new Set(rows.map(row => row.name));
+}
+
+function indexNames(db: Database.Database): Set<string> {
+  const rows = db.prepare<unknown[], { name: string }>(`
+    SELECT name FROM sqlite_master WHERE type = 'index'
+  `).all();
+  return new Set(rows.map(row => row.name));
+}
+
+describe('enterprise minimal schema', () => {
+  let db: Database.Database | undefined;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+  });
+
+  afterEach(() => {
+    db?.close();
+    db = undefined;
+  });
+
+  test('creates the §0.1.7 minimal enterprise tables and key columns', () => {
+    applyEnterpriseMinimalSchema(db!);
+
+    const tables = tableNames(db!);
+    for (const table of ENTERPRISE_MINIMAL_SCHEMA_TABLES) {
+      expect(tables.has(table)).toBe(true);
+    }
+    expect(tables.has('enterprise_schema_migrations')).toBe(true);
+
+    expect([...columnNames(db!, 'organizations')]).toEqual(expect.arrayContaining([
+      'id',
+      'name',
+      'status',
+      'plan',
+      'created_at',
+      'updated_at',
+    ]));
+    expect([...columnNames(db!, 'trace_assets')]).toEqual(expect.arrayContaining([
+      'id',
+      'tenant_id',
+      'workspace_id',
+      'owner_user_id',
+      'local_path',
+      'sha256',
+      'size_bytes',
+      'status',
+      'metadata_json',
+      'created_at',
+      'expires_at',
+    ]));
+    expect([...columnNames(db!, 'analysis_sessions')]).toEqual(expect.arrayContaining([
+      'id',
+      'tenant_id',
+      'workspace_id',
+      'trace_id',
+      'created_by',
+      'provider_snapshot_id',
+      'visibility',
+      'status',
+      'created_at',
+      'updated_at',
+    ]));
+    expect([...columnNames(db!, 'agent_events')]).toEqual(expect.arrayContaining([
+      'id',
+      'tenant_id',
+      'workspace_id',
+      'run_id',
+      'cursor',
+      'event_type',
+      'payload_json',
+      'created_at',
+    ]));
+    expect([...columnNames(db!, 'provider_snapshots')]).toEqual(expect.arrayContaining([
+      'id',
+      'tenant_id',
+      'provider_id',
+      'snapshot_hash',
+      'runtime_kind',
+      'resolved_config_json',
+      'secret_version',
+      'created_at',
+    ]));
+  });
+
+  test('creates owner-guard and replay indexes for high-risk lookup paths', () => {
+    applyEnterpriseMinimalSchema(db!);
+
+    const indexes = indexNames(db!);
+    expect(indexes.has('idx_trace_assets_owner_guard')).toBe(true);
+    expect(indexes.has('idx_analysis_sessions_owner_guard')).toBe(true);
+    expect(indexes.has('idx_analysis_runs_status')).toBe(true);
+    expect(indexes.has('idx_agent_events_replay')).toBe(true);
+    expect(indexes.has('idx_agent_events_owner_guard')).toBe(true);
+    expect(indexes.has('idx_provider_snapshots_provider')).toBe(true);
+  });
+
+  test('is idempotent and records the applied schema version once', () => {
+    applyEnterpriseMinimalSchema(db!);
+    applyEnterpriseMinimalSchema(db!);
+
+    const rows = db!.prepare<unknown[], { version: number }>(
+      'SELECT version FROM enterprise_schema_migrations ORDER BY version',
+    ).all();
+    expect(rows).toEqual([{ version: 1 }]);
+  });
+
+  test('enforces the tenant workspace session run event chain', () => {
+    applyEnterpriseMinimalSchema(db!);
+    const now = Date.now();
+
+    db!.prepare(`
+      INSERT INTO organizations (id, name, status, plan, created_at, updated_at)
+      VALUES ('tenant-a', 'Tenant A', 'active', 'enterprise', ?, ?)
+    `).run(now, now);
+    db!.prepare(`
+      INSERT INTO workspaces (id, tenant_id, name, created_at, updated_at)
+      VALUES ('workspace-a', 'tenant-a', 'Workspace A', ?, ?)
+    `).run(now, now);
+    db!.prepare(`
+      INSERT INTO users (id, tenant_id, email, display_name, idp_subject, created_at, updated_at)
+      VALUES ('user-a', 'tenant-a', 'a@example.test', 'User A', 'oidc|a', ?, ?)
+    `).run(now, now);
+    db!.prepare(`
+      INSERT INTO memberships (tenant_id, workspace_id, user_id, role, created_at)
+      VALUES ('tenant-a', 'workspace-a', 'user-a', 'admin', ?)
+    `).run(now);
+    db!.prepare(`
+      INSERT INTO trace_assets
+        (id, tenant_id, workspace_id, owner_user_id, local_path, sha256, size_bytes, status, created_at)
+      VALUES
+        ('trace-a', 'tenant-a', 'workspace-a', 'user-a', '/tmp/trace-a.pftrace', 'abc123', 1024, 'ready', ?)
+    `).run(now);
+    db!.prepare(`
+      INSERT INTO provider_snapshots
+        (id, tenant_id, provider_id, snapshot_hash, runtime_kind, resolved_config_json, secret_version, created_at)
+      VALUES
+        ('provider-snapshot-a', 'tenant-a', 'provider-a', 'hash-a', 'openai-agents-sdk', '{"models":{}}', 'v1', ?)
+    `).run(now);
+    db!.prepare(`
+      INSERT INTO analysis_sessions
+        (id, tenant_id, workspace_id, trace_id, created_by, provider_snapshot_id, visibility, status, created_at, updated_at)
+      VALUES
+        ('session-a', 'tenant-a', 'workspace-a', 'trace-a', 'user-a', 'provider-snapshot-a', 'private', 'running', ?, ?)
+    `).run(now, now);
+    db!.prepare(`
+      INSERT INTO analysis_runs
+        (id, tenant_id, workspace_id, session_id, mode, status, question, started_at)
+      VALUES
+        ('run-a', 'tenant-a', 'workspace-a', 'session-a', 'full', 'running', 'analyze', ?)
+    `).run(now);
+    db!.prepare(`
+      INSERT INTO agent_events
+        (id, tenant_id, workspace_id, run_id, cursor, event_type, payload_json, created_at)
+      VALUES
+        ('event-a-1', 'tenant-a', 'workspace-a', 'run-a', 1, 'progress', '{}', ?)
+    `).run(now);
+
+    expect(() => {
+      db!.prepare(`
+        INSERT INTO agent_events
+          (id, tenant_id, workspace_id, run_id, cursor, event_type, payload_json, created_at)
+        VALUES
+          ('event-a-duplicate', 'tenant-a', 'workspace-a', 'run-a', 1, 'progress', '{}', ?)
+      `).run(now);
+    }).toThrow();
+    expect(() => {
+      db!.prepare(`
+        INSERT INTO analysis_runs
+          (id, tenant_id, workspace_id, session_id, mode, status, question, started_at)
+        VALUES
+          ('run-missing', 'tenant-a', 'workspace-a', 'missing-session', 'full', 'running', 'analyze', ?)
+      `).run(now);
+    }).toThrow();
+  });
+});

--- a/backend/src/services/enterpriseSchema.ts
+++ b/backend/src/services/enterpriseSchema.ts
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 Gracker (Chris)
+// This file is part of SmartPerfetto. See LICENSE for details.
+
+import type Database from 'better-sqlite3';
+
+interface MigrationStep {
+  version: number;
+  up: (db: Database.Database) => void;
+}
+
+export const ENTERPRISE_MINIMAL_SCHEMA_TABLES = [
+  'organizations',
+  'workspaces',
+  'users',
+  'memberships',
+  'trace_assets',
+  'analysis_sessions',
+  'analysis_runs',
+  'agent_events',
+  'provider_snapshots',
+] as const;
+
+export type EnterpriseMinimalSchemaTable = typeof ENTERPRISE_MINIMAL_SCHEMA_TABLES[number];
+
+const MIGRATIONS: MigrationStep[] = [
+  {
+    version: 1,
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS organizations (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          status TEXT NOT NULL,
+          plan TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_organizations_status
+          ON organizations(status);
+
+        CREATE TABLE IF NOT EXISTS workspaces (
+          id TEXT PRIMARY KEY,
+          tenant_id TEXT NOT NULL,
+          name TEXT NOT NULL,
+          retention_policy TEXT,
+          quota_policy TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          FOREIGN KEY (tenant_id) REFERENCES organizations(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_workspaces_tenant
+          ON workspaces(tenant_id);
+
+        CREATE TABLE IF NOT EXISTS users (
+          id TEXT PRIMARY KEY,
+          tenant_id TEXT NOT NULL,
+          email TEXT NOT NULL,
+          display_name TEXT,
+          idp_subject TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          FOREIGN KEY (tenant_id) REFERENCES organizations(id) ON DELETE CASCADE,
+          UNIQUE (tenant_id, email),
+          UNIQUE (tenant_id, idp_subject)
+        );
+        CREATE INDEX IF NOT EXISTS idx_users_tenant
+          ON users(tenant_id);
+
+        CREATE TABLE IF NOT EXISTS memberships (
+          tenant_id TEXT NOT NULL,
+          workspace_id TEXT NOT NULL,
+          user_id TEXT NOT NULL,
+          role TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          PRIMARY KEY (tenant_id, workspace_id, user_id),
+          FOREIGN KEY (tenant_id) REFERENCES organizations(id) ON DELETE CASCADE,
+          FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+          FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_memberships_user
+          ON memberships(tenant_id, user_id);
+        CREATE INDEX IF NOT EXISTS idx_memberships_workspace
+          ON memberships(tenant_id, workspace_id);
+
+        CREATE TABLE IF NOT EXISTS trace_assets (
+          id TEXT PRIMARY KEY,
+          tenant_id TEXT NOT NULL,
+          workspace_id TEXT NOT NULL,
+          owner_user_id TEXT,
+          local_path TEXT NOT NULL,
+          sha256 TEXT,
+          size_bytes INTEGER,
+          status TEXT NOT NULL,
+          metadata_json TEXT,
+          created_at INTEGER NOT NULL,
+          expires_at INTEGER,
+          FOREIGN KEY (tenant_id) REFERENCES organizations(id) ON DELETE CASCADE,
+          FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+          FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE SET NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_trace_assets_owner_guard
+          ON trace_assets(tenant_id, workspace_id, id);
+        CREATE INDEX IF NOT EXISTS idx_trace_assets_status
+          ON trace_assets(tenant_id, workspace_id, status, created_at);
+        CREATE INDEX IF NOT EXISTS idx_trace_assets_sha256
+          ON trace_assets(tenant_id, workspace_id, sha256);
+
+        CREATE TABLE IF NOT EXISTS provider_snapshots (
+          id TEXT PRIMARY KEY,
+          tenant_id TEXT NOT NULL,
+          provider_id TEXT NOT NULL,
+          snapshot_hash TEXT NOT NULL,
+          runtime_kind TEXT NOT NULL,
+          resolved_config_json TEXT NOT NULL,
+          secret_version TEXT,
+          created_at INTEGER NOT NULL,
+          FOREIGN KEY (tenant_id) REFERENCES organizations(id) ON DELETE CASCADE,
+          UNIQUE (tenant_id, snapshot_hash)
+        );
+        CREATE INDEX IF NOT EXISTS idx_provider_snapshots_provider
+          ON provider_snapshots(tenant_id, provider_id, created_at);
+
+        CREATE TABLE IF NOT EXISTS analysis_sessions (
+          id TEXT PRIMARY KEY,
+          tenant_id TEXT NOT NULL,
+          workspace_id TEXT NOT NULL,
+          trace_id TEXT NOT NULL,
+          created_by TEXT,
+          provider_snapshot_id TEXT,
+          title TEXT,
+          visibility TEXT NOT NULL,
+          status TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          FOREIGN KEY (tenant_id) REFERENCES organizations(id) ON DELETE CASCADE,
+          FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+          FOREIGN KEY (trace_id) REFERENCES trace_assets(id) ON DELETE CASCADE,
+          FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL,
+          FOREIGN KEY (provider_snapshot_id) REFERENCES provider_snapshots(id) ON DELETE SET NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_analysis_sessions_owner_guard
+          ON analysis_sessions(tenant_id, workspace_id, id);
+        CREATE INDEX IF NOT EXISTS idx_analysis_sessions_trace
+          ON analysis_sessions(tenant_id, workspace_id, trace_id, created_at);
+        CREATE INDEX IF NOT EXISTS idx_analysis_sessions_status
+          ON analysis_sessions(tenant_id, workspace_id, status, updated_at);
+
+        CREATE TABLE IF NOT EXISTS analysis_runs (
+          id TEXT PRIMARY KEY,
+          tenant_id TEXT NOT NULL,
+          workspace_id TEXT NOT NULL,
+          session_id TEXT NOT NULL,
+          mode TEXT NOT NULL,
+          status TEXT NOT NULL,
+          question TEXT NOT NULL,
+          started_at INTEGER NOT NULL,
+          completed_at INTEGER,
+          error_json TEXT,
+          FOREIGN KEY (tenant_id) REFERENCES organizations(id) ON DELETE CASCADE,
+          FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+          FOREIGN KEY (session_id) REFERENCES analysis_sessions(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_analysis_runs_session
+          ON analysis_runs(session_id, started_at);
+        CREATE INDEX IF NOT EXISTS idx_analysis_runs_status
+          ON analysis_runs(tenant_id, workspace_id, status, started_at);
+
+        CREATE TABLE IF NOT EXISTS agent_events (
+          id TEXT PRIMARY KEY,
+          tenant_id TEXT NOT NULL,
+          workspace_id TEXT NOT NULL,
+          run_id TEXT NOT NULL,
+          cursor INTEGER NOT NULL,
+          event_type TEXT NOT NULL,
+          payload_json TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          FOREIGN KEY (tenant_id) REFERENCES organizations(id) ON DELETE CASCADE,
+          FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+          FOREIGN KEY (run_id) REFERENCES analysis_runs(id) ON DELETE CASCADE,
+          UNIQUE (run_id, cursor)
+        );
+        CREATE INDEX IF NOT EXISTS idx_agent_events_replay
+          ON agent_events(run_id, cursor);
+        CREATE INDEX IF NOT EXISTS idx_agent_events_owner_guard
+          ON agent_events(tenant_id, workspace_id, run_id, cursor);
+      `);
+    },
+  },
+];
+
+export function applyEnterpriseMinimalSchema(db: Database.Database): void {
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS enterprise_schema_migrations (
+      version INTEGER PRIMARY KEY,
+      applied_at INTEGER NOT NULL
+    );
+  `);
+  const applied = new Set(
+    db.prepare<unknown[], { version: number }>(
+      'SELECT version FROM enterprise_schema_migrations',
+    ).all().map(row => row.version),
+  );
+  for (const step of MIGRATIONS) {
+    if (applied.has(step.version)) continue;
+    const tx = db.transaction(() => {
+      step.up(db);
+      db.prepare(
+        'INSERT INTO enterprise_schema_migrations (version, applied_at) VALUES (?, ?)',
+      ).run(step.version, Date.now());
+    });
+    tx();
+  }
+}

--- a/backend/src/services/sessionPersistenceService.ts
+++ b/backend/src/services/sessionPersistenceService.ts
@@ -25,6 +25,7 @@ import { EnhancedSessionContext } from '../agent/context/enhancedSessionContext'
 import { FocusStore, FocusStoreSnapshot } from '../agent/context/focusStore';
 import { TraceAgentState } from '../agent/state/traceAgentState';
 import type { SessionStateSnapshot } from '../agentv3/sessionStateSnapshot';
+import { applyEnterpriseMinimalSchema } from './enterpriseSchema';
 
 // DB path is resolved lazily (in the constructor) rather than at module load.
 // Module-load resolution would capture `process.cwd()` at the time of the first
@@ -51,6 +52,8 @@ export class SessionPersistenceService {
 
     this.db = new Database(dbPath);
     this.db.pragma('journal_mode = WAL');
+    this.db.pragma('busy_timeout = 5000');
+    this.db.pragma('foreign_keys = ON');
     this.initializeSchema();
   }
 
@@ -88,6 +91,7 @@ export class SessionPersistenceService {
 
       CREATE INDEX IF NOT EXISTS idx_session_id ON messages(session_id);
     `);
+    applyEnterpriseMinimalSchema(this.db);
   }
 
   /**

--- a/docs/features/enterprise-multi-tenant/README.md
+++ b/docs/features/enterprise-multi-tenant/README.md
@@ -25,7 +25,7 @@
 - [x] 1.4 前端 `windowId` 注入 + pending trace key 加 windowId（`ai_panel.ts` / `session_manager.ts` / `backend_uploader.ts`）
 - [x] 1.5 SSE 路径明确收敛到 `fetch + ReadableStream` + `Authorization: Bearer` + `Last-Event-ID` cursor replay
 - [x] 1.6 `ProviderSnapshot` hash + resume 校验（`agentAnalyzeSessionService.prepareSession`），不再只比 `providerId`
-- [ ] 1.7 DB schema 最小切片：`organizations / workspaces / users / memberships / trace_assets / analysis_sessions / analysis_runs / agent_events / provider_snapshots`
+- [x] 1.7 DB schema 最小切片：`organizations / workspaces / users / memberships / trace_assets / analysis_sessions / analysis_runs / agent_events / provider_snapshots`
 - [ ] 1.8 三用户 + 双窗口回归脚本（落到 `backend/src/scripts/`），覆盖 D1/D2
 
 ### 0.2 主线 A：身份与权限（§18）


### PR DESCRIPTION
## Summary
- add the §0.1.7 minimal enterprise metadata schema for organizations, workspaces, users, memberships, trace assets, analysis sessions/runs, replayable agent events, and provider snapshots
- apply the schema through the existing SessionPersistenceService SQLite initialization path
- add in-memory schema tests for required tables, owner-guard/replay indexes, migration idempotency, foreign-key chain, and agent event cursor uniqueness
- mark enterprise multi-tenant README §0.1.7 complete

## Verification
- export PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH"; cd backend && npx jest src/services/__tests__/enterpriseSchema.test.ts --runInBand
- export PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH"; cd backend && npx jest src/services/__tests__/enterpriseSchema.test.ts src/services/__tests__/sessionPersistenceService.test.ts --runInBand
- export PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH"; cd backend && npm run typecheck
- export PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH"; cd backend && npm run test:scene-trace-regression
- export PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH"; npm run verify:pr

Note: local backend/node_modules/better-sqlite3 was rebuilt for Node 24.15.0 because the previous native binding ABI did not match the repository Node runtime.