### PR TITLE
feat(enterprise): guard trace cleanup with leases

### DIFF
--- a/backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts
+++ b/backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts
@@ -9,9 +9,11 @@ import os from 'os';
 import path from 'path';
 import request from 'supertest';
 import { ENTERPRISE_FEATURE_FLAG_ENV } from '../../config';
+import { listEnterpriseAuditEvents } from '../../services/enterpriseAuditService';
 import { ENTERPRISE_DB_PATH_ENV, openEnterpriseDb } from '../../services/enterpriseDb';
 import { ENTERPRISE_DATA_DIR_ENV } from '../../services/traceMetadataStore';
 import { setTraceProcessorServiceForTests } from '../../services/traceProcessorService';
+import { getTraceProcessorLeaseStore, setTraceProcessorLeaseStoreForTests } from '../../services/traceProcessorLeaseStore';
 import { TraceProcessorFactory } from '../../services/workingTraceProcessor';
 import traceRoutes from '../simpleTraceRoutes';
 
@@ -45,6 +47,7 @@ let fakeTraceProcessorService: {
   getTraceWithPort: jest.Mock;
   getAllTraces: jest.Mock;
   deleteTrace: jest.Mock;
+  cleanupProcessorsForTraces: jest.Mock;
 };
 
 function makeApp(): express.Express {
@@ -70,6 +73,16 @@ function ssoHeaders(req: request.Test, workspaceId = 'workspace-a'): request.Tes
     .set('X-SmartPerfetto-SSO-Workspace-Id', workspaceId)
     .set('X-SmartPerfetto-SSO-Roles', 'analyst')
     .set('X-SmartPerfetto-SSO-Scopes', 'trace:read,trace:write,trace:download');
+}
+
+function adminHeaders(req: request.Test, workspaceId = 'workspace-a'): request.Test {
+  return req
+    .set('X-SmartPerfetto-SSO-User-Id', 'admin-a')
+    .set('X-SmartPerfetto-SSO-Email', 'admin-a@example.test')
+    .set('X-SmartPerfetto-SSO-Tenant-Id', 'tenant-a')
+    .set('X-SmartPerfetto-SSO-Workspace-Id', workspaceId)
+    .set('X-SmartPerfetto-SSO-Roles', 'workspace_admin')
+    .set('X-SmartPerfetto-SSO-Scopes', 'trace:read,trace:write,trace:delete:any,audit:read');
 }
 
 function readTraceAsset(traceId: string): TraceAssetRow | null {
@@ -114,6 +127,39 @@ function readTraceProcessorLeases(traceId: string): Array<{
   }
 }
 
+function readTraceProcessorLeaseRows(traceId: string): Array<{
+  id: string;
+  state: string;
+  holder_count: number;
+}> {
+  const db = openEnterpriseDb(dbPath);
+  try {
+    return db.prepare<unknown[], {
+      id: string;
+      state: string;
+      holder_count: number;
+    }>(`
+      SELECT l.id, l.state, COUNT(h.id) as holder_count
+      FROM trace_processor_leases l
+      LEFT JOIN trace_processor_holders h ON h.lease_id = l.id
+      WHERE l.trace_id = ?
+      GROUP BY l.id
+      ORDER BY l.id ASC
+    `).all(traceId);
+  } finally {
+    db.close();
+  }
+}
+
+function readAuditActions(): string[] {
+  const db = openEnterpriseDb(dbPath);
+  try {
+    return listEnterpriseAuditEvents(db).map(event => event.action);
+  } finally {
+    db.close();
+  }
+}
+
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'smartperfetto-enterprise-trace-routes-'));
   dbPath = path.join(tmpDir, 'enterprise.sqlite');
@@ -134,6 +180,7 @@ beforeEach(async () => {
     getTraceWithPort: jest.fn(() => undefined),
     getAllTraces: jest.fn(() => []),
     deleteTrace: jest.fn(async () => undefined),
+    cleanupProcessorsForTraces: jest.fn(() => 0),
   };
   setTraceProcessorServiceForTests(fakeTraceProcessorService as any);
 });
