### PR TITLE
fix(startup): handle nvm without NVM_DIR

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format:check": "biome check --formatter-enabled=true --linter-enabled=false --assist-enabled=false package.json backend/package.json biome.json knip.json",
     "deadcode": "knip --dependencies --max-show-issues 50 --no-config-hints",
     "shellcheck": "shellcheck -x start.sh scripts/*.sh",
+    "test:node-env": "bash scripts/test-node-env.sh",
     "rust:fmt": "cargo fmt --manifest-path rust/flamegraph-analyzer/Cargo.toml -- --check",
     "rust:check": "cargo check --manifest-path rust/flamegraph-analyzer/Cargo.toml",
     "rust:test": "cargo test --manifest-path rust/flamegraph-analyzer/Cargo.toml",

--- a/scripts/node-env.sh
+++ b/scripts/node-env.sh
@@ -43,6 +43,8 @@ smartperfetto_load_nvm() {
     return 1
   fi
 
+  export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+
   # shellcheck source=/dev/null
   . "$nvm_sh"
   command -v nvm >/dev/null 2>&1
@@ -103,6 +105,15 @@ smartperfetto_ensure_node() {
   echo ""
   echo "Install and use Node.js $SMARTPERFETTO_NODE_MAJOR, then rerun:"
   echo "  nvm install $node_spec && nvm use $node_spec"
+  echo ""
+  echo "If nvm is installed but not initialized, initialize one of these paths first:"
+  echo "  export NVM_DIR=\"\$HOME/.nvm\""
+  echo "  [ -s \"\$NVM_DIR/nvm.sh\" ] && . \"\$NVM_DIR/nvm.sh\""
+  echo '  [ -s "/opt/homebrew/opt/nvm/nvm.sh" ] && . "/opt/homebrew/opt/nvm/nvm.sh"'
+  echo '  [ -s "/usr/local/opt/nvm/nvm.sh" ] && . "/usr/local/opt/nvm/nvm.sh"'
+  echo ""
+  echo "One-shot workaround:"
+  echo "  NVM_DIR=\"\$HOME/.nvm\" ./start.sh"
   echo ""
   echo "The repo includes .nvmrc/.node-version so most shells can auto-select it."
   return 1

--- a/scripts/test-node-env.sh
+++ b/scripts/test-node-env.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2024-2026 Gracker (Chris)
+# This file is part of SmartPerfetto. See LICENSE for details.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_HOME="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_HOME"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_HOME/.nvm"
+cat > "$TMP_HOME/.nvm/nvm.sh" <<'NVM'
+[ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"
+nvm() {
+  return 0
+}
+NVM
+
+# shellcheck disable=SC2016
+HOME="$TMP_HOME" env -u NVM_DIR bash -u -c '
+  . "$1/scripts/node-env.sh"
+  smartperfetto_load_nvm
+  test "${NVM_DIR:-}" = "$HOME/.nvm"
+' bash "$PROJECT_ROOT"
+
+echo "node-env tests passed"


### PR DESCRIPTION
## Summary

- Default `NVM_DIR` before sourcing `nvm.sh` so startup scripts work under `bash -u`.
- Expand Node activation failure guidance for standard nvm and Homebrew nvm paths.
- Add a shell regression test for unset `NVM_DIR` startup behavior.

## Verification

- `npm run test:node-env`
- `npm run shellcheck`
- `bash -n scripts/node-env.sh scripts/test-node-env.sh start.sh scripts/start-dev.sh scripts/restart-backend.sh`