### PR TITLE
test(enterprise): cover auth route guards

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -41,7 +41,7 @@
     "prepack": "npm run build",
     "typecheck": "tsc --noEmit",
     "test": "jest",
-    "test:core": "jest --runInBand --forceExit src/agent/communication/__tests__/agentMessageBus.test.ts src/agent/core/executors/__tests__/strategyExecutor.test.ts src/agent/core/executors/__tests__/hypothesisExecutor.test.ts src/agent/context/__tests__/enhancedSessionContext.test.ts src/tests/adbTools.test.ts src/services/__tests__/sessionLogger.test.ts src/services/__tests__/traceAnalysisSkillConfig.test.ts src/agent/agents/domain/__tests__/registry.test.ts src/agentv3/__tests__/sqlIncludeInjector.test.ts",
+    "test:core": "jest --runInBand --forceExit src/agent/communication/__tests__/agentMessageBus.test.ts src/agent/core/executors/__tests__/strategyExecutor.test.ts src/agent/core/executors/__tests__/hypothesisExecutor.test.ts src/agent/context/__tests__/enhancedSessionContext.test.ts src/tests/adbTools.test.ts src/services/__tests__/sessionLogger.test.ts src/services/__tests__/traceAnalysisSkillConfig.test.ts src/agent/agents/domain/__tests__/registry.test.ts src/agentv3/__tests__/sqlIncludeInjector.test.ts src/middleware/__tests__/auth.test.ts src/services/__tests__/rbac.test.ts src/routes/__tests__/agentRoutesRbac.test.ts src/routes/__tests__/ownerGuardRoutes.test.ts src/routes/__tests__/requestContextRouteCoverage.test.ts src/middleware/__tests__/legacyApiCompatibility.test.ts",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:unit": "jest --testPathPatterns=src/tests",

--- a/backend/src/middleware/__tests__/legacyApiCompatibility.test.ts
+++ b/backend/src/middleware/__tests__/legacyApiCompatibility.test.ts
@@ -8,7 +8,7 @@ import {
   getLegacyApiUsageSnapshot,
   resetLegacyApiUsageTelemetryForTests,
 } from '../../services/legacyApiTelemetry';
-import { LEGACY_AGENT_API_SUNSET, markLegacyApi } from '../legacyAgentApi';
+import { LEGACY_AGENT_API_SUNSET, markLegacyApi, rejectLegacyAgentApi } from '../legacyAgentApi';
 
 describe('legacy API compatibility headers', () => {
   afterEach(() => {
@@ -42,5 +42,49 @@ describe('legacy API compatibility headers', () => {
     const telemetry = getLegacyApiUsageSnapshot();
     expect(telemetry.totalLegacyRequests).toBe(1);
     expect(telemetry.topPaths[0].key).toBe('GET /api/traces');
+  });
+
+  test('rejects removed legacy agent paths with mapped successors and telemetry', async () => {
+    const app = express();
+    app.use('/api/agent', rejectLegacyAgentApi);
+
+    const res = await request(app)
+      .post('/api/agent/llm/completions?debug=1')
+      .set('Authorization', 'Bearer legacy-token')
+      .send({ prompt: 'hello' })
+      .expect(410);
+
+    expect(res.headers.deprecation).toBe('true');
+    expect(res.headers.sunset).toBe(LEGACY_AGENT_API_SUNSET);
+    expect(res.headers.link).toBe('</api/agent/v1>; rel="successor-version"');
+    expect(res.headers.warning).toContain('Legacy agent API has been removed');
+    expect(res.body).toMatchObject({
+      success: false,
+      error: 'Legacy agent API has been removed',
+      migration: {
+        successor: '/api/agent/v1/llm/completions',
+        root: '/api/agent/v1',
+        llm: '/api/agent/v1/llm',
+      },
+    });
+
+    const telemetry = getLegacyApiUsageSnapshot();
+    expect(telemetry.totalLegacyRequests).toBe(1);
+    expect(telemetry.topPaths[0].key).toBe('POST /api/agent/llm/completions');
+    expect(telemetry.topAuthSubjects[0]?.authSubject).toMatch(/^bearer:/);
+  });
+
+  test('passes through the current /api/agent/v1 subtree when mounted at the legacy root', async () => {
+    const app = express();
+    app.use('/api/agent', rejectLegacyAgentApi);
+    app.get('/api/agent/v1/status', (_req, res) => res.json({ ok: true }));
+
+    const res = await request(app)
+      .get('/api/agent/v1/status')
+      .expect(200);
+
+    expect(res.headers.deprecation).toBeUndefined();
+    expect(res.body).toEqual({ ok: true });
+    expect(getLegacyApiUsageSnapshot().totalLegacyRequests).toBe(0);
   });
 });

--- a/backend/src/routes/__tests__/requestContextRouteCoverage.test.ts
+++ b/backend/src/routes/__tests__/requestContextRouteCoverage.test.ts
@@ -6,6 +6,8 @@ import { afterEach, describe, expect, it } from '@jest/globals';
 import express from 'express';
 import request from 'supertest';
 import { markLegacyApi } from '../../middleware/legacyAgentApi';
+import agentRoutes from '../agentRoutes';
+import providerRoutes from '../providerRoutes';
 import reportRoutes from '../reportRoutes';
 import traceRoutes from '../simpleTraceRoutes';
 
@@ -29,6 +31,22 @@ function makeApp(): express.Express {
       'Legacy report API is deprecated. Migrate to workspace-scoped report APIs',
     ),
     reportRoutes,
+  );
+  app.use(
+    '/api/agent/v1',
+    markLegacyApi(
+      '/api/workspaces/:workspaceId/agent',
+      'Legacy agent API is deprecated. Migrate to workspace-scoped agent APIs',
+    ),
+    agentRoutes,
+  );
+  app.use(
+    '/api/v1/providers',
+    markLegacyApi(
+      '/api/workspaces/:workspaceId/providers',
+      'Legacy provider API is deprecated. Migrate to workspace-scoped provider APIs',
+    ),
+    providerRoutes,
   );
   return app;
 }
