### PR TITLE
feat(enterprise): add trace processor lease supervisor

### DIFF
--- a/backend/src/routes/__tests__/traceProcessorProxyRoutes.test.ts
+++ b/backend/src/routes/__tests__/traceProcessorProxyRoutes.test.ts
@@ -249,7 +249,16 @@ describe('trace processor lease proxy routes', () => {
     expect(queryRawMock).toHaveBeenCalledWith(
       'trace-a',
       queryBody,
-      { priority: 'p0', leaseId: lease.id, leaseMode: 'shared' },
+      {
+        priority: 'p0',
+        leaseId: lease.id,
+        leaseMode: 'shared',
+        leaseScope: {
+          tenantId: 'tenant-a',
+          workspaceId: 'workspace-a',
+          userId: 'user-a',
+        },
+      },
     );
   });
 

--- a/backend/src/routes/agentRoutes.ts
+++ b/backend/src/routes/agentRoutes.ts
@@ -1035,7 +1035,7 @@ async function handleAnalyzeRequest(
           { mode: agentRunLeaseDecision.mode },
         );
         agentRunLease = markLeaseReadyIfNew(agentRunLease, scope);
-        await traceProcessorService.ensureProcessorForLease(traceId, agentRunLease.id, agentRunLease.mode);
+        await traceProcessorService.ensureProcessorForLease(traceId, agentRunLease.id, agentRunLease.mode, scope);
       } catch (leaseError: any) {
         if (agentRunLease) {
           try {
@@ -1073,7 +1073,12 @@ async function handleAnalyzeRequest(
       traceContext: traceContext && traceContext.length > 0 ? traceContext : undefined,
       providerId: sessionForRun.providerId !== undefined ? sessionForRun.providerId : providerId,
       traceProcessorLease: agentRunLease
-        ? { traceId, leaseId: agentRunLease.id, mode: agentRunLease.mode }
+        ? {
+          traceId,
+          leaseId: agentRunLease.id,
+          mode: agentRunLease.mode,
+          leaseScope: leaseScopeFromRequestContext(requestContext),
+        }
         : undefined,
     }).catch((error) => {
       const session = assistantAppService.getSession(sessionId);

--- a/backend/src/routes/traceProcessorProxyRoutes.ts
+++ b/backend/src/routes/traceProcessorProxyRoutes.ts
@@ -27,6 +27,7 @@ import { normalizeTraceProcessorQueryPriority } from '../services/traceProcessor
 import { hasRbacPermission, sendForbidden } from '../services/rbac';
 import { EnterpriseSsoService } from '../services/enterpriseSsoService';
 import { EnterpriseApiKeyService } from '../services/enterpriseApiKeyService';
+import type { EnterpriseRepositoryScope } from '../services/enterpriseRepository';
 
 const router = Router();
 const READY_STATES = new Set<TraceProcessorLeaseState>(['ready', 'idle', 'active']);
@@ -62,6 +63,7 @@ interface RequestIdentity {
 interface ProxyTarget {
   lease: TraceProcessorLeaseRecord;
   port: number;
+  scope: EnterpriseRepositoryScope;
 }
 
 function sanitizeContextId(value: unknown): string {
@@ -266,7 +268,7 @@ async function resolveProxyTargetForContext(
     throw new TraceProcessorProxyError(404, 'Trace not found for trace processor lease');
   }
 
-  await traceProcessorService.ensureProcessorForLease(lease.traceId, lease.id, lease.mode);
+  await traceProcessorService.ensureProcessorForLease(lease.traceId, lease.id, lease.mode, scope);
   const traceWithPort = traceProcessorService.getTraceWithLeasePort(lease.traceId, lease.id, lease.mode);
   if (!traceWithPort?.port) {
     throw new TraceProcessorProxyError(503, 'Trace processor HTTP RPC port is not ready');
@@ -275,6 +277,7 @@ async function resolveProxyTargetForContext(
   return {
     lease,
     port: traceWithPort.port,
+    scope,
   };
 }
 
@@ -351,6 +354,7 @@ async function forwardQueryRpc(req: Request, res: Response): Promise<void> {
     priority,
     leaseId: target.lease.id,
     leaseMode: target.lease.mode,
+    leaseScope: target.scope,
   });
   res.setHeader('content-type', 'application/x-protobuf');
   res.status(200).send(responseBody);

--- a/backend/src/services/__tests__/traceProcessorLeaseProcessorRouting.test.ts
+++ b/backend/src/services/__tests__/traceProcessorLeaseProcessorRouting.test.ts
@@ -5,7 +5,14 @@
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
+import Database from 'better-sqlite3';
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { applyEnterpriseMinimalSchema } from '../enterpriseSchema';
+import type { EnterpriseRepositoryScope } from '../enterpriseRepository';
+import {
+  setTraceProcessorLeaseStoreForTests,
+  TraceProcessorLeaseStore,
+} from '../traceProcessorLeaseStore';
 import {
   TraceProcessorFactory,
   type QueryResult,
@@ -39,6 +46,7 @@ describe('TraceProcessorService lease processor routing', () => {
   afterEach(() => {
     jest.restoreAllMocks();
     TraceProcessorFactory.cleanup();
+    setTraceProcessorLeaseStoreForTests(null);
   });
 
   it('routes shared work by traceId and isolated work by lease processor key', async () => {
@@ -90,6 +98,176 @@ describe('TraceProcessorService lease processor routing', () => {
       expect(shared.query).toHaveBeenCalledWith('SELECT shared', {});
       expect(isolated.query).toHaveBeenCalledWith('SELECT isolated', {});
       expect(isolated.queryRaw).toHaveBeenCalledWith(Buffer.from('raw'), {});
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+const scope: EnterpriseRepositoryScope = {
+  tenantId: 'tenant-a',
+  workspaceId: 'workspace-a',
+  userId: 'user-a',
+};
+
+function seedEnterpriseGraph(db: Database.Database, traceId: string): void {
+  const now = 1_700_000_000_000;
+  db.prepare(`
+    INSERT INTO organizations (id, name, status, plan, created_at, updated_at)
+    VALUES ('tenant-a', 'Tenant A', 'active', 'enterprise', ?, ?)
+  `).run(now, now);
+  db.prepare(`
+    INSERT INTO workspaces (id, tenant_id, name, created_at, updated_at)
+    VALUES ('workspace-a', 'tenant-a', 'Workspace A', ?, ?)
+  `).run(now, now);
+  db.prepare(`
+    INSERT INTO trace_assets
+      (id, tenant_id, workspace_id, local_path, status, created_at)
+    VALUES
+      (?, 'tenant-a', 'workspace-a', ?, 'ready', ?)
+  `).run(traceId, `/tmp/${traceId}.pftrace`, now);
+}
+
+function createActiveLease(store: TraceProcessorLeaseStore, traceId: string): string {
+  let lease = store.acquireHolder(scope, traceId, {
+    holderType: 'agent_run',
+    holderRef: 'run-a',
+    runId: 'run-a',
+  }, { mode: 'isolated', now: 1000 });
+  store.markStarting(scope, lease.id);
+  lease = store.markReady(scope, lease.id);
+  return lease.id;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('TraceProcessorService lease restart supervisor', () => {
+  let db: Database.Database | null = null;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    TraceProcessorFactory.cleanup();
+    setTraceProcessorLeaseStoreForTests(null);
+    db?.close();
+    db = null;
+  });
+
+  it('uses one supervisor restart for concurrent crashed lease holders and preserves the lease id', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'smartperfetto-lease-restart-'));
+    try {
+      const traceId = 'trace-restart';
+      const tracePath = path.join(tmpDir, `${traceId}.trace`);
+      await fs.writeFile(tracePath, 'trace bytes');
+
+      db = new Database(':memory:');
+      applyEnterpriseMinimalSchema(db);
+      seedEnterpriseGraph(db, traceId);
+      const store = new TraceProcessorLeaseStore(db);
+      setTraceProcessorLeaseStoreForTests(store);
+      const leaseId = createActiveLease(store, traceId);
+
+      const service = new TraceProcessorService(tmpDir, {
+        backoffMs: [1000, 5000, 15000],
+        jitterMs: 0,
+        sleep: async () => undefined,
+      });
+      await service.initializeUploadWithId(traceId, 'trace-restart.trace', 11, tracePath);
+
+      const dead = fakeProcessor('dead-processor', traceId);
+      dead.status = 'error';
+      (service as any).processors.set(`${traceId}:lease:${leaseId}`, dead);
+
+      const restarted = fakeProcessor('restarted-processor', traceId);
+      const gate = deferred<TraceProcessor>();
+      const createSpy = jest
+        .spyOn(TraceProcessorFactory, 'create')
+        .mockImplementation(async () => gate.promise as Promise<any>);
+
+      const queryA = service.query(traceId, 'SELECT a', {
+        leaseId,
+        leaseMode: 'isolated',
+        leaseScope: scope,
+      });
+      const queryB = service.query(traceId, 'SELECT b', {
+        leaseId,
+        leaseMode: 'isolated',
+        leaseScope: scope,
+      });
+
+      await Promise.resolve();
+      gate.resolve(restarted);
+
+      await expect(queryA).resolves.toMatchObject({ rows: [['restarted-processor']] });
+      await expect(queryB).resolves.toMatchObject({ rows: [['restarted-processor']] });
+
+      expect(createSpy).toHaveBeenCalledTimes(1);
+      expect(createSpy).toHaveBeenCalledWith(traceId, tracePath, expect.objectContaining({
+        processorKey: `${traceId}:lease:${leaseId}`,
+        leaseId,
+        leaseMode: 'isolated',
+      }));
+      expect(dead.destroy).toHaveBeenCalledTimes(1);
+      expect(store.getLeaseById(scope, leaseId)).toMatchObject({
+        id: leaseId,
+        state: 'active',
+      });
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('marks the lease failed after the 1s/5s/15s backoff restart attempts all fail', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'smartperfetto-lease-restart-fail-'));
+    try {
+      const traceId = 'trace-restart-fail';
+      const tracePath = path.join(tmpDir, `${traceId}.trace`);
+      await fs.writeFile(tracePath, 'trace bytes');
+
+      db = new Database(':memory:');
+      applyEnterpriseMinimalSchema(db);
+      seedEnterpriseGraph(db, traceId);
+      const store = new TraceProcessorLeaseStore(db);
+      setTraceProcessorLeaseStoreForTests(store);
+      const leaseId = createActiveLease(store, traceId);
+
+      const observedBackoff: number[] = [];
+      const service = new TraceProcessorService(tmpDir, {
+        backoffMs: [1000, 5000, 15000],
+        jitterMs: 0,
+        sleep: async delayMs => {
+          observedBackoff.push(delayMs);
+        },
+      });
+      await service.initializeUploadWithId(traceId, 'trace-restart-fail.trace', 11, tracePath);
+
+      const dead = fakeProcessor('dead-processor', traceId);
+      dead.status = 'error';
+      (service as any).processors.set(`${traceId}:lease:${leaseId}`, dead);
+
+      const createSpy = jest
+        .spyOn(TraceProcessorFactory, 'create')
+        .mockRejectedValue(new Error('spawn failed') as never);
+
+      await expect(service.query(traceId, 'SELECT a', {
+        leaseId,
+        leaseMode: 'isolated',
+        leaseScope: scope,
+      })).rejects.toThrow('spawn failed');
+
+      expect(createSpy).toHaveBeenCalledTimes(3);
+      expect(observedBackoff).toEqual([1000, 5000, 15000]);
+      expect(store.getLeaseById(scope, leaseId)).toMatchObject({
+        id: leaseId,
+        state: 'failed',
+      });
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }

--- a/backend/src/services/traceProcessorLeaseStore.ts
+++ b/backend/src/services/traceProcessorLeaseStore.ts
@@ -634,5 +634,5 @@ export function getTraceProcessorLeaseStore(): TraceProcessorLeaseStore {
 
 export function setTraceProcessorLeaseStoreForTests(store: TraceProcessorLeaseStore | null): void {
   singleton = store;
-  singletonDbPath = null;
+  singletonDbPath = store ? resolveEnterpriseDbPath() : null;
 }

--- a/backend/src/services/traceProcessorService.ts
+++ b/backend/src/services/traceProcessorService.ts
@@ -9,7 +9,12 @@ import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { WorkingTraceProcessor, TraceProcessorFactory } from './workingTraceProcessor';
 import type { TraceProcessorQueryOptions } from './traceProcessorSqlWorker';
-import type { TraceProcessorLeaseMode } from './traceProcessorLeaseStore';
+import {
+  getTraceProcessorLeaseStore,
+  type TraceProcessorLeaseMode,
+  type TraceProcessorLeaseState,
+} from './traceProcessorLeaseStore';
+import type { EnterpriseRepositoryScope } from './enterpriseRepository';
 
 export interface TraceInfo {
   id: string;
@@ -51,12 +56,25 @@ export interface TraceProcessorLeaseQueryContext {
   traceId: string;
   leaseId: string;
   mode: TraceProcessorLeaseMode | string;
+  leaseScope?: EnterpriseRepositoryScope;
 }
 
 export type TraceProcessorServiceQueryOptions = TraceProcessorQueryOptions & {
   leaseId?: string;
   leaseMode?: TraceProcessorLeaseMode | string;
+  leaseScope?: EnterpriseRepositoryScope;
 };
+
+export interface TraceProcessorLeaseRestartPolicy {
+  backoffMs?: number[];
+  jitterMs?: number;
+  sleep?: (delayMs: number) => Promise<void>;
+  random?: () => number;
+}
+
+const DEFAULT_LEASE_RESTART_BACKOFF_MS = [1000, 5000, 15000];
+const DEFAULT_LEASE_RESTART_JITTER_MS = 250;
+const LEASE_RESTART_CONFLICT_STATES = new Set<TraceProcessorLeaseState>(['draining', 'released', 'failed']);
 
 /**
  * Manages trace files and processors using the actual Perfetto Trace Processor WASM
@@ -68,9 +86,14 @@ export class TraceProcessorService extends EventEmitter {
   private uploadDir: string;
   /** Guards against concurrent auto-recovery for the same trace. */
   private recoveryInProgress: Map<string, Promise<TraceProcessor>> = new Map();
+  /** Single lease supervisor per processor key; holders wait instead of retrying. */
+  private leaseRestartInProgress: Map<string, Promise<TraceProcessor>> = new Map();
   private readonly queryLeaseContext = new AsyncLocalStorage<TraceProcessorLeaseQueryContext>();
 
-  constructor(uploadDir = './uploads/traces') {
+  constructor(
+    uploadDir = './uploads/traces',
+    private readonly leaseRestartPolicy: TraceProcessorLeaseRestartPolicy = {},
+  ) {
     super();
     this.uploadDir = path.resolve(uploadDir);
     this.ensureUploadDir();
@@ -107,6 +130,7 @@ export class TraceProcessorService extends EventEmitter {
         traceId,
         leaseId: options.leaseId,
         mode: options.leaseMode ?? 'shared',
+        ...(options.leaseScope ? { leaseScope: options.leaseScope } : {}),
       };
     }
     const stored = this.queryLeaseContext.getStore();
@@ -318,7 +342,12 @@ export class TraceProcessorService extends EventEmitter {
     const processorKey = this.processorKeyForLease(traceId, leaseContext?.leaseId, leaseContext?.mode);
     let processor = this.processors.get(processorKey);
     if (!processor && leaseContext) {
-      processor = await this.ensureProcessorForLease(traceId, leaseContext.leaseId, leaseContext.mode);
+      processor = await this.ensureProcessorForLease(
+        traceId,
+        leaseContext.leaseId,
+        leaseContext.mode,
+        leaseContext.leaseScope,
+      );
     }
     if (!processor) {
       throw new Error(`No processor for trace ${traceId}`);
@@ -329,6 +358,14 @@ export class TraceProcessorService extends EventEmitter {
 
     // Auto-recover dead processor
     if (processor.status === 'error') {
+      if (leaseContext?.leaseId) {
+        try {
+          processor = await this.restartLeaseProcessor(traceId, leaseContext);
+        } catch (err: any) {
+          throw new Error(`HTTP server not ready (auto-recovery failed: ${err.message})`);
+        }
+        return processor;
+      }
       // Serialize concurrent recovery attempts for the same trace
       let recovery = this.recoveryInProgress.get(processorKey);
       if (!recovery) {
@@ -366,7 +403,7 @@ export class TraceProcessorService extends EventEmitter {
     options: TraceProcessorServiceQueryOptions = {},
   ): Promise<QueryResult> {
     const processor = await this.processorForQuery(traceId, options);
-    const { leaseId: _leaseId, leaseMode: _leaseMode, ...queryOptions } = options;
+    const { leaseId: _leaseId, leaseMode: _leaseMode, leaseScope: _leaseScope, ...queryOptions } = options;
     return await processor.query(sql, queryOptions);
   }
 
@@ -376,7 +413,7 @@ export class TraceProcessorService extends EventEmitter {
     options: TraceProcessorServiceQueryOptions = {},
   ): Promise<Buffer> {
     const processor = await this.processorForQuery(traceId, options);
-    const { leaseId: _leaseId, leaseMode: _leaseMode, ...queryOptions } = options;
+    const { leaseId: _leaseId, leaseMode: _leaseMode, leaseScope: _leaseScope, ...queryOptions } = options;
     return await processor.queryRaw(body, queryOptions);
   }
 
@@ -570,12 +607,21 @@ export class TraceProcessorService extends EventEmitter {
     traceId: string,
     leaseId: string,
     mode: TraceProcessorLeaseMode | string,
+    leaseScope?: EnterpriseRepositoryScope,
   ): Promise<TraceProcessor> {
     const key = this.processorKeyForLease(traceId, leaseId, mode);
     const existing = this.processors.get(key);
     if (existing && existing.status === 'ready') {
       this.touchTrace(traceId);
       return existing;
+    }
+    if (existing && existing.status === 'error') {
+      return this.restartLeaseProcessor(traceId, {
+        traceId,
+        leaseId,
+        mode,
+        ...(leaseScope ? { leaseScope } : {}),
+      });
     }
 
     const trace = this.traces.get(traceId);
@@ -589,6 +635,131 @@ export class TraceProcessorService extends EventEmitter {
     }
 
     return this.createProcessor(traceId, { leaseId, mode });
+  }
+
+  private async restartLeaseProcessor(
+    traceId: string,
+    leaseContext: TraceProcessorLeaseQueryContext,
+  ): Promise<TraceProcessor> {
+    const processorKey = this.processorKeyForLease(traceId, leaseContext.leaseId, leaseContext.mode);
+    const inProgress = this.leaseRestartInProgress.get(processorKey);
+    if (inProgress) {
+      console.log(`[TraceProcessorService] Waiting for lease supervisor restart of ${processorKey}`);
+      return inProgress;
+    }
+
+    const restart = this.runLeaseRestartSupervisor(traceId, leaseContext, processorKey)
+      .finally(() => {
+        this.leaseRestartInProgress.delete(processorKey);
+      });
+    this.leaseRestartInProgress.set(processorKey, restart);
+    return restart;
+  }
+
+  private async runLeaseRestartSupervisor(
+    traceId: string,
+    leaseContext: TraceProcessorLeaseQueryContext,
+    processorKey: string,
+  ): Promise<TraceProcessor> {
+    const backoffMs = this.leaseRestartPolicy.backoffMs ?? DEFAULT_LEASE_RESTART_BACKOFF_MS;
+    const attempts = Math.max(1, backoffMs.length);
+    let lastError: unknown;
+
+    console.warn(`[TraceProcessorService] Lease processor crashed; supervisor restarting ${processorKey}`);
+    this.markLeaseCrashedForRestart(leaseContext);
+
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      const delayMs = this.restartBackoffDelayMs(backoffMs, attempt);
+      if (delayMs > 0) {
+        await this.restartSleep(delayMs);
+      }
+
+      this.markLeaseRestarting(leaseContext);
+      this.destroyProcessorForRestart(processorKey);
+
+      try {
+        const processor = await this.createProcessor(traceId, leaseContext);
+        this.markLeaseReadyAfterRestart(leaseContext);
+        console.log(
+          `[TraceProcessorService] Lease processor restart succeeded for ${processorKey} ` +
+          `(attempt ${attempt + 1}/${attempts})`,
+        );
+        return processor;
+      } catch (error: any) {
+        lastError = error;
+        console.warn(
+          `[TraceProcessorService] Lease processor restart failed for ${processorKey} ` +
+          `(attempt ${attempt + 1}/${attempts}): ${error?.message || error}`,
+        );
+      }
+    }
+
+    this.markLeaseFailedAfterRestart(leaseContext);
+    throw lastError instanceof Error ? lastError : new Error(String(lastError || 'Lease processor restart failed'));
+  }
+
+  private restartBackoffDelayMs(backoffMs: number[], attemptIndex: number): number {
+    const base = backoffMs[Math.min(attemptIndex, backoffMs.length - 1)] ?? 0;
+    const jitterMs = this.leaseRestartPolicy.jitterMs ?? DEFAULT_LEASE_RESTART_JITTER_MS;
+    if (base <= 0 || jitterMs <= 0) return Math.max(0, base);
+    const random = this.leaseRestartPolicy.random ?? Math.random;
+    return base + Math.floor(random() * jitterMs);
+  }
+
+  private restartSleep(delayMs: number): Promise<void> {
+    if (this.leaseRestartPolicy.sleep) return this.leaseRestartPolicy.sleep(delayMs);
+    return new Promise(resolve => {
+      const timer = setTimeout(resolve, delayMs);
+      if (typeof (timer as any).unref === 'function') {
+        (timer as any).unref();
+      }
+    });
+  }
+
+  private destroyProcessorForRestart(processorKey: string): void {
+    const processor = this.processors.get(processorKey);
+    this.processors.delete(processorKey);
+    if (TraceProcessorFactory.remove(processorKey)) return;
+    try {
+      processor?.destroy();
+    } catch {
+      // Best-effort cleanup before the supervisor creates the replacement.
+    }
+  }
+
+  private markLeaseCrashedForRestart(context: TraceProcessorLeaseQueryContext): void {
+    if (!context.leaseScope) return;
+    const store = getTraceProcessorLeaseStore();
+    const lease = store.getLeaseById(context.leaseScope, context.leaseId);
+    if (!lease) throw new Error(`Trace processor lease not found: ${context.leaseId}`);
+    if (LEASE_RESTART_CONFLICT_STATES.has(lease.state)) {
+      throw new Error(`Trace processor lease ${lease.id} is ${lease.state}`);
+    }
+    if (lease.state === 'crashed' || lease.state === 'restarting') return;
+    store.markCrashed(context.leaseScope, lease.id);
+  }
+
+  private markLeaseRestarting(context: TraceProcessorLeaseQueryContext): void {
+    if (!context.leaseScope) return;
+    const store = getTraceProcessorLeaseStore();
+    const lease = store.getLeaseById(context.leaseScope, context.leaseId);
+    if (!lease) throw new Error(`Trace processor lease not found: ${context.leaseId}`);
+    if (lease.state === 'restarting') return;
+    if (lease.state !== 'crashed') return;
+    store.markRestarting(context.leaseScope, lease.id);
+  }
+
+  private markLeaseReadyAfterRestart(context: TraceProcessorLeaseQueryContext): void {
+    if (!context.leaseScope) return;
+    getTraceProcessorLeaseStore().markReady(context.leaseScope, context.leaseId);
+  }
+
+  private markLeaseFailedAfterRestart(context: TraceProcessorLeaseQueryContext): void {
+    if (!context.leaseScope) return;
+    const store = getTraceProcessorLeaseStore();
+    const lease = store.getLeaseById(context.leaseScope, context.leaseId);
+    if (!lease || lease.state === 'failed' || lease.state === 'released') return;
+    store.markFailed(context.leaseScope, context.leaseId);
   }
 
   /**

--- a/docs/features/enterprise-multi-tenant/README.md
+++ b/docs/features/enterprise-multi-tenant/README.md
@@ -70,7 +70,7 @@
 - [x] 4.7 RAM budget + 启动后实测 RSS + admission control（§11.5），暴露 stats endpoint
 - [x] 4.8 Shared / isolated 自动判定（§11.6），UI 明确展示队列/共享/独立状态
 - [x] 4.9 24h query timeout 覆盖 WorkingTraceProcessor 与 ExternalRpcProcessor 双路径；独立 health channel `SELECT 1`（§11.8）
-- [ ] 4.10 crash recovery + backoff（1s/5s/15s + jitter）+ 稳定 leaseId；单 supervisor 重启，holder 不各自重试
+- [x] 4.10 crash recovery + backoff（1s/5s/15s + jitter）+ 稳定 leaseId；单 supervisor 重启，holder 不各自重试
 - [ ] 4.11 `/api/traces/cleanup` 企业模式禁用或 admin-only + draining + audit
 - [ ] 4.12 §11.11 漏洞清单：每行设计验收都打勾验证
 


### PR DESCRIPTION
## Summary
- add a single restart supervisor for crashed lease-bound trace processors
- preserve stable lease ids while transitioning crashed -> restarting -> active/failed
- apply 1s/5s/15s restart backoff with jitter and make concurrent holders wait on the same supervisor promise
- carry enterprise lease scope through agent/proxy query paths so restart state updates hit the scoped repository

## Verification
- `cd backend && PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npx jest --runInBand src/services/__tests__/traceProcessorLeaseProcessorRouting.test.ts src/services/__tests__/traceProcessorLeaseStore.test.ts src/routes/__tests__/agentRoutesRbac.test.ts src/routes/__tests__/traceProcessorProxyRoutes.test.ts`
- `cd backend && PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npm run typecheck`
- `cd backend && PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npm run test:core`
- `cd backend && PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npm run test:scene-trace-regression`
- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npm run verify:pr`
- `git diff --check`
