### PR TITLE
feat(enterprise): add frontend lease heartbeat

### DIFF
--- a/backend/src/routes/__tests__/traceProcessorProxyRoutes.test.ts
+++ b/backend/src/routes/__tests__/traceProcessorProxyRoutes.test.ts
@@ -298,6 +298,96 @@ describe('trace processor lease proxy routes', () => {
     expect(res.status).toBe(404);
   });
 
+  it('refreshes frontend holder heartbeat with hidden visibility TTL', async () => {
+    const app = makeApp();
+    const before = Date.now();
+
+    const res = await ssoHeaders(
+      request(app)
+        .post(`/api/tp/${lease.id}/heartbeat`)
+        .send({ visibility: 'hidden' }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      action: 'heartbeat',
+      lease: {
+        id: lease.id,
+        state: 'active',
+      },
+      holder: {
+        holderType: 'frontend_http_rpc',
+        holderRef: 'window-a',
+        windowId: 'window-a',
+        frontendVisibility: 'hidden',
+      },
+    });
+    const updated = getTraceProcessorLeaseStore().getLeaseById(scope, lease.id);
+    const holder = updated?.holders.find(item => item.holderRef === 'window-a');
+    expect(holder).toBeDefined();
+    expect(holder?.metadata).toEqual(expect.objectContaining({
+      frontendVisibility: 'hidden',
+      heartbeat: 'frontend',
+      proxy: 'trace_processor',
+    }));
+    expect(holder?.expiresAt ?? 0).toBeGreaterThanOrEqual(before + 10 * 60 * 1000 - 1000);
+  });
+
+  it('reacquires the frontend holder on heartbeat after the window holder disappeared', async () => {
+    const app = makeApp();
+    const store = getTraceProcessorLeaseStore();
+    store.releaseHolder(scope, lease.id, 'frontend_http_rpc', 'window-a');
+    expect(store.getLeaseById(scope, lease.id)?.holderCount).toBe(0);
+    const before = Date.now();
+
+    const res = await ssoHeaders(
+      request(app)
+        .post(`/api/tp/${lease.id}/heartbeat`)
+        .send({ visibility: 'offline' }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      action: 'heartbeat',
+      lease: {
+        id: lease.id,
+        state: 'active',
+        holderCount: 1,
+      },
+      holder: {
+        holderType: 'frontend_http_rpc',
+        holderRef: 'window-a',
+        frontendVisibility: 'offline',
+      },
+    });
+    const reacquired = store.getLeaseById(scope, lease.id);
+    const holder = reacquired?.holders.find(item => item.holderRef === 'window-a');
+    expect(holder).toBeDefined();
+    expect(holder?.metadata).toEqual(expect.objectContaining({
+      frontendVisibility: 'offline',
+      heartbeat: 'frontend',
+    }));
+    expect(holder?.expiresAt ?? 0).toBeGreaterThanOrEqual(before + 30 * 60 * 1000 - 1000);
+  });
+
+  it('rejects invalid frontend heartbeat visibility', async () => {
+    const app = makeApp();
+
+    const res = await ssoHeaders(
+      request(app)
+        .post(`/api/tp/${lease.id}/heartbeat`)
+        .send({ visibility: 'minimized' }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      error: 'frontend visibility must be visible, hidden, or offline',
+    });
+  });
+
   it('requires runtime manage permission for lease admin actions', async () => {
     const app = makeApp();
 

--- a/backend/src/routes/traceProcessorProxyRoutes.ts
+++ b/backend/src/routes/traceProcessorProxyRoutes.ts
@@ -19,6 +19,7 @@ import {
 import { getTraceProcessorService } from '../services/traceProcessorService';
 import {
   getTraceProcessorLeaseStore,
+  type FrontendHolderVisibility,
   type TraceProcessorHolderInput,
   type TraceProcessorLeaseRecord,
   type TraceProcessorLeaseState,
@@ -32,6 +33,7 @@ import type { EnterpriseRepositoryScope } from '../services/enterpriseRepository
 const router = Router();
 const READY_STATES = new Set<TraceProcessorLeaseState>(['ready', 'idle', 'active']);
 const CONFLICT_STATES = new Set<TraceProcessorLeaseState>(['draining', 'released', 'failed']);
+const FRONTEND_VISIBILITIES = new Set<FrontendHolderVisibility>(['visible', 'hidden', 'offline']);
 const HOP_BY_HOP_HEADERS = new Set([
   'connection',
   'host',
@@ -219,18 +221,32 @@ function leaseScopeFromContext(context: RequestContext) {
 function frontendHolderForContext(
   context: RequestContext,
   metadata: Record<string, unknown> = {},
+  frontendVisibility?: FrontendHolderVisibility,
 ): TraceProcessorHolderInput {
   const holderRef = context.windowId || context.requestId || context.userId;
   return {
     holderType: 'frontend_http_rpc',
     holderRef,
     windowId: context.windowId,
+    ...(frontendVisibility ? { frontendVisibility } : {}),
     metadata: {
       requestId: context.requestId,
       proxy: 'trace_processor',
       ...metadata,
     },
   };
+}
+
+function parseFrontendVisibility(value: unknown): FrontendHolderVisibility {
+  if (value === undefined || value === null || value === '') return 'visible';
+  if (typeof value !== 'string') {
+    throw new TraceProcessorProxyError(400, 'frontend visibility must be visible, hidden, or offline');
+  }
+  const normalized = value.trim().toLowerCase();
+  if (FRONTEND_VISIBILITIES.has(normalized as FrontendHolderVisibility)) {
+    return normalized as FrontendHolderVisibility;
+  }
+  throw new TraceProcessorProxyError(400, 'frontend visibility must be visible, hidden, or offline');
 }
 
 function ensureTraceRead(context: RequestContext): void {
@@ -369,6 +385,56 @@ async function forwardQueryRpc(req: Request, res: Response): Promise<void> {
   });
   res.setHeader('content-type', 'application/x-protobuf');
   res.status(200).send(responseBody);
+}
+
+async function heartbeatLease(req: Request, res: Response): Promise<void> {
+  const leaseId = sanitizeContextId(req.params.leaseId);
+  if (!leaseId) {
+    res.status(400).json({ success: false, error: 'leaseId is required' });
+    return;
+  }
+
+  const context = requireRequestContext(req);
+  ensureTraceRead(context);
+  const visibility = parseFrontendVisibility(req.body?.visibility);
+  const scope = leaseScopeFromContext(context);
+  const store = getTraceProcessorLeaseStore();
+  let lease = store.getLeaseById(scope, leaseId);
+  if (!lease) {
+    throw new TraceProcessorProxyError(404, 'Trace processor lease not found');
+  }
+  if (CONFLICT_STATES.has(lease.state)) {
+    throw new TraceProcessorProxyError(409, `Trace processor lease is ${lease.state}`);
+  }
+
+  const holder = frontendHolderForContext(context, {
+    heartbeat: 'frontend',
+    lastHeartbeatAt: Date.now(),
+  }, visibility);
+  try {
+    lease = store.acquireHolderForLease(scope, lease.id, holder);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes('not acquirable')) {
+      throw new TraceProcessorProxyError(409, message);
+    }
+    if (message.includes('not found')) {
+      throw new TraceProcessorProxyError(404, 'Trace processor lease not found');
+    }
+    throw error;
+  }
+
+  res.json({
+    success: true,
+    action: 'heartbeat',
+    lease,
+    holder: {
+      holderType: holder.holderType,
+      holderRef: holder.holderRef,
+      windowId: holder.windowId ?? null,
+      frontendVisibility: visibility,
+    },
+  });
 }
 
 async function drainLease(req: Request, res: Response): Promise<void> {
@@ -541,6 +607,14 @@ router.post('/:leaseId/status', express.raw({ type: '*/*', limit: serverConfig.b
 router.post('/:leaseId/query', express.raw({ type: '*/*', limit: serverConfig.bodyLimit }), async (req, res) => {
   try {
     await forwardQueryRpc(req, res);
+  } catch (error) {
+    sendProxyError(res, error);
+  }
+});
+
+router.post('/:leaseId/heartbeat', express.json({ limit: '32kb' }), async (req, res) => {
+  try {
+    await heartbeatLease(req, res);
   } catch (error) {
     sendProxyError(res, error);
   }

--- a/docs/features/enterprise-multi-tenant/README.md
+++ b/docs/features/enterprise-multi-tenant/README.md
@@ -61,7 +61,7 @@
 - [x] 4.2 上传链路 stream 化（§11.1）：URL 上传不再 `arrayBuffer()` 全量进内存；本地上传与 RAM/磁盘策略联动；temp file 用 traceId/uuid + 原子 rename
 - [ ] 4.3 RSS benchmark：scroll/startup/ANR/memory/heapprofd/vendor 大 trace × 100MB/500MB/1GB，记录启动 RSS、load peak、query headroom
 - [x] 4.4 `TraceProcessorLease` 4 类 holder（frontend_http_rpc / agent_run / report_generation / manual_register）+ 状态机（§11.4）+ 分级 TTL
-- [x] 4.5 Backend proxy `/api/tp/:leaseId/{status,websocket,query}`（§11.3）
+- [x] 4.5 Backend proxy `/api/tp/:leaseId/{status,websocket,query,heartbeat}`（§11.3）
   - [x] 4.5.1 同时支持 `/status` HTTP / `/websocket` 二进制双向 / `/query` HTTP
   - [x] 4.5.2 前端 `HttpRpcEngine` 抽象成 `HttpRpcTarget`（direct-port + backend-lease-proxy）
   - [x] 4.5.3 同一 frontend WebSocket holder 内严格 FIFO，不做乱序返回
@@ -533,6 +533,7 @@ trace_processor_shell 需要本地文件路径，不支持直接从对象存储 
 ```text
 Browser -> Backend proxy /api/tp/{leaseId}/status
 Browser -> Backend proxy /api/tp/{leaseId}/websocket
+Browser -> Backend proxy /api/tp/{leaseId}/heartbeat
 Agent   -> Backend proxy /api/tp/{leaseId}/query
              -> lease lookup
              -> SQL Worker
@@ -550,6 +551,7 @@ Agent   -> Backend proxy /api/tp/{leaseId}/query
 
 - `/status` 代理，用于 UI 检测 trace_processor 可用性。
 - `/websocket` 二进制双向代理，用于 Perfetto UI 的 streaming query 和 timeline 查询。
+- `/heartbeat` 前端 holder 心跳，用于窗口 visible/hidden/offline TTL 与休眠恢复后的 lease reacquire。
 - `/query` HTTP 代理，用于 backend agent/MCP tool 的 SQL。
 
 不能只做 `/query`。如果前端 WebSocket 仍然直连裸 port，那么 lease、crash recovery、限流和 holder/ref-count 都绕不过前端主查询路径，双窗口问题仍然可能复现。
@@ -564,6 +566,7 @@ interface HttpRpcTarget {
   leaseId?: string;
   statusUrl: string;
   websocketUrl: string;
+  heartbeatUrl?: string;
 }
 ```
 
@@ -592,14 +595,14 @@ pending -> starting -> ready -> idle <-> active
 - `ref_count > 0` 的 lease 不可被 cleanup 删除。
 - running run、active lease、report generation artifact 都不可被 cleanup 删除。
 - 删除 trace/workspace/tenant 必须先进入 draining：拒绝新 run，等待 running run 结束或显式 cancel，等待 active lease 释放，再 tombstone + async purge。
-- holder heartbeat 默认 30s，但不同 holder 类型有不同 TTL。
+- holder heartbeat 按 holder 类型和前端可见性分级，默认只用于判定 holder stale，不是用户可见的 trace 保留时长。
 
 分级 TTL：
 
 | Holder | TTL 策略 |
 |---|---|
-| frontend visible | 心跳 30s，idle TTL 4h |
-| frontend hidden | 心跳 5min，idle TTL 8h |
+| frontend visible | 心跳 90s，idle TTL 4h |
+| frontend hidden | 心跳 10min，idle TTL 8h |
 | frontend offline | 心跳停止后保留 30min 重连窗口，再转 stale |
 | agent_run | 跟随 run lifecycle，run complete/cancel 后释放 |
 | report_generation | 跟随 job lifecycle，complete/fail 后释放 |


### PR DESCRIPTION
## Summary
- add POST /api/tp/:leaseId/heartbeat for frontend holder visibility heartbeats
- reacquire the scoped frontend holder when the window holder disappeared but the lease remains acquirable
- document the heartbeat proxy target and align frontend visibility TTLs with the current lease store policy

## Tests
- PATH="/Users/chris/.nvm/versions/node/v24.15.0/bin:/Users/chris/.codex/tmp/arg0/codex-arg0Ggjp4H:/Users/chris/.nvm/versions/node/v20.19.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.config/kaku/zsh/bin:/Users/chris/.opencode/bin:/Users/chris/.bun/bin:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.nvm/versions/node/v20.19.0/bin:/opt/homebrew/share/google-cloud-sdk/bin:/Users/chris/.local/bin:/Users/chris/.local/bin:/Users/chris/.codeium/windsurf/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/chris/.cargo/bin:/Users/chris/tools/Android-sdk/platform-tools/:/Users/chris/tools/TTDeDroid/bin:/Users/chris/tools/depot_tools:/Users/chris/tools/flutter/flutter/bin:/Applications/Warp.app/Contents/Resources/bin" npx jest --runInBand --forceExit src/routes/__tests__/traceProcessorProxyRoutes.test.ts
- PATH="/Users/chris/.nvm/versions/node/v24.15.0/bin:/Users/chris/.codex/tmp/arg0/codex-arg0Ggjp4H:/Users/chris/.nvm/versions/node/v20.19.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.config/kaku/zsh/bin:/Users/chris/.opencode/bin:/Users/chris/.bun/bin:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.nvm/versions/node/v20.19.0/bin:/opt/homebrew/share/google-cloud-sdk/bin:/Users/chris/.local/bin:/Users/chris/.local/bin:/Users/chris/.codeium/windsurf/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/chris/.cargo/bin:/Users/chris/tools/Android-sdk/platform-tools/:/Users/chris/tools/TTDeDroid/bin:/Users/chris/tools/depot_tools:/Users/chris/tools/flutter/flutter/bin:/Applications/Warp.app/Contents/Resources/bin" npm run typecheck
- PATH="/Users/chris/.nvm/versions/node/v24.15.0/bin:/Users/chris/.codex/tmp/arg0/codex-arg0Ggjp4H:/Users/chris/.nvm/versions/node/v20.19.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.config/kaku/zsh/bin:/Users/chris/.opencode/bin:/Users/chris/.bun/bin:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.nvm/versions/node/v20.19.0/bin:/opt/homebrew/share/google-cloud-sdk/bin:/Users/chris/.local/bin:/Users/chris/.local/bin:/Users/chris/.codeium/windsurf/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/chris/.cargo/bin:/Users/chris/tools/Android-sdk/platform-tools/:/Users/chris/tools/TTDeDroid/bin:/Users/chris/tools/depot_tools:/Users/chris/tools/flutter/flutter/bin:/Applications/Warp.app/Contents/Resources/bin" npm run test:core
- PATH="/Users/chris/.nvm/versions/node/v24.15.0/bin:/Users/chris/.codex/tmp/arg0/codex-arg0Ggjp4H:/Users/chris/.nvm/versions/node/v20.19.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.config/kaku/zsh/bin:/Users/chris/.opencode/bin:/Users/chris/.bun/bin:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.nvm/versions/node/v20.19.0/bin:/opt/homebrew/share/google-cloud-sdk/bin:/Users/chris/.local/bin:/Users/chris/.local/bin:/Users/chris/.codeium/windsurf/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/chris/.cargo/bin:/Users/chris/tools/Android-sdk/platform-tools/:/Users/chris/tools/TTDeDroid/bin:/Users/chris/tools/depot_tools:/Users/chris/tools/flutter/flutter/bin:/Applications/Warp.app/Contents/Resources/bin" npm run verify:pr