@@ -75,6 +93,30 @@ describe('RequestContext route coverage', () => {
     process.env.SMARTPERFETTO_API_KEY = 'test-secret';
 
     const res = await request(makeApp()).get('/api/reports/missing-report');
+
+    expect(res.status).toBe(401);
+    expect(res.headers.deprecation).toBe('true');
+    expect(res.headers.sunset).toBeDefined();
+    expect(res.body.error).toBe('Unauthorized');
+  });
+
+  it('applies RequestContext auth middleware to legacy agent routes before analysis starts', async () => {
+    process.env.SMARTPERFETTO_API_KEY = 'test-secret';
+
+    const res = await request(makeApp())
+      .post('/api/agent/v1/analyze')
+      .send({ traceId: 'trace-a', query: 'analyze this trace' });
+
+    expect(res.status).toBe(401);
+    expect(res.headers.deprecation).toBe('true');
+    expect(res.headers.sunset).toBeDefined();
+    expect(res.body.error).toBe('Unauthorized');
+  });
+
+  it('applies RequestContext auth middleware to legacy provider routes', async () => {
+    process.env.SMARTPERFETTO_API_KEY = 'test-secret';
+
+    const res = await request(makeApp()).get('/api/v1/providers');
 
     expect(res.status).toBe(401);
     expect(res.headers.deprecation).toBe('true');

--- a/docs/features/enterprise-multi-tenant/README.md
+++ b/docs/features/enterprise-multi-tenant/README.md
@@ -36,7 +36,7 @@
 - [x] 2.5 旧 API 兼容 wrapper：返回 `Deprecation: true` + `Sunset` header；统一走 RequestContext
 - [x] 2.6 Resource-oriented API 切到 `/api/workspaces/:workspaceId/*`（§8.3）
 - [x] 2.7 前端 workspace selection UI + workspace/window 上下文持久化分层（§9.2 表格）
-- [ ] 2.8 单元测试覆盖：RequestContext 解析 / RBAC / owner guard / 旧路径包装
+- [x] 2.8 单元测试覆盖：RequestContext 解析 / RBAC / owner guard / 旧路径包装
 
 ### 0.3 主线 B：存储与持久化（§18）
 - [ ] 3.1 选 SQLite WAL 还是单 Postgres，落地 ADR；建立 repository 抽象（默认追加 tenantId/workspaceId filter）


### PR DESCRIPTION
## Summary

- close §0.2.8 by making the RequestContext/RBAC/owner-guard/legacy-wrapper coverage part of `backend` `test:core`
- add legacy agent API rejection/pass-through tests for removed `/api/agent/*` paths and mapped successors
- extend legacy route coverage so agent and provider compatibility paths still run RequestContext auth before handlers
- mark README §0.2.8 complete

## Validation

- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npx jest --runInBand --forceExit src/middleware/__tests__/auth.test.ts src/services/__tests__/rbac.test.ts src/routes/__tests__/agentRoutesRbac.test.ts src/routes/__tests__/ownerGuardRoutes.test.ts src/routes/__tests__/requestContextRouteCoverage.test.ts src/middleware/__tests__/legacyApiCompatibility.test.ts` in `backend`
- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npm run test:core` in `backend`
- `git diff --check`
- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npm run verify:pr`
