### PR TITLE
feat(enterprise): add api key management

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -36,6 +36,7 @@ import memoryRoutes from './routes/memoryRoutes';
 import caseRoutes from './routes/caseRoutes';
 import ragAdminRoutes from './routes/ragAdminRoutes';
 import enterpriseAuthRoutes from './routes/enterpriseAuthRoutes';
+import enterpriseApiKeyRoutes from './routes/enterpriseApiKeyRoutes';
 import {authenticate} from './middleware/auth';
 import {
   assertTraceAnalysisConfiguredForStartup,
@@ -147,6 +148,7 @@ app.get('/debug', (req, res) => {
 // API routes
 app.use('/api/sql', sqlRoutes);
 app.use('/api/auth', enterpriseAuthRoutes);
+app.use('/api/auth', enterpriseApiKeyRoutes);
 app.use('/api/traces', simpleTraceRoutes);
 app.use(AGENT_API_V1_LLM_BASE, aiChatRoutes);
 app.use('/api/perfetto', perfettoLocalRoutes);

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -6,6 +6,10 @@ import { Request, Response, NextFunction } from 'express';
 import crypto from 'crypto';
 import { ErrorResponse } from '../types';
 import { resolveFeatureConfig } from '../config';
+import {
+  EnterpriseApiKeyService,
+  requestHasEnterpriseApiKeyCredential,
+} from '../services/enterpriseApiKeyService';
 import { EnterpriseSsoService } from '../services/enterpriseSsoService';
 
 type RequestContextAuthType = 'sso' | 'api_key' | 'dev';
@@ -272,6 +276,27 @@ export const authenticate = async (
         sendUnauthorized(
           res,
           error instanceof Error ? error.message : 'Invalid SSO session',
+        );
+        return;
+      }
+    }
+  }
+
+  if (requestHasEnterpriseApiKeyCredential(req)) {
+    try {
+      const apiKeyIdentity = EnterpriseApiKeyService.getInstance().resolveRequestIdentityFromRequest(req);
+      if (apiKeyIdentity) {
+        attachIdentity(req, apiKeyIdentity);
+        next();
+        return;
+      }
+      sendUnauthorized(res, 'Invalid or expired API key');
+      return;
+    } catch (error) {
+      if (resolveFeatureConfig(process.env).enterprise) {
+        sendUnauthorized(
+          res,
+          error instanceof Error ? error.message : 'Invalid or expired API key',
         );
         return;
       }

--- a/backend/src/routes/__tests__/enterpriseApiKeyRoutes.test.ts
+++ b/backend/src/routes/__tests__/enterpriseApiKeyRoutes.test.ts
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 Gracker (Chris)
+// This file is part of SmartPerfetto. See LICENSE for details.
+
+import express from 'express';
+import request from 'supertest';
+import Database from 'better-sqlite3';
+import {
+  authenticate,
+  type AuthenticatedRequest,
+} from '../../middleware/auth';
+import { createEnterpriseApiKeyRouter } from '../enterpriseApiKeyRoutes';
+import { applyEnterpriseMinimalSchema } from '../../services/enterpriseSchema';
+import { EnterpriseApiKeyService } from '../../services/enterpriseApiKeyService';
+import { listEnterpriseAuditEvents } from '../../services/enterpriseAuditService';
+
+const originalApiKey = process.env.SMARTPERFETTO_API_KEY;
+const originalEnterprise = process.env.SMARTPERFETTO_ENTERPRISE;
+const originalSsoTrustedHeaders = process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS;
+
+function adminHeaders(): Record<string, string> {
+  return {
+    'X-SmartPerfetto-SSO-User-Id': 'admin-user',
+    'X-SmartPerfetto-SSO-Email': 'admin@example.test',
+    'X-SmartPerfetto-SSO-Tenant-Id': 'tenant-a',
+    'X-SmartPerfetto-SSO-Workspace-Id': 'workspace-a',
+    'X-SmartPerfetto-SSO-Roles': 'workspace_admin',
+  };
+}
+
+function viewerHeaders(): Record<string, string> {
+  return {
+    ...adminHeaders(),
+    'X-SmartPerfetto-SSO-User-Id': 'viewer-user',
+    'X-SmartPerfetto-SSO-Roles': 'viewer',
+    'X-SmartPerfetto-SSO-Scopes': 'trace:read',
+  };
+}
+
+function makeApp(service: EnterpriseApiKeyService): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/auth', createEnterpriseApiKeyRouter({ apiKeyService: service }));
+  app.get('/protected', authenticate, (req, res) => {
+    res.json({ requestContext: (req as AuthenticatedRequest).requestContext });
+  });
+  return app;
+}
+
+function seedIdentity(db: Database.Database): void {
+  const now = Date.now();
+  db.prepare(`
+    INSERT INTO organizations (id, name, status, plan, created_at, updated_at)
+    VALUES ('tenant-a', 'Tenant A', 'active', 'enterprise', ?, ?)
+  `).run(now, now);
+  db.prepare(`
+    INSERT INTO workspaces (id, tenant_id, name, created_at, updated_at)
+    VALUES ('workspace-a', 'tenant-a', 'Workspace A', ?, ?)
+  `).run(now, now);
+  db.prepare(`
+    INSERT INTO users (id, tenant_id, email, display_name, idp_subject, created_at, updated_at)
+    VALUES
+      ('admin-user', 'tenant-a', 'admin@example.test', 'Admin', 'oidc|admin', ?, ?),
+      ('viewer-user', 'tenant-a', 'viewer@example.test', 'Viewer', 'oidc|viewer', ?, ?)
+  `).run(now, now, now, now);
+  db.prepare(`
+    INSERT INTO memberships (tenant_id, workspace_id, user_id, role, created_at)
+    VALUES
+      ('tenant-a', 'workspace-a', 'admin-user', 'workspace_admin', ?),
+      ('tenant-a', 'workspace-a', 'viewer-user', 'viewer', ?)
+  `).run(now, now);
+}
+
+describe('enterprise API key routes', () => {
+  let db: Database.Database;
+  let service: EnterpriseApiKeyService;
+  let app: express.Express;
+
+  beforeEach(() => {
+    process.env.SMARTPERFETTO_ENTERPRISE = 'true';
+    process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS = 'true';
+    delete process.env.SMARTPERFETTO_API_KEY;
+    EnterpriseApiKeyService.resetForTests();
+    db = new Database(':memory:');
+    applyEnterpriseMinimalSchema(db);
+    seedIdentity(db);
+    service = new EnterpriseApiKeyService(db);
+    EnterpriseApiKeyService.setInstanceForTests(service);
+    app = makeApp(service);
+  });
+
+  afterEach(() => {
+    db.close();
+    EnterpriseApiKeyService.resetForTests();
+    if (originalApiKey === undefined) {
+      delete process.env.SMARTPERFETTO_API_KEY;
+    } else {
+      process.env.SMARTPERFETTO_API_KEY = originalApiKey;
+    }
+    if (originalEnterprise === undefined) {
+      delete process.env.SMARTPERFETTO_ENTERPRISE;
+    } else {
+      process.env.SMARTPERFETTO_ENTERPRISE = originalEnterprise;
+    }
+    if (originalSsoTrustedHeaders === undefined) {
+      delete process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS;
+    } else {
+      process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS = originalSsoTrustedHeaders;
+    }
+  });
+
+  test('creates, lists, authenticates with, and revokes a scoped API key with audit events', async () => {
+    const created = await request(app)
+      .post('/api/auth/api-keys')
+      .set(adminHeaders())
+      .send({
+        name: 'CI runner',
+        scopes: ['trace:read', 'agent:run'],
+        expiresAt: Date.now() + 60_000,
+      })
+      .expect(201);
+
+    expect(created.body.token).toMatch(/^spak_/);
+    expect(created.body.apiKey).toMatchObject({
+      tenantId: 'tenant-a',
+      workspaceId: 'workspace-a',
+      ownerUserId: 'admin-user',
+      name: 'CI runner',
+      scopes: ['trace:read', 'agent:run'],
+    });
+    expect(JSON.stringify(created.body)).not.toContain('key_hash');
+
+    const listed = await request(app)
+      .get('/api/auth/api-keys')
+      .set(adminHeaders())
+      .expect(200);
+    expect(listed.body.apiKeys).toHaveLength(1);
+    expect(listed.body.apiKeys[0].id).toBe(created.body.apiKey.id);
+    expect(JSON.stringify(listed.body)).not.toContain(created.body.token);
+
+    const protectedRes = await request(app)
+      .get('/protected')
+      .set('Authorization', `Bearer ${created.body.token}`)
+      .expect(200);
+    expect(protectedRes.body.requestContext).toMatchObject({
+      tenantId: 'tenant-a',
+      workspaceId: 'workspace-a',
+      userId: 'admin-user',
+      authType: 'api_key',
+      roles: ['api_key'],
+      scopes: ['trace:read', 'agent:run'],
+    });
+
+    const revoked = await request(app)
+      .post(`/api/auth/api-keys/${created.body.apiKey.id}/revoke`)
+      .set(adminHeaders())
+      .expect(200);
+    expect(revoked.body.apiKey.revokedAt).toBeGreaterThan(0);
+
+    await request(app)
+      .get('/protected')
+      .set('Authorization', `Bearer ${created.body.token}`)
+      .expect(401);
+
+    expect(listEnterpriseAuditEvents(db).map(event => event.action)).toEqual([
+      'api_key_created',
+      'api_key_revoked',
+    ]);
+  });
+
+  test('rejects API key management without admin role or api_key scope', async () => {
+    await request(app)
+      .post('/api/auth/api-keys')
+      .set(viewerHeaders())
+      .send({ name: 'Denied key' })
+      .expect(403);
+  });
+
+  test('rejects creating a key for a different workspace in this minimal slice', async () => {
+    const res = await request(app)
+      .post('/api/auth/api-keys')
+      .set(adminHeaders())
+      .send({ name: 'Wrong workspace', workspaceId: 'workspace-b' })
+      .expect(400);
+
+    expect(res.body.error).toContain('workspaceId must match');
+  });
+
+  test('rejects expired managed API keys during authenticate', async () => {
+    const created = await request(app)
+      .post('/api/auth/api-keys')
+      .set(adminHeaders())
+      .send({ name: 'Short key' })
+      .expect(201);
+    db.prepare('UPDATE api_keys SET expires_at = ? WHERE id = ?')
+      .run(Date.now() - 1_000, created.body.apiKey.id);
+
+    await request(app)
+      .get('/protected')
+      .set('Authorization', `Bearer ${created.body.token}`)
+      .expect(401);
+  });
+});

--- a/backend/src/routes/enterpriseApiKeyRoutes.ts
+++ b/backend/src/routes/enterpriseApiKeyRoutes.ts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 Gracker (Chris)
+// This file is part of SmartPerfetto. See LICENSE for details.
+
+import express from 'express';
+import {
+  authenticate,
+  requireRequestContext,
+  type AuthenticatedRequest,
+  type RequestContext,
+} from '../middleware/auth';
+import {
+  EnterpriseApiKeyService,
+  type CreateEnterpriseApiKeyInput,
+} from '../services/enterpriseApiKeyService';
+
+interface EnterpriseApiKeyRouteDeps {
+  apiKeyService?: EnterpriseApiKeyService;
+}
+
+function hasScope(context: RequestContext, scope: string): boolean {
+  return context.scopes.includes('*') || context.scopes.includes(scope);
+}
+
+function canReadApiKeys(context: RequestContext): boolean {
+  return hasScope(context, 'api_key:read')
+    || hasScope(context, 'api_key:write')
+    || context.roles.includes('workspace_admin')
+    || context.roles.includes('org_admin');
+}
+
+function canWriteApiKeys(context: RequestContext): boolean {
+  return hasScope(context, 'api_key:write')
+    || context.roles.includes('workspace_admin')
+    || context.roles.includes('org_admin');
+}
+
+function forbidden(res: express.Response): void {
+  res.status(403).json({
+    success: false,
+    error: 'Forbidden',
+    details: 'API key management requires api_key:write scope or workspace/org admin role',
+  });
+}
+
+function createInputFromBody(body: any): CreateEnterpriseApiKeyInput {
+  return {
+    name: typeof body?.name === 'string' ? body.name : undefined,
+    workspaceId: body?.workspaceId === null || typeof body?.workspaceId === 'string'
+      ? body.workspaceId
+      : undefined,
+    ownerUserId: body?.ownerUserId === null || typeof body?.ownerUserId === 'string'
+      ? body.ownerUserId
+      : undefined,
+    scopes: body?.scopes,
+    expiresAt: body?.expiresAt,
+  };
+}
+
+function firstParam(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? value[0] || '' : value || '';
+}
+
+export function createEnterpriseApiKeyRouter(deps: EnterpriseApiKeyRouteDeps = {}): express.Router {
+  const router = express.Router();
+  const getService = () => deps.apiKeyService || EnterpriseApiKeyService.getInstance();
+
+  router.get('/api-keys', authenticate, (req, res) => {
+    const context = requireRequestContext(req);
+    if (!canReadApiKeys(context)) {
+      forbidden(res);
+      return;
+    }
+    res.json({
+      success: true,
+      apiKeys: getService().listApiKeys(context),
+    });
+  });
+
+  router.post('/api-keys', authenticate, (req: AuthenticatedRequest, res) => {
+    const context = requireRequestContext(req);
+    if (!canWriteApiKeys(context)) {
+      forbidden(res);
+      return;
+    }
+    try {
+      const created = getService().createApiKey(context, createInputFromBody(req.body));
+      res.status(201).json({
+        success: true,
+        apiKey: created.apiKey,
+        token: created.token,
+      });
+    } catch (error) {
+      res.status(400).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to create API key',
+      });
+    }
+  });
+
+  router.post('/api-keys/:id/revoke', authenticate, (req, res) => {
+    const context = requireRequestContext(req);
+    if (!canWriteApiKeys(context)) {
+      forbidden(res);
+      return;
+    }
+    const revoked = getService().revokeApiKey(context, firstParam(req.params.id));
+    if (!revoked) {
+      res.status(404).json({
+        success: false,
+        error: 'API key not found',
+      });
+      return;
+    }
+    res.json({
+      success: true,
+      apiKey: revoked,
+    });
+  });
+
+  router.delete('/api-keys/:id', authenticate, (req, res) => {
+    const context = requireRequestContext(req);
+    if (!canWriteApiKeys(context)) {
+      forbidden(res);
+      return;
+    }
+    const revoked = getService().revokeApiKey(context, firstParam(req.params.id));
+    if (!revoked) {
+      res.status(404).json({
+        success: false,
+        error: 'API key not found',
+      });
+      return;
+    }
+    res.json({
+      success: true,
+      apiKey: revoked,
+    });
+  });
+
+  return router;
+}
+
+export default createEnterpriseApiKeyRouter();

