### PR TITLE
feat(enterprise): parse auth context modes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,11 @@ FRONTEND_URL=http://localhost:10000
 
 # API Authentication (recommended in any shared environment)
 # SMARTPERFETTO_API_KEY=replace_with_a_strong_random_secret
+# Enterprise mode disables unauthenticated dev fallback. SSO trusted headers are
+# only safe behind an OIDC-authenticated reverse proxy that strips inbound
+# client-supplied SSO headers.
+# SMARTPERFETTO_ENTERPRISE=false
+# SMARTPERFETTO_SSO_TRUSTED_HEADERS=false
 
 # ---------------------------------------------------
 # AI runtime

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -525,6 +525,11 @@ FRONTEND_URL=http://localhost:10000
 # If set, all protected APIs require:
 #   Authorization: Bearer <SMARTPERFETTO_API_KEY>
 # SMARTPERFETTO_API_KEY=replace_with_a_strong_random_secret
+#
+# Enterprise mode disables unauthenticated dev fallback. SSO trusted headers are
+# only safe behind an OIDC-authenticated reverse proxy that strips inbound
+# client-supplied SSO headers before injecting trusted identity headers.
+# SMARTPERFETTO_SSO_TRUSTED_HEADERS=false
 
 # ---------------------------------------------------
 # Request Throttling (optional, in-memory, per API key/IP)

--- a/backend/src/middleware/__tests__/auth.test.ts
+++ b/backend/src/middleware/__tests__/auth.test.ts
@@ -12,6 +12,8 @@ import {
 } from '../auth';
 
 const originalApiKey = process.env.SMARTPERFETTO_API_KEY;
+const originalEnterprise = process.env.SMARTPERFETTO_ENTERPRISE;
+const originalSsoTrustedHeaders = process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS;
 
 function makeProbeApp(middleware = authenticate): express.Express {
   const app = express();
@@ -31,6 +33,16 @@ afterEach(() => {
     delete process.env.SMARTPERFETTO_API_KEY;
   } else {
     process.env.SMARTPERFETTO_API_KEY = originalApiKey;
+  }
+  if (originalEnterprise === undefined) {
+    delete process.env.SMARTPERFETTO_ENTERPRISE;
+  } else {
+    process.env.SMARTPERFETTO_ENTERPRISE = originalEnterprise;
+  }
+  if (originalSsoTrustedHeaders === undefined) {
+    delete process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS;
+  } else {
+    process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS = originalSsoTrustedHeaders;
   }
 });
 
@@ -85,6 +97,64 @@ describe('authenticate RequestContext', () => {
     expect(res.body).toEqual({
       error: 'Unauthorized',
       details: 'Invalid or missing API key',
+    });
+  });
+
+  it('rejects dev fallback in enterprise mode when no SSO or API key identity is present', async () => {
+    delete process.env.SMARTPERFETTO_API_KEY;
+    process.env.SMARTPERFETTO_ENTERPRISE = 'true';
+
+    const res = await request(makeProbeApp()).get('/probe');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({
+      error: 'Unauthorized',
+      details: 'Enterprise mode requires SSO or API key authentication',
+    });
+  });
+
+  it('ignores SSO identity headers unless trusted SSO headers are enabled', async () => {
+    delete process.env.SMARTPERFETTO_API_KEY;
+    process.env.SMARTPERFETTO_ENTERPRISE = 'true';
+    process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS = 'false';
+
+    const res = await request(makeProbeApp())
+      .get('/probe')
+      .set('X-SSO-User-Id', 'alice');
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Unauthorized');
+  });
+
+  it('injects SSO RequestContext from trusted identity headers', async () => {
+    delete process.env.SMARTPERFETTO_API_KEY;
+    process.env.SMARTPERFETTO_ENTERPRISE = 'true';
+    process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS = 'true';
+
+    const res = await request(makeProbeApp())
+      .get('/probe')
+      .set('X-SmartPerfetto-SSO-User-Id', 'user<>alice')
+      .set('X-SmartPerfetto-SSO-Email', 'alice@example.test')
+      .set('X-SmartPerfetto-SSO-Tenant-Id', 'tenant-a')
+      .set('X-SmartPerfetto-SSO-Workspace-Id', 'workspace-a')
+      .set('X-SmartPerfetto-SSO-Roles', 'analyst,workspace_admin')
+      .set('X-SmartPerfetto-SSO-Scopes', 'trace:read,trace:write,agent:run')
+      .set('X-Window-Id', 'window-a');
+
+    expect(res.status).toBe(200);
+    expect(res.body.user).toMatchObject({
+      id: 'useralice',
+      email: 'alice@example.test',
+      subscription: 'enterprise',
+    });
+    expect(res.body.requestContext).toMatchObject({
+      tenantId: 'tenant-a',
+      workspaceId: 'workspace-a',
+      userId: 'useralice',
+      authType: 'sso',
+      roles: ['analyst', 'workspace_admin'],
+      scopes: ['trace:read', 'trace:write', 'agent:run'],
+      windowId: 'window-a',
     });
   });
 

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -5,6 +5,7 @@
 import { Request, Response, NextFunction } from 'express';
 import crypto from 'crypto';
 import { ErrorResponse } from '../types';