@@ -141,6 +188,7 @@ beforeEach(async () => {
 afterEach(async () => {
   jest.restoreAllMocks();
   setTraceProcessorServiceForTests(null);
+  setTraceProcessorLeaseStoreForTests(null);
   restoreEnvValue(ENTERPRISE_FEATURE_FLAG_ENV, originalEnv.enterprise);
   restoreEnvValue('SMARTPERFETTO_SSO_TRUSTED_HEADERS', originalEnv.trustedHeaders);
   restoreEnvValue(ENTERPRISE_DB_PATH_ENV, originalEnv.enterpriseDbPath);
@@ -364,6 +412,101 @@ describe('enterprise trace metadata routes', () => {
       Buffer.byteLength(traceBytes),
       expectedTracePath,
     );
+  });
+
+  it('blocks enterprise cleanup when scoped trace processor leases still have active holders and audits the attempt', async () => {
+    const app = makeApp();
+    const sourceTracePath = path.join(tmpDir, 'active-cleanup.trace');
+    await fs.writeFile(sourceTracePath, 'active-cleanup');
+
+    const uploadRes = await ssoHeaders(
+      request(app)
+        .post('/api/traces/upload')
+        .attach('file', sourceTracePath),
+    );
+    expect(uploadRes.status).toBe(200);
+    const traceId = uploadRes.body.trace.id as string;
+
+    const cleanupRes = await adminHeaders(request(app).post('/api/traces/cleanup'));
+
+    expect(cleanupRes.status).toBe(409);
+    expect(cleanupRes.body).toEqual(expect.objectContaining({
+      success: false,
+      error: 'Trace cleanup blocked by active trace processor leases',
+    }));
+    expect(cleanupRes.body.blockedLeases).toEqual([
+      expect.objectContaining({
+        traceId,
+        holderCount: 1,
+        holderTypes: ['frontend_http_rpc'],
+      }),
+    ]);
+    expect(fakeTraceProcessorService.cleanupProcessorsForTraces).not.toHaveBeenCalled();
+    expect(readTraceProcessorLeaseRows(traceId)).toEqual([
+      expect.objectContaining({
+        state: 'active',
+        holder_count: 1,
+      }),
+    ]);
+    expect(readAuditActions()).toContain('trace_cleanup_blocked');
+  });
+
+  it('hides enterprise cleanup from non-admin analysts', async () => {
+    const app = makeApp();
+
+    const cleanupRes = await ssoHeaders(request(app).post('/api/traces/cleanup'));
+
+    expect(cleanupRes.status).toBe(404);
+    expect(cleanupRes.body.success).toBe(false);
+    expect(fakeTraceProcessorService.cleanupProcessorsForTraces).not.toHaveBeenCalled();
+    expect(readAuditActions()).not.toContain('trace_cleanup_completed');
+  });
+
+  it('drains idle enterprise leases before scoped processor cleanup and records an audit event', async () => {
+    const app = makeApp();
+    const sourceTracePath = path.join(tmpDir, 'idle-cleanup.trace');
+    await fs.writeFile(sourceTracePath, 'idle-cleanup');
+
+    const uploadRes = await ssoHeaders(
+      request(app)
+        .post('/api/traces/upload')
+        .attach('file', sourceTracePath),
+    );
+    expect(uploadRes.status).toBe(200);
+    const traceId = uploadRes.body.trace.id as string;
+    const scope = {
+      tenantId: 'tenant-a',
+      workspaceId: 'workspace-a',
+      userId: 'user-a',
+    };
+    const store = getTraceProcessorLeaseStore();
+    const lease = store.listLeases(scope, { traceId })[0];
+    for (const holder of lease.holders) {
+      store.releaseHolder(scope, lease.id, holder.holderType, holder.holderRef);
+    }
+
+    fakeTraceProcessorService.cleanupProcessorsForTraces.mockImplementation((traceIds: unknown) => {
+      expect(Array.from(traceIds as Iterable<string>)).toEqual([traceId]);
+      return 1;
+    });
+
+    const cleanupRes = await adminHeaders(request(app).post('/api/traces/cleanup'));
+
+    expect(cleanupRes.status).toBe(200);
+    expect(cleanupRes.body).toEqual(expect.objectContaining({
+      success: true,
+      releasedLeaseIds: [lease.id],
+      cleanedProcessors: 1,
+      traceCount: 1,
+    }));
+    expect(fakeTraceProcessorService.cleanupProcessorsForTraces).toHaveBeenCalledTimes(1);
+    expect(readTraceProcessorLeaseRows(traceId)).toEqual([
+      expect.objectContaining({
+        state: 'released',
+        holder_count: 0,
+      }),
+    ]);
+    expect(readAuditActions()).toContain('trace_cleanup_completed');
   });
 
   it('deletes enterprise trace files and trace_assets metadata through the scoped owner path', async () => {

--- a/backend/src/routes/simpleTraceRoutes.ts
+++ b/backend/src/routes/simpleTraceRoutes.ts
@@ -17,9 +17,12 @@ import { attachRequestContext, requireRequestContext, type RequestContext } from
 import { getTraceProcessorService } from '../services/traceProcessorService';
 import { getPortPool } from '../services/portPool';
 import { TraceProcessorFactory } from '../services/workingTraceProcessor';
+import { openEnterpriseDb } from '../services/enterpriseDb';
+import { recordEnterpriseAuditEvent } from '../services/enterpriseAuditService';
 import {
   getTraceProcessorLeaseStore,
   type TraceProcessorLeaseRecord,
+  type TraceProcessorLeaseState,
   type TraceProcessorHolderType,
 } from '../services/traceProcessorLeaseStore';
 import {
@@ -53,6 +56,7 @@ const STREAMED_UPLOAD_BYTES_CAP = 1024 * 1024 * 1024;
 export const TRACE_UPLOAD_MAX_BYTES_ENV = 'SMARTPERFETTO_TRACE_UPLOAD_MAX_BYTES';
 const URL_UPLOAD_TIMEOUT_MS = 300000;
 const TEMP_UPLOAD_SUFFIX = '.uploading';
+const CLEANUP_TERMINAL_LEASE_STATES = new Set<TraceProcessorLeaseState>(['released', 'failed']);
 
 class TraceUploadTooLargeError extends Error {
   constructor(readonly maxBytes: number) {
@@ -149,6 +153,103 @@ function recordLeaseRssFromProcessor(
 
 function queueLengthForTrace(traceId: string): number {
   return sharedQueueLengthForTrace(traceId, TraceProcessorFactory.getStats().processors);
+}
+
+function recordTraceCleanupAudit(
+  context: RequestContext,
+  action: 'trace_cleanup_blocked' | 'trace_cleanup_completed',
+  metadata: Record<string, unknown>,
+): void {
+  const db = openEnterpriseDb();
+  try {
+    const actor = db.prepare<unknown[], { id: string }>(`
+      SELECT id FROM users WHERE tenant_id = ? AND id = ? LIMIT 1
+    `).get(context.tenantId, context.userId);
+    recordEnterpriseAuditEvent(db, {
+      tenantId: context.tenantId,
+      workspaceId: context.workspaceId,
+      actorUserId: actor?.id,
+      action,
+      resourceType: 'trace_cleanup',
+      resourceId: context.workspaceId,
+      metadata,
+    });
+  } finally {
+    db.close();
+  }
+}
+
+async function cleanupEnterpriseWorkspaceProcessors(context: RequestContext): Promise<{
+  blocked: boolean;
+  blockedLeases: Array<{
+    id: string;
+    traceId: string;
+    state: string;
+    holderCount: number;
+    holderTypes: string[];
+  }>;
+  releasedLeaseIds: string[];
+  cleanedProcessors: number;
+  traceIds: string[];
+}> {
+  const scope = leaseScopeFromContext(context);
+  const traces = await listTraceMetadataForContext(context);
+  const traceIds = traces.map(trace => trace.id);
+  const traceIdSet = new Set(traceIds);
+  const store = getTraceProcessorLeaseStore();
+  const leases = store.listLeases(scope)
+    .filter(lease => traceIdSet.has(lease.traceId) && !CLEANUP_TERMINAL_LEASE_STATES.has(lease.state));
+  const blockedLeases = leases
+    .filter(lease => lease.holderCount > 0)
+    .map(lease => ({
+      id: lease.id,
+      traceId: lease.traceId,
+      state: lease.state,
+      holderCount: lease.holderCount,
+      holderTypes: Array.from(new Set(lease.holders.map(holder => holder.holderType))),
+    }));
+
+  if (blockedLeases.length > 0) {
+    recordTraceCleanupAudit(context, 'trace_cleanup_blocked', {
+      traceCount: traceIds.length,
+      blockedLeaseCount: blockedLeases.length,
+      blockedLeases,
+    });
+    return {
+      blocked: true,
+      blockedLeases,
+      releasedLeaseIds: [],
+      cleanedProcessors: 0,
+      traceIds,
+    };
+  }
+
+  const releasedLeaseIds: string[] = [];
+  for (const lease of leases) {
+    const drained = lease.state === 'draining'
+      ? lease
+      : store.beginDraining(scope, lease.id);
+    const current = store.getLeaseById(scope, drained.id);
+    if (current?.state === 'released') {
+      releasedLeaseIds.push(current.id);
+    }
+  }
+
+  const cleanedProcessors = getTraceProcessorService().cleanupProcessorsForTraces(traceIdSet);
+  recordTraceCleanupAudit(context, 'trace_cleanup_completed', {
+    traceCount: traceIds.length,
+    releasedLeaseCount: releasedLeaseIds.length,
+    cleanedProcessors,
+    traceIds,
+  });
+
+  return {
+    blocked: false,
+    blockedLeases: [],
+    releasedLeaseIds,
+    cleanedProcessors,
+    traceIds,
+  };
 }
 
 function ownedTraceIdForProcessorKey(processorKey: string, ownedTraceIds: Set<string>): string | null {
@@ -704,8 +805,31 @@ router.get('/stats', async (req, res) => {
 router.post('/cleanup', async (req, res) => {
   try {
     const context = requireRequestContext(req);
-    if (!isPrivilegedRequestContext(context)) {
+    const isEnterprise = enterpriseLeasesEnabled();
+    const canAdminCleanup = isEnterprise
+      ? hasRbacPermission(context, 'trace:delete_any')
+      : isPrivilegedRequestContext(context);
+    if (!canAdminCleanup) {
       return sendResourceNotFound(res);
+    }
+
+    if (isEnterprise) {
+      const result = await cleanupEnterpriseWorkspaceProcessors(context);
+      if (result.blocked) {
+        return res.status(409).json({
+          success: false,
+          error: 'Trace cleanup blocked by active trace processor leases',
+          blockedLeases: result.blockedLeases,
+        });
+      }
+
+      return res.json({
+        success: true,
+        message: `Enterprise cleanup complete. Released ${result.releasedLeaseIds.length} lease(s) and cleaned ${result.cleanedProcessors} processor(s).`,
+        releasedLeaseIds: result.releasedLeaseIds,
+        cleanedProcessors: result.cleanedProcessors,
+        traceCount: result.traceIds.length,
+      });
     }
 
     console.log('[Traces] Starting full cleanup...');

--- a/backend/src/services/traceProcessorService.ts
+++ b/backend/src/services/traceProcessorService.ts
@@ -794,6 +794,20 @@ export class TraceProcessorService extends EventEmitter {
     this.emit('trace-deleted', traceId);
   }
 
+  public cleanupProcessorsForTraces(traceIds: Iterable<string>): number {
+    const traceIdSet = new Set(traceIds);
+    let cleaned = 0;
+    for (const [processorKey, processor] of Array.from(this.processors.entries())) {
+      if (!traceIdSet.has(processor.traceId)) continue;
+      if (!TraceProcessorFactory.remove(processorKey)) {
+        processor.destroy();
+      }
+      this.processors.delete(processorKey);
+      cleaned++;
+    }
+    return cleaned;
+  }
+
   /**
    * Load a trace directly from a file path (for CLI/testing use)
    * This copies the file to the upload directory and processes it

--- a/docs/features/enterprise-multi-tenant/README.md
+++ b/docs/features/enterprise-multi-tenant/README.md
@@ -71,7 +71,7 @@
 - [x] 4.8 Shared / isolated 自动判定（§11.6），UI 明确展示队列/共享/独立状态
 - [x] 4.9 24h query timeout 覆盖 WorkingTraceProcessor 与 ExternalRpcProcessor 双路径；独立 health channel `SELECT 1`（§11.8）
 - [x] 4.10 crash recovery + backoff（1s/5s/15s + jitter）+ 稳定 leaseId；单 supervisor 重启，holder 不各自重试
-- [ ] 4.11 `/api/traces/cleanup` 企业模式禁用或 admin-only + draining + audit
+- [x] 4.11 `/api/traces/cleanup` 企业模式禁用或 admin-only + draining + audit
 - [ ] 4.12 §11.11 漏洞清单：每行设计验收都打勾验证
 
 ### 0.5 主线 D：控制面与合规（§18）


### PR DESCRIPTION
## Summary
- make enterprise `/api/traces/cleanup` admin-only via `trace:delete_any`
- block cleanup with 409 when scoped trace processor leases still have active holders
- drain/release idle scoped leases before cleanup and clean only processors for current workspace traces
- record `trace_cleanup_blocked` and `trace_cleanup_completed` audit events

## Verification
- `cd backend && PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npx jest --runInBand src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts src/services/__tests__/traceProcessorService.test.ts`
- `cd backend && PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npm run typecheck`
- `cd backend && PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npm run test:core`
- `cd backend && PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npm run test:scene-trace-regression`
- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npm run verify:pr`
- `git diff --check`