--- a/backend/src/services/__tests__/enterpriseSchema.test.ts
+++ b/backend/src/services/__tests__/enterpriseSchema.test.ts
@@ -123,6 +123,19 @@ describe('enterprise minimal schema', () => {
       'expires_at',
       'revoked_at',
     ]));
+    expect([...columnNames(db!, 'api_keys')]).toEqual(expect.arrayContaining([
+      'id',
+      'tenant_id',
+      'workspace_id',
+      'owner_user_id',
+      'name',
+      'key_hash',
+      'scopes',
+      'created_at',
+      'expires_at',
+      'revoked_at',
+      'last_used_at',
+    ]));
   });
 
   test('creates owner-guard and replay indexes for high-risk lookup paths', () => {
@@ -139,6 +152,9 @@ describe('enterprise minimal schema', () => {
     expect(indexes.has('idx_audit_events_actor')).toBe(true);
     expect(indexes.has('idx_sso_sessions_user')).toBe(true);
     expect(indexes.has('idx_sso_sessions_expiry')).toBe(true);
+    expect(indexes.has('idx_api_keys_scope')).toBe(true);
+    expect(indexes.has('idx_api_keys_owner')).toBe(true);
+    expect(indexes.has('idx_api_keys_expiry')).toBe(true);
   });
 
   test('is idempotent and records the applied schema version once', () => {
@@ -148,7 +164,7 @@ describe('enterprise minimal schema', () => {
     const rows = db!.prepare<unknown[], { version: number }>(
       'SELECT version FROM enterprise_schema_migrations ORDER BY version',
     ).all();
-    expect(rows).toEqual([{ version: 1 }, { version: 2 }]);
+    expect(rows).toEqual([{ version: 1 }, { version: 2 }, { version: 3 }]);
   });
 
   test('enforces the tenant workspace session run event chain', () => {

--- a/backend/src/services/enterpriseApiKeyService.ts
+++ b/backend/src/services/enterpriseApiKeyService.ts
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 Gracker (Chris)
+// This file is part of SmartPerfetto. See LICENSE for details.
+
+import crypto from 'crypto';
+import type { Request } from 'express';
+import type Database from 'better-sqlite3';
+import type { RequestContext, RequestContextAuthType } from '../middleware/auth';
+import { openEnterpriseDb } from './enterpriseDb';
+import { recordEnterpriseAuditEvent } from './enterpriseAuditService';
+
+export const ENTERPRISE_API_KEY_PREFIX = 'spak_';
+
+const DEFAULT_API_KEY_SCOPES = ['trace:read', 'trace:write', 'agent:run', 'report:read'];
+
+interface ApiKeyTokenParts {
+  id: string;
+  secret: string;
+}
+
+interface ApiKeyRow {
+  id: string;
+  tenant_id: string;
+  workspace_id: string | null;
+  owner_user_id: string | null;
+  name: string;
+  key_hash: string;
+  scopes: string;
+  created_at: number;
+  expires_at: number | null;
+  revoked_at: number | null;
+  last_used_at: number | null;
+}
+
+export interface EnterpriseApiKeyRecord {
+  id: string;
+  tenantId: string;
+  workspaceId?: string;
+  ownerUserId?: string;
+  name: string;
+  scopes: string[];
+  createdAt: number;
+  expiresAt?: number;
+  revokedAt?: number;
+  lastUsedAt?: number;
+}
+
+export interface CreateEnterpriseApiKeyInput {
+  name?: string;
+  tenantId?: string;
+  workspaceId?: string | null;
+  ownerUserId?: string | null;
+  scopes?: unknown;
+  expiresAt?: unknown;
+}
+
+export interface CreatedEnterpriseApiKey {
+  apiKey: EnterpriseApiKeyRecord;
+  token: string;
+}
+
+export interface RequestApiKeyIdentity {
+  userId: string;
+  email: string;
+  subscription: string;
+  authType: RequestContextAuthType;
+  tenantId: string;
+  workspaceId?: string;
+  roles: string[];
+  scopes: string[];
+}
+
+function nowMs(): number {
+  return Date.now();
+}
+
+function sanitizeId(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  return value.trim().replace(/[^a-zA-Z0-9._:-]/g, '').slice(0, 128);
+}
+
+function sanitizeScope(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  if (trimmed === '*') return '*';
+  return trimmed.replace(/[^a-zA-Z0-9._:-]/g, '').slice(0, 128);
+}
+
+function safeText(value: unknown, fallback: string): string {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim().replace(/[\r\n]/g, '').slice(0, 120);
+  return trimmed || fallback;
+}
+
+function normalizeScopes(input: unknown, fallback = DEFAULT_API_KEY_SCOPES): string[] {
+  const raw = Array.isArray(input)
+    ? input
+    : typeof input === 'string'
+      ? input.split(/[,\s]+/)
+      : [];
+  const scopes = raw
+    .map(scope => sanitizeScope(scope))
+    .filter(Boolean);
+  return scopes.length > 0 ? [...new Set(scopes)] : [...fallback];
+}
+
+function parseScopes(value: string): string[] {
+  try {
+    return normalizeScopes(JSON.parse(value), []);
+  } catch {
+    return normalizeScopes(value, []);
+  }
+}
+
+function normalizeExpiresAt(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const parsed = typeof value === 'number'
+    ? value
+    : typeof value === 'string' && /^\d+$/.test(value.trim())
+      ? Number.parseInt(value, 10)
+      : Date.parse(String(value));
+  if (!Number.isFinite(parsed)) {
+    throw new Error('expiresAt must be a Unix millisecond timestamp or ISO date string');
+  }
+  if (parsed <= nowMs()) {
+    throw new Error('expiresAt must be in the future');
+  }
+  return parsed;
+}
+
+function hashTokenSecret(id: string, secret: string): string {
+  return crypto.createHash('sha256').update(`${id}.${secret}`).digest('hex');
+}
+
+function safeEquals(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a);
+  const bBuf = Buffer.from(b);
+  return aBuf.length === bBuf.length && crypto.timingSafeEqual(aBuf, bBuf);
+}
+
+function parseApiKeyToken(token: string | undefined): ApiKeyTokenParts | null {
+  if (!token?.startsWith(ENTERPRISE_API_KEY_PREFIX)) return null;
+  const payload = token.slice(ENTERPRISE_API_KEY_PREFIX.length);
+  const separator = payload.indexOf('.');
+  if (separator <= 0) return null;
+  const id = payload.slice(0, separator);
+  const secret = payload.slice(separator + 1);
+  return sanitizeId(id) === id && secret.length >= 32 ? { id, secret } : null;
+}
+
+export function extractEnterpriseApiKeyToken(req: Request): string | undefined {
+  const authHeader = req.headers.authorization;
+  if (typeof authHeader === 'string' && authHeader.startsWith('Bearer ')) {
+    const token = authHeader.slice('Bearer '.length).trim();
+    if (token.startsWith(ENTERPRISE_API_KEY_PREFIX)) return token;
+  }
+  const headerKey = req.headers['x-api-key'];
+  if (typeof headerKey === 'string' && headerKey.trim().startsWith(ENTERPRISE_API_KEY_PREFIX)) {
+    return headerKey.trim();
+  }
+  return undefined;
+}
+
+export function requestHasEnterpriseApiKeyCredential(req: Request): boolean {
+  return Boolean(extractEnterpriseApiKeyToken(req));
+}
+
+function rowToRecord(row: ApiKeyRow): EnterpriseApiKeyRecord {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    ...(row.workspace_id ? { workspaceId: row.workspace_id } : {}),
+    ...(row.owner_user_id ? { ownerUserId: row.owner_user_id } : {}),
+    name: row.name,
+    scopes: parseScopes(row.scopes),
+    createdAt: row.created_at,
+    ...(row.expires_at ? { expiresAt: row.expires_at } : {}),
+    ...(row.revoked_at ? { revokedAt: row.revoked_at } : {}),
+    ...(row.last_used_at ? { lastUsedAt: row.last_used_at } : {}),
+  };
+}
+
+export class EnterpriseApiKeyService {
+  private static instance: EnterpriseApiKeyService | undefined;
+
+  constructor(private readonly db: Database.Database = openEnterpriseDb()) {}
+
+  static getInstance(): EnterpriseApiKeyService {
+    if (!EnterpriseApiKeyService.instance) {
+      EnterpriseApiKeyService.instance = new EnterpriseApiKeyService();
+    }
+    return EnterpriseApiKeyService.instance;
+  }
+
+  static resetForTests(): void {
+    EnterpriseApiKeyService.instance = undefined;
+  }
+
+  static setInstanceForTests(service: EnterpriseApiKeyService): void {
+    EnterpriseApiKeyService.instance = service;
+  }
+
+  createApiKey(context: RequestContext, input: CreateEnterpriseApiKeyInput = {}): CreatedEnterpriseApiKey {
+    const requestedTenantId = sanitizeId(input.tenantId);
+    if (requestedTenantId && requestedTenantId !== context.tenantId) {
+      throw new Error('tenantId must match the authenticated RequestContext');
+    }
+    const requestedWorkspaceId = sanitizeId(input.workspaceId);
+    if (requestedWorkspaceId && requestedWorkspaceId !== context.workspaceId) {
+      throw new Error('workspaceId must match the authenticated RequestContext');
+    }
+    const tenantId = context.tenantId;
+    const workspaceId = input.workspaceId === null ? undefined : context.workspaceId;
+    const ownerUserId = input.ownerUserId === null
+      ? undefined
+      : this.existingUserId(tenantId, sanitizeId(input.ownerUserId) || context.userId);
+    const scopes = normalizeScopes(input.scopes);
+    const expiresAt = normalizeExpiresAt(input.expiresAt);
+    const id = `ak_${crypto.randomUUID()}`;
+    const secret = crypto.randomBytes(32).toString('base64url');
+    const createdAt = nowMs();
+
+    this.db.prepare(`
+      INSERT INTO api_keys
+        (id, tenant_id, workspace_id, owner_user_id, name, key_hash, scopes, created_at, expires_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      id,
+      tenantId,
+      workspaceId ?? null,
+      ownerUserId ?? null,
+      safeText(input.name, 'API key'),
+      hashTokenSecret(id, secret),
+      JSON.stringify(scopes),
+      createdAt,
+      expiresAt ?? null,
+    );
+
+    recordEnterpriseAuditEvent(this.db, {
+      tenantId,
+      workspaceId,
+      actorUserId: this.existingUserId(tenantId, context.userId),
+      action: 'api_key_created',
+      resourceType: 'api_key',
+      resourceId: id,
+      metadata: {
+        name: safeText(input.name, 'API key'),
+        scopes,
+        expiresAt,
+        ownerUserId,
+      },
+    });
+
+    const row = this.getRow(id);
+    if (!row) throw new Error('API key was not persisted');
+    return {
+      apiKey: rowToRecord(row),
+      token: `${ENTERPRISE_API_KEY_PREFIX}${id}.${secret}`,
+    };
+  }
+
+  listApiKeys(context: RequestContext): EnterpriseApiKeyRecord[] {
+    return this.db.prepare<unknown[], ApiKeyRow>(`
+      SELECT *
+      FROM api_keys
+      WHERE tenant_id = ?
+        AND (workspace_id IS NULL OR workspace_id = ?)
+      ORDER BY created_at DESC
+    `).all(context.tenantId, context.workspaceId).map(rowToRecord);
+  }
+
+  revokeApiKey(context: RequestContext, idInput: string): EnterpriseApiKeyRecord | null {
+    const id = sanitizeId(idInput);
+    const existing = id ? this.getRowForContext(context, id) : null;
+    if (!existing || existing.revoked_at) return null;
+    const revokedAt = nowMs();
+    this.db.prepare(`
+      UPDATE api_keys SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL
+    `).run(revokedAt, existing.id);
+
+    recordEnterpriseAuditEvent(this.db, {
+      tenantId: existing.tenant_id,
+      workspaceId: existing.workspace_id ?? undefined,
+      actorUserId: this.existingUserId(existing.tenant_id, context.userId),
+      action: 'api_key_revoked',
+      resourceType: 'api_key',
+      resourceId: existing.id,
+      metadata: {
+        ownerUserId: existing.owner_user_id,
+        scopes: parseScopes(existing.scopes),
+      },
+    });
+
+    const row = this.getRow(existing.id);
+    return row ? rowToRecord(row) : null;
+  }
+
+  resolveRequestIdentityFromRequest(req: Request): RequestApiKeyIdentity | null {
+    const parts = parseApiKeyToken(extractEnterpriseApiKeyToken(req));
+    if (!parts) return null;
+    const row = this.getRow(parts.id);
+    if (!row || row.revoked_at || (row.expires_at && row.expires_at <= nowMs())) return null;
+    const expectedHash = hashTokenSecret(parts.id, parts.secret);
+    if (!safeEquals(row.key_hash, expectedHash)) return null;
+    this.db.prepare('UPDATE api_keys SET last_used_at = ? WHERE id = ?').run(nowMs(), row.id);
+    return {
+      userId: row.owner_user_id || row.id,
+      email: '',
+      subscription: 'enterprise',
+      authType: 'api_key',
+      tenantId: row.tenant_id,
+      ...(row.workspace_id ? { workspaceId: row.workspace_id } : {}),
+      roles: ['api_key'],
+      scopes: parseScopes(row.scopes),
+    };
+  }
+
+  private getRow(id: string): ApiKeyRow | null {
+    return this.db.prepare<unknown[], ApiKeyRow>('SELECT * FROM api_keys WHERE id = ?').get(id) || null;
+  }
+
+  private getRowForContext(context: RequestContext, id: string): ApiKeyRow | null {
+    return this.db.prepare<unknown[], ApiKeyRow>(`
+      SELECT *
+      FROM api_keys
+      WHERE id = ?
+        AND tenant_id = ?
+        AND (workspace_id IS NULL OR workspace_id = ?)
+    `).get(id, context.tenantId, context.workspaceId) || null;
+  }
+
+  private existingUserId(tenantId: string, userId: string | undefined): string | undefined {
+    if (!userId) return undefined;
+    const row = this.db.prepare<unknown[], { id: string }>(
+      'SELECT id FROM users WHERE tenant_id = ? AND id = ?',
+    ).get(tenantId, userId);
+    return row?.id;
+  }
+}

--- a/backend/src/services/enterpriseAuditService.ts
+++ b/backend/src/services/enterpriseAuditService.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 Gracker (Chris)
+// This file is part of SmartPerfetto. See LICENSE for details.
+
+import crypto from 'crypto';
+import type Database from 'better-sqlite3';
+
+export interface EnterpriseAuditInput {
+  tenantId: string;
+  workspaceId?: string;
+  actorUserId?: string;
+  action: string;
+  resourceType: string;
+  resourceId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface EnterpriseAuditRow {
+  action: string;
+  resource_type: string;
+  resource_id: string | null;
+  tenant_id: string;
+  workspace_id: string | null;
+  actor_user_id: string | null;
+}
+
+export function recordEnterpriseAuditEvent(
+  db: Database.Database,
+  input: EnterpriseAuditInput,
+): void {
+  db.prepare(`
+    INSERT INTO audit_events
+      (id, tenant_id, workspace_id, actor_user_id, action, resource_type, resource_id, metadata_json, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    crypto.randomUUID(),
+    input.tenantId,
+    input.workspaceId ?? null,
+    input.actorUserId ?? null,
+    input.action,
+    input.resourceType,
+    input.resourceId ?? null,
+    input.metadata ? JSON.stringify(input.metadata) : null,
+    Date.now(),
+  );
+}
+
+export function listEnterpriseAuditEvents(db: Database.Database): EnterpriseAuditRow[] {
+  return db.prepare<unknown[], EnterpriseAuditRow>(`
+    SELECT action, resource_type, resource_id, tenant_id, workspace_id, actor_user_id
+    FROM audit_events
+    ORDER BY created_at ASC
+  `).all();
+}

--- a/backend/src/services/enterpriseSchema.ts
+++ b/backend/src/services/enterpriseSchema.ts
@@ -14,6 +14,7 @@ export const ENTERPRISE_MINIMAL_SCHEMA_TABLES = [
   'workspaces',
   'users',
   'memberships',
+  'api_keys',
   'trace_assets',
   'analysis_sessions',
   'analysis_runs',
@@ -233,6 +234,35 @@ const MIGRATIONS: MigrationStep[] = [
           ON sso_sessions(tenant_id, user_id, expires_at);
         CREATE INDEX IF NOT EXISTS idx_sso_sessions_expiry
           ON sso_sessions(expires_at, revoked_at);
+      `);
+    },
+  },
+  {
+    version: 3,
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS api_keys (
+          id TEXT PRIMARY KEY,
+          tenant_id TEXT NOT NULL,
+          workspace_id TEXT,
+          owner_user_id TEXT,
+          name TEXT NOT NULL,
+          key_hash TEXT NOT NULL UNIQUE,
+          scopes TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          expires_at INTEGER,
+          revoked_at INTEGER,
+          last_used_at INTEGER,
+          FOREIGN KEY (tenant_id) REFERENCES organizations(id) ON DELETE CASCADE,
+          FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+          FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE SET NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_api_keys_scope
+          ON api_keys(tenant_id, workspace_id, created_at);
+        CREATE INDEX IF NOT EXISTS idx_api_keys_owner
+          ON api_keys(tenant_id, owner_user_id, created_at);
+        CREATE INDEX IF NOT EXISTS idx_api_keys_expiry
+          ON api_keys(expires_at, revoked_at);
       `);
     },
   },

--- a/backend/src/services/enterpriseSsoService.ts
+++ b/backend/src/services/enterpriseSsoService.ts
@@ -7,6 +7,12 @@ import type { Request } from 'express';
 import type Database from 'better-sqlite3';
 import { resolveFeatureConfig } from '../config';
 import type { RequestContextAuthType } from '../middleware/auth';
+import {
+  listEnterpriseAuditEvents,
+  recordEnterpriseAuditEvent,
+  type EnterpriseAuditInput,
+  type EnterpriseAuditRow,
+} from './enterpriseAuditService';
 import { openEnterpriseDb } from './enterpriseDb';
 import type { EnterpriseOidcUserInfo } from './enterpriseOidcClient';
 
@@ -73,25 +79,6 @@ export interface RequestSsoIdentity {
   workspaceId: string;
   roles: string[];
   scopes: string[];
-}
-
-interface AuditInput {
-  tenantId: string;
-  workspaceId?: string;
-  actorUserId?: string;
-  action: string;
-  resourceType: string;
-  resourceId?: string;
-  metadata?: Record<string, unknown>;
-}
-
-interface AuditRow {
-  action: string;
-  resource_type: string;
-  resource_id: string | null;
-  tenant_id: string;
-  workspace_id: string | null;
-  actor_user_id: string | null;
 }
 
 function nowMs(): number {
@@ -424,12 +411,8 @@ export class EnterpriseSsoService {
     return result.changes > 0;
   }
 
-  listAuditEvents(): AuditRow[] {
-    return this.db.prepare<unknown[], AuditRow>(`
-      SELECT action, resource_type, resource_id, tenant_id, workspace_id, actor_user_id
-      FROM audit_events
-      ORDER BY created_at ASC
-    `).all();
+  listAuditEvents(): EnterpriseAuditRow[] {
+    return listEnterpriseAuditEvents(this.db);
   }
 
   private extractSessionToken(req: Request): string | undefined {
@@ -683,22 +666,8 @@ export class EnterpriseSsoService {
     });
   }
 
-  private recordAudit(input: AuditInput): void {
-    this.db.prepare(`
-      INSERT INTO audit_events
-        (id, tenant_id, workspace_id, actor_user_id, action, resource_type, resource_id, metadata_json, created_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      crypto.randomUUID(),
-      input.tenantId,
-      input.workspaceId ?? null,
-      input.actorUserId ?? null,
-      input.action,
-      input.resourceType,
-      input.resourceId ?? null,
-      input.metadata ? JSON.stringify(input.metadata) : null,
-      nowMs(),
-    );
+  private recordAudit(input: EnterpriseAuditInput): void {
+    recordEnterpriseAuditEvent(this.db, input);
   }
 }
 

--- a/docs/features/enterprise-multi-tenant/README.md
+++ b/docs/features/enterprise-multi-tenant/README.md
@@ -31,7 +31,7 @@
 ### 0.2 主线 A：身份与权限（§18）
 - [x] 2.1 `RequestContext` 接口与解析 middleware（SSO / API key / dev 三模式）
 - [x] 2.2 OIDC SSO 集成 + Onboarding flow（§15 全流程，含 audit）
-- [ ] 2.3 API key 管理（创建 / 撤销 / scope / 过期 / 审计）
+- [x] 2.3 API key 管理（创建 / 撤销 / scope / 过期 / 审计）
 - [ ] 2.4 Membership / Role / RBAC 权限矩阵（§8.2）+ owner guard 全 route 覆盖
 - [ ] 2.5 旧 API 兼容 wrapper：返回 `Deprecation: true` + `Sunset` header；统一走 RequestContext
 - [ ] 2.6 Resource-oriented API 切到 `/api/workspaces/:workspaceId/*`（§8.3）


### PR DESCRIPTION
## Summary
- add `api_keys` enterprise schema migration with scoped lookup/expiry indexes
- add managed API key service and `/api/auth/api-keys` create/list/revoke endpoints
- authenticate managed API keys via bearer or `x-api-key`, enforcing revocation, expiry, and stored scopes
- share enterprise audit helpers and record API key create/revoke audit events
- mark README §0.2.3 complete

## Scope note
- API key creation is limited to the authenticated RequestContext workspace, or tenant-wide with `workspaceId: null`.
- Full RBAC matrix and cross-workspace/org-admin policy expansion remains §0.2.4.

## Verification
- `cd backend && npx jest src/services/__tests__/enterpriseSchema.test.ts src/routes/__tests__/enterpriseApiKeyRoutes.test.ts src/services/__tests__/enterpriseOidcClient.test.ts src/routes/__tests__/enterpriseAuthRoutes.test.ts src/middleware/__tests__/auth.test.ts src/routes/__tests__/requestContextRouteCoverage.test.ts src/routes/__tests__/ownerGuardRoutes.test.ts src/services/__tests__/sessionPersistenceService.test.ts --runInBand`
- `cd backend && npm run typecheck`
- `cd backend && npm run test:scene-trace-regression`
- `npm run verify:pr`