+import { resolveFeatureConfig } from '../config';
 
 type RequestContextAuthType = 'sso' | 'api_key' | 'dev';
 
@@ -29,6 +30,7 @@ interface AuthenticatedRequest extends Request {
 }
 
 const API_KEY_ENV = 'SMARTPERFETTO_API_KEY';
+const SSO_TRUSTED_HEADERS_ENV = 'SMARTPERFETTO_SSO_TRUSTED_HEADERS';
 export const DEFAULT_TENANT_ID = 'default-dev-tenant';
 export const DEFAULT_WORKSPACE_ID = 'default-workspace';
 export const DEFAULT_DEV_USER_ID = 'dev-user-123';
@@ -37,6 +39,17 @@ const MAX_REQUESTS = Number.parseInt(process.env.SMARTPERFETTO_USAGE_MAX_REQUEST
 const MAX_TRACE_REQUESTS = Number.parseInt(process.env.SMARTPERFETTO_USAGE_MAX_TRACE_REQUESTS || '', 10);
 
 const usageTracker = new Map<string, { resetAt: number; total: number; trace: number }>();
+
+interface ResolvedIdentity {
+  userId: string;
+  email: string;
+  subscription: string;
+  authType: RequestContextAuthType;
+  tenantId?: string;
+  workspaceId?: string;
+  roles?: string[];
+  scopes?: string[];
+}
 
 const getProvidedApiKey = (req: Request): string | undefined => {
   const authHeader = req.headers.authorization;
@@ -62,9 +75,19 @@ const safeEquals = (a: string, b: string): boolean => {
 const hashApiKey = (apiKey: string): string =>
   crypto.createHash('sha256').update(apiKey).digest('hex').slice(0, 8);
 
+const truthyEnv = (value: string | undefined): boolean => {
+  if (!value) return false;
+  return ['1', 'true', 'yes', 'on', 'enabled'].includes(value.trim().toLowerCase());
+};
+
 const sanitizeContextId = (value: unknown): string => {
   if (typeof value !== 'string') return '';
   return value.trim().replace(/[^a-zA-Z0-9._:-]/g, '').slice(0, 128);
+};
+
+const sanitizeHeaderText = (value: unknown): string => {
+  if (typeof value !== 'string') return '';
+  return value.trim().replace(/[\r\n]/g, '').slice(0, 320);
 };
 
 const getHeaderValue = (req: Request, name: string): string => {
@@ -73,13 +96,39 @@ const getHeaderValue = (req: Request, name: string): string => {
   return typeof value === 'string' ? value : '';
 };
 
-const buildRequestContext = (
-  req: Request,
-  userId: string,
-  authType: RequestContextAuthType,
-): RequestContext => {
-  const tenantId = sanitizeContextId(getHeaderValue(req, 'x-tenant-id')) || DEFAULT_TENANT_ID;
-  const workspaceId = sanitizeContextId(getHeaderValue(req, 'x-workspace-id')) || DEFAULT_WORKSPACE_ID;
+const getFirstHeaderValue = (req: Request, names: string[]): string => {
+  for (const name of names) {
+    const value = getHeaderValue(req, name);
+    if (value.trim().length > 0) return value;
+  }
+  return '';
+};
+
+const parseHeaderList = (req: Request, names: string[], fallback: string[]): string[] => {
+  const raw = getFirstHeaderValue(req, names);
+  if (!raw.trim()) return fallback;
+  const parsed = raw
+    .split(',')
+    .map(value => sanitizeContextId(value))
+    .filter(Boolean);
+  return parsed.length > 0 ? parsed : fallback;
+};
+
+const defaultRolesForAuthType = (authType: RequestContextAuthType): string[] =>
+  authType === 'dev' ? ['org_admin'] : ['analyst'];
+
+const defaultScopesForAuthType = (authType: RequestContextAuthType): string[] =>
+  authType === 'dev'
+    ? ['*']
+    : ['trace:read', 'trace:write', 'agent:run', 'report:read'];
+
+const buildRequestContext = (req: Request, identity: ResolvedIdentity): RequestContext => {
+  const tenantId = identity.tenantId
+    || sanitizeContextId(getFirstHeaderValue(req, ['x-tenant-id', 'x-sso-tenant-id']))
+    || DEFAULT_TENANT_ID;
+  const workspaceId = identity.workspaceId
+    || sanitizeContextId(getFirstHeaderValue(req, ['x-workspace-id', 'x-sso-workspace-id']))
+    || DEFAULT_WORKSPACE_ID;
   const requestId =
     sanitizeContextId(getHeaderValue(req, 'x-request-id')) ||
     `req-${Date.now()}-${crypto.randomBytes(4).toString('hex')}`;
@@ -88,15 +137,84 @@ const buildRequestContext = (
   return {
     tenantId,
     workspaceId,
-    userId,
-    authType,
-    roles: authType === 'dev' ? ['org_admin'] : ['analyst'],
-    scopes: authType === 'dev'
-      ? ['*']
-      : ['trace:read', 'trace:write', 'agent:run', 'report:read'],
+    userId: identity.userId,
+    authType: identity.authType,
+    roles: identity.roles ?? defaultRolesForAuthType(identity.authType),
+    scopes: identity.scopes ?? defaultScopesForAuthType(identity.authType),
     requestId,
     ...(windowId ? { windowId } : {}),
   };
+};
+
+const makeDevIdentity = (): ResolvedIdentity => ({
+  userId: DEFAULT_DEV_USER_ID,
+  email: 'dev@example.com',
+  subscription: 'pro',
+  authType: 'dev',
+});
+
+const makeApiKeyIdentity = (apiKey: string): ResolvedIdentity => ({
+  userId: `api-key-${hashApiKey(apiKey)}`,
+  email: '',
+  subscription: 'pro',
+  authType: 'api_key',
+});
+
+const resolveTrustedSsoIdentity = (req: Request): ResolvedIdentity | null => {
+  if (!truthyEnv(process.env[SSO_TRUSTED_HEADERS_ENV])) return null;
+
+  const userId = sanitizeContextId(getFirstHeaderValue(req, [
+    'x-smartperfetto-sso-user-id',
+    'x-sso-user-id',
+    'x-auth-request-user',
+  ]));
+  if (!userId) return null;
+
+  return {
+    userId,
+    email: sanitizeHeaderText(getFirstHeaderValue(req, [
+      'x-smartperfetto-sso-email',
+      'x-sso-email',
+      'x-auth-request-email',
+    ])),
+    subscription: 'enterprise',
+    authType: 'sso',
+    tenantId: sanitizeContextId(getFirstHeaderValue(req, [
+      'x-smartperfetto-sso-tenant-id',
+      'x-sso-tenant-id',
+      'x-tenant-id',
+    ])) || undefined,
+    workspaceId: sanitizeContextId(getFirstHeaderValue(req, [
+      'x-smartperfetto-sso-workspace-id',
+      'x-sso-workspace-id',
+      'x-workspace-id',
+    ])) || undefined,
+    roles: parseHeaderList(req, [
+      'x-smartperfetto-sso-roles',
+      'x-sso-roles',
+    ], defaultRolesForAuthType('sso')),
+    scopes: parseHeaderList(req, [
+      'x-smartperfetto-sso-scopes',
+      'x-sso-scopes',
+    ], defaultScopesForAuthType('sso')),
+  };
+};
+
+const attachIdentity = (req: AuthenticatedRequest, identity: ResolvedIdentity): void => {
+  req.user = {
+    id: identity.userId,
+    email: identity.email,
+    subscription: identity.subscription,
+  };
+  req.requestContext = buildRequestContext(req, identity);
+};
+
+const sendUnauthorized = (res: Response, details: string): void => {
+  const error: ErrorResponse = {
+    error: 'Unauthorized',
+    details,
+  };
+  res.status(401).json(error);
 };
 
 export const getRequestContext = (req: Request): RequestContext | undefined =>
@@ -118,35 +236,31 @@ export const authenticate = async (
   res: Response,
   next: NextFunction
 ): Promise<void> => {
+  const ssoIdentity = resolveTrustedSsoIdentity(req);
+  if (ssoIdentity) {
+    attachIdentity(req, ssoIdentity);
+    next();
+    return;
+  }
+
   const configuredKey = process.env[API_KEY_ENV];
   if (!configuredKey) {
-    // No auth configured: use mock user
-    req.user = {
-      id: DEFAULT_DEV_USER_ID,
-      email: 'dev@example.com',
-      subscription: 'pro',
-    };
-    req.requestContext = buildRequestContext(req, req.user.id, 'dev');
+    if (resolveFeatureConfig(process.env).enterprise) {
+      sendUnauthorized(res, 'Enterprise mode requires SSO or API key authentication');
+      return;
+    }
+    attachIdentity(req, makeDevIdentity());
     next();
     return;
   }
 
   const providedKey = getProvidedApiKey(req);
   if (!providedKey || !safeEquals(providedKey, configuredKey)) {
-    const error: ErrorResponse = {
-      error: 'Unauthorized',
-      details: 'Invalid or missing API key',
-    };
-    res.status(401).json(error);
+    sendUnauthorized(res, 'Invalid or missing API key');
     return;
   }
 
-  req.user = {
-    id: `api-key-${hashApiKey(providedKey)}`,
-    email: '',
-    subscription: 'pro',
-  };
-  req.requestContext = buildRequestContext(req, req.user.id, 'api_key');
+  attachIdentity(req, makeApiKeyIdentity(providedKey));
   next();
 };
 

--- a/docs/features/enterprise-multi-tenant/README.md
+++ b/docs/features/enterprise-multi-tenant/README.md
@@ -29,7 +29,7 @@
 - [x] 1.8 三用户 + 双窗口回归脚本（落到 `backend/src/scripts/`），覆盖 D1/D2
 
 ### 0.2 主线 A：身份与权限（§18）
-- [ ] 2.1 `RequestContext` 接口与解析 middleware（SSO / API key / dev 三模式）
+- [x] 2.1 `RequestContext` 接口与解析 middleware（SSO / API key / dev 三模式）
 - [ ] 2.2 OIDC SSO 集成 + Onboarding flow（§15 全流程，含 audit）
 - [ ] 2.3 API key 管理（创建 / 撤销 / scope / 过期 / 审计）
 - [ ] 2.4 Membership / Role / RBAC 权限矩阵（§8.2）+ owner guard 全 route 覆盖


### PR DESCRIPTION
## Summary
- make `authenticate` resolve RequestContext through explicit trusted SSO, API key, and dev identities
- keep SSO header parsing disabled unless `SMARTPERFETTO_SSO_TRUSTED_HEADERS=true`, and block unauthenticated dev fallback when `SMARTPERFETTO_ENTERPRISE=true`
- add auth-mode tests and env example notes for the trusted-header boundary
- mark README §0.2.1 complete

## Scope note
- This is not the full OIDC onboarding flow from §0.2.2. The SSO path is a trusted identity-header adapter for an OIDC-authenticated reverse proxy.

## Verification
- `cd backend && npx jest src/middleware/__tests__/auth.test.ts --runInBand`
- `cd backend && npx jest src/routes/__tests__/requestContextRouteCoverage.test.ts src/routes/__tests__/ownerGuardRoutes.test.ts --runInBand`
- `cd backend && npm run typecheck`
- `npm run verify:pr`
