### PR TITLE
feat(enterprise): stream trace uploads to scoped storage

### DIFF
--- a/backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts
+++ b/backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts
@@ -107,6 +107,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  jest.restoreAllMocks();
   setTraceProcessorServiceForTests(null);
   restoreEnvValue(ENTERPRISE_FEATURE_FLAG_ENV, originalEnv.enterprise);
   restoreEnvValue('SMARTPERFETTO_SSO_TRUSTED_HEADERS', originalEnv.trustedHeaders);
@@ -134,6 +135,8 @@ describe('enterprise trace metadata routes', () => {
     const expectedTracePath = path.join(dataDir, 'tenant-a', 'workspace-a', 'traces', `${traceId}.trace`);
     await expect(fs.access(expectedTracePath)).resolves.toBeUndefined();
     await expect(fs.access(path.join(uploadDir, 'traces', `${traceId}.json`))).rejects.toThrow();
+    const traceDirFiles = await fs.readdir(path.dirname(expectedTracePath));
+    expect(traceDirFiles).toEqual([`${traceId}.trace`]);
 
     expect(fakeTraceProcessorService.initializeUploadWithId).toHaveBeenCalledWith(
       traceId,
@@ -165,6 +168,47 @@ describe('enterprise trace metadata routes', () => {
       'workspace-b',
     );
     expect(otherWorkspaceRes.status).toBe(404);
+  });
+
+  it('streams URL uploads into scoped trace storage without buffering the response body', async () => {
+    const app = makeApp();
+    const traceBytes = 'url-trace-content';
+    const response = new Response(traceBytes, {
+      status: 200,
+      headers: {
+        'content-length': String(Buffer.byteLength(traceBytes)),
+      },
+    });
+    const arrayBufferSpy = jest.spyOn(response, 'arrayBuffer').mockImplementation(async () => {
+      throw new Error('arrayBuffer should not be used for URL trace uploads');
+    });
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(response);
+
+    const uploadRes = await ssoHeaders(
+      request(app)
+        .post('/api/traces/upload-url')
+        .send({ url: 'https://example.test/traces/url-stream.trace' }),
+    );
+
+    expect(uploadRes.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://example.test/traces/url-stream.trace',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(arrayBufferSpy).not.toHaveBeenCalled();
+
+    const traceId = uploadRes.body.trace.id as string;
+    const expectedTracePath = path.join(dataDir, 'tenant-a', 'workspace-a', 'traces', `${traceId}.trace`);
+    await expect(fs.readFile(expectedTracePath, 'utf-8')).resolves.toBe(traceBytes);
+    const traceDirFiles = await fs.readdir(path.dirname(expectedTracePath));
+    expect(traceDirFiles).toEqual([`${traceId}.trace`]);
+
+    expect(fakeTraceProcessorService.initializeUploadWithId).toHaveBeenCalledWith(
+      traceId,
+      'url-stream.trace',
+      Buffer.byteLength(traceBytes),
+      expectedTracePath,
+    );
   });
 
   it('deletes enterprise trace files and trace_assets metadata through the scoped owner path', async () => {

--- a/backend/src/routes/simpleTraceRoutes.ts
+++ b/backend/src/routes/simpleTraceRoutes.ts
@@ -5,8 +5,12 @@
 import { Router, type NextFunction, type Request, type Response } from 'express';
 import multer from 'multer';
 import path from 'path';
+import { createWriteStream } from 'fs';
 import fs from 'fs/promises';
 import net from 'net';
+import os from 'os';
+import { Readable, Transform } from 'stream';
+import { pipeline } from 'stream/promises';
 import { v4 as uuidv4 } from 'uuid';
 import { attachRequestContext, requireRequestContext, type RequestContext } from '../middleware/auth';
 import { getTraceProcessorService } from '../services/traceProcessorService';
@@ -33,8 +37,33 @@ import {
 } from '../services/rbac';
 
 const router = Router();
-const MAX_UPLOAD_BYTES = 500 * 1024 * 1024;
+const DEFAULT_UPLOAD_BYTES = 500 * 1024 * 1024;
+const STREAMED_UPLOAD_BYTES_CAP = 1024 * 1024 * 1024;
+export const TRACE_UPLOAD_MAX_BYTES_ENV = 'SMARTPERFETTO_TRACE_UPLOAD_MAX_BYTES';
 const URL_UPLOAD_TIMEOUT_MS = 300000;
+const TEMP_UPLOAD_SUFFIX = '.uploading';
+
+class TraceUploadTooLargeError extends Error {
+  constructor(readonly maxBytes: number) {
+    super(`Trace file too large. Maximum allowed size is ${maxBytes} bytes`);
+    this.name = 'TraceUploadTooLargeError';
+  }
+}
+
+function parsePositiveInteger(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function resolveTraceUploadLimitBytes(env: NodeJS.ProcessEnv = process.env): number {
+  const configured = parsePositiveInteger(env[TRACE_UPLOAD_MAX_BYTES_ENV]);
+  if (configured) {
+    return Math.min(configured, STREAMED_UPLOAD_BYTES_CAP);
+  }
+  const ramBudget = Math.floor(os.totalmem() * 0.1);
+  return Math.max(DEFAULT_UPLOAD_BYTES, Math.min(STREAMED_UPLOAD_BYTES_CAP, ramBudget));
+}
 
 function requireTracePermission(permission: 'trace:read' | 'trace:write', details: string) {
   return (req: Request, res: Response, next: NextFunction): void => {
@@ -115,6 +144,66 @@ function isBlockedTraceUrl(url: URL): boolean {
   return false;
 }
 
+function tempUploadFilename(): string {
+  return `${uuidv4()}${TEMP_UPLOAD_SUFFIX}`;
+}
+
+async function cleanupFile(filePath: string | undefined): Promise<void> {
+  if (!filePath) return;
+  try {
+    await fs.unlink(filePath);
+  } catch {
+    // Best-effort cleanup only.
+  }
+}
+
+async function renameTraceAtomically(tempPath: string, finalPath: string): Promise<void> {
+  await fs.rename(tempPath, finalPath);
+}
+
+function createUploadSizeLimitStream(maxBytes: number): { stream: Transform; getBytesWritten: () => number } {
+  let bytesWritten = 0;
+  const stream = new Transform({
+    transform(chunk, _encoding, callback) {
+      const bytes = Buffer.isBuffer(chunk)
+        ? chunk.length
+        : chunk instanceof Uint8Array
+          ? chunk.byteLength
+          : Buffer.byteLength(String(chunk));
+      bytesWritten += bytes;
+      if (bytesWritten > maxBytes) {
+        callback(new TraceUploadTooLargeError(maxBytes));
+        return;
+      }
+      callback(null, chunk);
+    },
+  });
+
+  return {
+    stream,
+    getBytesWritten: () => bytesWritten,
+  };
+}
+
+async function streamResponseBodyToTempFile(response: globalThis.Response, tempPath: string): Promise<number> {
+  if (!response.body) {
+    throw new Error('Trace URL response body is empty');
+  }
+
+  const limiter = createUploadSizeLimitStream(resolveTraceUploadLimitBytes());
+  try {
+    await pipeline(
+      Readable.fromWeb(response.body as any),
+      limiter.stream,
+      createWriteStream(tempPath, { flags: 'wx' }),
+    );
+    return limiter.getBytesWritten();
+  } catch (error) {
+    await cleanupFile(tempPath);
+    throw error;
+  }
+}
+
 // GET /api/traces/health - Health check for auto-upload feature
 // This endpoint allows the frontend to quickly check if the backend is available
 router.get('/health', (req, res) => {
@@ -130,18 +219,27 @@ router.use(attachRequestContext);
 // Configure multer for file uploads
 const storage = multer.diskStorage({
   destination: (req, file, cb) => {
-    cb(null, process.env.UPLOAD_DIR || './uploads');
+    let tracesDir: string;
+    try {
+      tracesDir = getWritableTraceDirForContext(requireRequestContext(req));
+    } catch (error) {
+      cb(error as Error, process.env.UPLOAD_DIR || './uploads');
+      return;
+    }
+
+    fs.mkdir(tracesDir, { recursive: true })
+      .then(() => cb(null, tracesDir))
+      .catch((error) => cb(error, tracesDir));
   },
   filename: (req, file, cb) => {
-    // Keep the original filename
-    cb(null, file.originalname);
+    cb(null, tempUploadFilename());
   },
 });
 
 const upload = multer({
   storage,
   limits: {
-    fileSize: MAX_UPLOAD_BYTES, // 500MB
+    fileSize: resolveTraceUploadLimitBytes(),
   },
 });
 
@@ -161,16 +259,13 @@ router.post(
 
       const file = req.file;
 
-      // Store trace info (in a real app, this would go to a database)
-      const tracesDir = getWritableTraceDirForContext(context);
-      await fs.mkdir(tracesDir, { recursive: true });
-
       // Generate trace ID upfront for consistency
       const traceId = uuidv4();
 
       // Move file to traces directory with proper name
+      const tracesDir = path.dirname(file.path);
       const finalPath = path.join(tracesDir, `${traceId}.trace`);
-      await fs.rename(file.path, finalPath);
+      await renameTraceAtomically(file.path, finalPath);
 
       console.log(`File uploaded successfully: ${file.originalname} -> ${traceId}`);
 
@@ -192,6 +287,7 @@ router.post(
       });
 
     } catch (error: any) {
+      await cleanupFile(req.file?.path);
       console.error('Upload error:', error);
       res.status(500).json({
         error: 'Upload failed',
@@ -243,18 +339,11 @@ router.post('/upload-url', async (req, res) => {
     }
 
     const contentLength = response.headers.get('content-length');
-    if (contentLength && Number.parseInt(contentLength, 10) > MAX_UPLOAD_BYTES) {
+    const uploadLimitBytes = resolveTraceUploadLimitBytes();
+    if (contentLength && Number.parseInt(contentLength, 10) > uploadLimitBytes) {
       return res.status(413).json({
         error: 'Trace file too large',
-        details: `Remote trace exceeds ${MAX_UPLOAD_BYTES} bytes`
-      });
-    }
-
-    const buffer = Buffer.from(await response.arrayBuffer());
-    if (buffer.byteLength > MAX_UPLOAD_BYTES) {
-      return res.status(413).json({
-        error: 'Trace file too large',
-        details: `Remote trace exceeds ${MAX_UPLOAD_BYTES} bytes`
+        details: `Remote trace exceeds ${uploadLimitBytes} bytes`
       });
     }
 
@@ -262,19 +351,27 @@ router.post('/upload-url', async (req, res) => {
     await fs.mkdir(tracesDir, { recursive: true });
 
     const traceId = uuidv4();
+    const tempPath = path.join(tracesDir, tempUploadFilename());
     const finalPath = path.join(tracesDir, `${traceId}.trace`);
-    await fs.writeFile(finalPath, buffer);
+    let size = 0;
+    try {
+      size = await streamResponseBodyToTempFile(response, tempPath);
+      await renameTraceAtomically(tempPath, finalPath);
+    } catch (streamError) {
+      await cleanupFile(tempPath);
+      throw streamError;
+    }
 
     console.log(`URL trace fetched successfully: ${rawUrl} -> ${traceId}`);
 
-    const traceInfo = await finalizeTraceUpload(traceId, filename, buffer.byteLength, finalPath, context);
+    const traceInfo = await finalizeTraceUpload(traceId, filename, size, finalPath, context);
 
     res.json({
       success: true,
       trace: {
         id: traceId,
         filename,
-        size: buffer.byteLength,
+        size,
         uploadedAt: traceInfo?.uploadTime || new Date().toISOString(),
         status: traceInfo?.status || 'ready',
         port: traceInfo?.port,
@@ -283,6 +380,12 @@ router.post('/upload-url', async (req, res) => {
     });
 
   } catch (error: any) {
+    if (error instanceof TraceUploadTooLargeError) {
+      return res.status(413).json({
+        error: 'Trace file too large',
+        details: `Remote trace exceeds ${error.maxBytes} bytes`,
+      });
+    }
     console.error('URL upload error:', error);
     res.status(500).json({
       error: 'URL upload failed',

--- a/docs/features/enterprise-multi-tenant/README.md
+++ b/docs/features/enterprise-multi-tenant/README.md
@@ -58,7 +58,7 @@
   - [x] 4.1.4 LRU 跳过 ExternalRpcProcessor 或改为 lease/ref-count 判定
   - [x] 4.1.5 pending trace localStorage key 加 `windowId`，必要时迁 sessionStorage
   - [x] 4.1.6 AI session cache 加 mtime/CAS 或改为后端权威 session list
-- [ ] 4.2 上传链路 stream 化（§11.1）：URL 上传不再 `arrayBuffer()` 全量进内存；本地上传与 RAM/磁盘策略联动；temp file 用 traceId/uuid + 原子 rename
+- [x] 4.2 上传链路 stream 化（§11.1）：URL 上传不再 `arrayBuffer()` 全量进内存；本地上传与 RAM/磁盘策略联动；temp file 用 traceId/uuid + 原子 rename
 - [ ] 4.3 RSS benchmark：scroll/startup/ANR/memory/heapprofd/vendor 大 trace × 100MB/500MB/1GB，记录启动 RSS、load peak、query headroom
 - [ ] 4.4 `TraceProcessorLease` 4 类 holder（frontend_http_rpc / agent_run / report_generation / manual_register）+ 状态机（§11.4）+ 分级 TTL
 - [ ] 4.5 Backend proxy `/api/tp/:leaseId/{status,websocket,query}`（§11.3）
@@ -486,6 +486,11 @@ audit_events(id, tenant_id, actor_user_id, action, resource_type, resource_id, m
    - URL 上传不能 `arrayBuffer()` 全量进内存。
    - 本地上传从固定 500MB 上限改为与机器 RAM budget 和磁盘策略相关。
    - 大 trace 必须先流式落盘，再交给 trace_processor。
+   - 当前实现：`/api/traces/upload-url` 通过 `Readable.fromWeb(...)` + `pipeline`
+     流式写入同目录 uuid `.uploading` 临时文件，超过
+     `SMARTPERFETTO_TRACE_UPLOAD_MAX_BYTES` / RAM 派生上限时直接 413。
+     本地 multipart 上传也写入 scoped trace 目录下的 uuid 临时文件，再原子
+     rename 为 `{traceId}.trace`，避免同名 trace 的临时文件互相覆盖。
 2. RSS benchmark。
    - admission control 可以先用 `trace_file_size × 系数` 粗估。
    - 实际资源占用必须以启动后 child RSS、load peak、query headroom 修正。


### PR DESCRIPTION
## Summary
- Stream /api/traces/upload-url response bodies directly to uuid .uploading files via pipeline instead of arrayBuffer().
- Store multipart temp files in the scoped trace directory with uuid names, then rename to {traceId}.trace to avoid original-filename collisions.
- Add upload limit resolution from SMARTPERFETTO_TRACE_UPLOAD_MAX_BYTES / RAM-derived budget with a 1 GiB cap, and mark README §0.4.2 complete.

## Verification
- cd backend && npx jest --runInBand --forceExit src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts
- cd backend && npm run typecheck
- cd backend && npx jest --runInBand --forceExit src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts src/routes/__tests__/ownerGuardRoutes.test.ts src/routes/__tests__/workspaceResourceRoutes.test.ts
- git diff --check
- cd backend && npm run test:scene-trace-regression
- cd backend && npx jest --runInBand --forceExit src/agentv3/__tests__/analysisPatternMemory.test.ts
- cd backend && npm run test:core
- npm run verify:pr

Note: the first test:core run hit an existing order-sensitive analysisPatternMemory assertion; rerunning that suite and test:core passed before verify:pr, and verify:pr passed end-to-end.

Stacked on #82 / feature/enterprise-multi-tenant-restart-persistence-tests.