### PR TITLE
test(enterprise): verify D6 SSE replay

### DIFF
--- a/backend/src/scripts/__tests__/verifyEnterpriseMultiTenantWindows.test.ts
+++ b/backend/src/scripts/__tests__/verifyEnterpriseMultiTenantWindows.test.ts
@@ -31,7 +31,7 @@ describe('verifyEnterpriseMultiTenantWindows script', () => {
     await fs.rm(tempRoot, { recursive: true, force: true });
   });
 
-  test('covers current D1/D2/D4/D5 isolation invariants without invoking a real provider', async () => {
+  test('covers current D1/D2/D4/D5/D6 isolation invariants without invoking a real provider', async () => {
     const tracePath = path.join(tempRoot, 'fixture.pftrace');
     const uploadRoot = path.join(tempRoot, 'uploads');
     const outputPath = path.join(tempRoot, 'report.json');
@@ -45,13 +45,18 @@ describe('verifyEnterpriseMultiTenantWindows script', () => {
     });
 
     expect(report.passed).toBe(true);
-    expect(report.checks).toEqual({ D1: true, D2: true, D4: true, D5: true });
+    expect(report.checks).toEqual({ D1: true, D2: true, D4: true, D5: true, D6: true });
     expect(Object.values(report.scenarios.D1.checks)).toEqual(expect.arrayContaining([true]));
     expect(Object.values(report.scenarios.D1.checks).every(Boolean)).toBe(true);
     expect(Object.values(report.scenarios.D2.checks).every(Boolean)).toBe(true);
     expect(Object.values(report.scenarios.D4.checks).every(Boolean)).toBe(true);
     expect(Object.values(report.scenarios.D5.checks).every(Boolean)).toBe(true);
+    expect(Object.values(report.scenarios.D6.checks).every(Boolean)).toBe(true);
     expect(report.coverageLimitations.join('\n')).toContain('TraceProcessorLease');
+    expect(report.scenarios.D6.details).toEqual(expect.objectContaining({
+      reportUrl: expect.stringMatching(/^\/api\/reports\//),
+      crossTenantReplayCount: 0,
+    }));
     expect(process.env.UPLOAD_DIR).toBe(previousUploadDir);
 
     const written = JSON.parse(await fs.readFile(outputPath, 'utf8')) as EnterpriseWindowRegressionReport;
@@ -60,6 +65,6 @@ describe('verifyEnterpriseMultiTenantWindows script', () => {
 
     const traceFiles = (await fs.readdir(path.join(uploadRoot, 'traces')))
       .filter(file => file.endsWith('.trace'));
-    expect(traceFiles).toHaveLength(8);
+    expect(traceFiles).toHaveLength(9);
   });
 });

--- a/backend/src/scripts/verifyEnterpriseMultiTenantWindows.ts
+++ b/backend/src/scripts/verifyEnterpriseMultiTenantWindows.ts
@@ -20,7 +20,7 @@ import { TraceProcessorLeaseStore } from '../services/traceProcessorLeaseStore';
 import { ownerFieldsFromContext } from '../services/resourceOwnership';
 import type { RequestContext } from '../middleware/auth';
 
-type ScenarioName = 'D1' | 'D2' | 'D4' | 'D5';
+type ScenarioName = 'D1' | 'D2' | 'D4' | 'D5' | 'D6';
 
 interface VerifyOptions {
   tracePath?: string;
@@ -337,6 +337,7 @@ function appendAgentEvent(
   runId: string,
   cursor: number,
   eventType = 'progress',
+  payload?: Record<string, unknown>,
 ): void {
   db.prepare(`
     INSERT INTO agent_events
@@ -349,13 +350,39 @@ function appendAgentEvent(
     runId,
     cursor,
     eventType,
-    JSON.stringify({
+    JSON.stringify(payload ?? {
       scenario: 'enterprise-window',
       label: wc.label,
       cursor,
     }),
     Date.now(),
   );
+}
+
+function listAgentEventsAfter(
+  db: Database.Database,
+  wc: WindowContext,
+  runId: string,
+  lastEventId: number,
+): Array<{ cursor: number; eventType: string; payload: Record<string, unknown> }> {
+  return db.prepare<unknown[], { cursor: number; event_type: string; payload_json: string }>(`
+    SELECT cursor, event_type, payload_json
+    FROM agent_events
+    WHERE tenant_id = ?
+      AND workspace_id = ?
+      AND run_id = ?
+      AND cursor > ?
+    ORDER BY cursor ASC
+  `).all(
+    wc.context.tenantId,
+    wc.context.workspaceId,
+    runId,
+    lastEventId,
+  ).map(row => ({
+    cursor: row.cursor,
+    eventType: row.event_type,
+    payload: JSON.parse(row.payload_json) as Record<string, unknown>,
+  }));
 }
 
 function scalar<T>(db: Database.Database, sql: string, params: unknown[] = [], column = 'value'): T {
@@ -693,6 +720,109 @@ async function scenarioD5(
   };
 }
 
+async function scenarioD6(
+  db: Database.Database,
+  tracePath: string,
+  userAWindow1: WindowContext,
+  userCWindow1: WindowContext,
+): Promise<ScenarioReport> {
+  const upload = await simulateUpload(db, userAWindow1, tracePath, 'd6-user-a-sse-replay.pftrace');
+  const run = createAnalysisRun(db, userAWindow1, upload, 'running');
+  const reportId = `report-${crypto.randomUUID()}`;
+  const reportUrl = `/api/reports/${reportId}`;
+  const disconnectedAfterCursor = 10;
+  const completedCursor = 11;
+
+  appendAgentEvent(db, userAWindow1, run.runId, disconnectedAfterCursor, 'conclusion', {
+    type: 'conclusion',
+    data: {
+      summary: 'client received conclusion before disconnect',
+    },
+  });
+
+  db.prepare(`
+    INSERT INTO report_artifacts
+      (id, tenant_id, workspace_id, session_id, run_id, local_path, content_hash, visibility, created_by, created_at, expires_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, 'private', ?, ?, NULL)
+  `).run(
+    reportId,
+    userAWindow1.context.tenantId,
+    userAWindow1.context.workspaceId,
+    run.sessionId,
+    run.runId,
+    `reports/${reportId}.html`,
+    crypto.createHash('sha256').update(reportId).digest('hex'),
+    userAWindow1.context.userId,
+    Date.now(),
+  );
+  appendAgentEvent(db, userAWindow1, run.runId, completedCursor, 'analysis_completed', {
+    type: 'analysis_completed',
+    data: {
+      reportId,
+      reportUrl,
+    },
+  });
+  db.prepare(`
+    UPDATE analysis_runs SET status = 'completed', completed_at = ?, updated_at = ? WHERE id = ?
+  `).run(Date.now(), Date.now(), run.runId);
+  db.prepare(`
+    UPDATE analysis_sessions SET status = 'completed', updated_at = ? WHERE id = ?
+  `).run(Date.now(), run.sessionId);
+
+  const replayed = listAgentEventsAfter(db, userAWindow1, run.runId, disconnectedAfterCursor);
+  const crossTenantReplay = listAgentEventsAfter(db, userCWindow1, run.runId, disconnectedAfterCursor);
+  const terminal = replayed.find(event => event.eventType === 'analysis_completed');
+  const terminalPayload = terminal?.payload.data as { reportId?: string; reportUrl?: string } | undefined;
+  const reportRow = db.prepare<unknown[], { id: string; run_id: string }>(`
+    SELECT id, run_id FROM report_artifacts
+    WHERE tenant_id = ? AND workspace_id = ? AND id = ?
+  `).get(
+    userAWindow1.context.tenantId,
+    userAWindow1.context.workspaceId,
+    reportId,
+  );
+  const runStatus = scalar<string>(
+    db,
+    'SELECT status AS value FROM analysis_runs WHERE id = ?',
+    [run.runId],
+  );
+  const sessionStatus = scalar<string>(
+    db,
+    'SELECT status AS value FROM analysis_sessions WHERE id = ?',
+    [run.sessionId],
+  );
+
+  const checks = {
+    conclusionPersistedBeforeDisconnect: scalar<number>(
+      db,
+      'SELECT COUNT(*) AS value FROM agent_events WHERE run_id = ? AND cursor = ? AND event_type = ?',
+      [run.runId, disconnectedAfterCursor, 'conclusion'],
+    ) === 1,
+    terminalReplayAfterLastEventIdIncludesReportUrl: replayed.length === 1
+      && terminal?.cursor === completedCursor
+      && terminalPayload?.reportUrl === reportUrl,
+    replayUsesMonotonicCursorAfterDisconnect: replayed.map(event => event.cursor).join(',') === String(completedCursor),
+    replayIsTenantWorkspaceScoped: crossTenantReplay.length === 0,
+    reportArtifactMatchesReplayedUrl: reportRow?.id === reportId && reportRow.run_id === run.runId,
+    terminalEventCompletesRunAndSession: runStatus === 'completed' && sessionStatus === 'completed',
+  };
+
+  return {
+    checks,
+    details: {
+      traceId: upload.traceId,
+      run,
+      disconnectedAfterCursor,
+      replayed,
+      crossTenantReplayCount: crossTenantReplay.length,
+      reportId,
+      reportUrl,
+      runStatus,
+      sessionStatus,
+    },
+  };
+}
+
 function allChecksPassed(report: EnterpriseWindowRegressionReport): boolean {
   return Object.values(report.scenarios).every(scenario =>
     Object.values(scenario.checks).every(Boolean),
@@ -756,6 +886,7 @@ export async function runEnterpriseWindowRegression(
       ),
       D4: await scenarioD4(db, tracePath, windows.userAWindow1),
       D5: await scenarioD5(db, tracePath, windows.userAWindow1),
+      D6: await scenarioD6(db, tracePath, windows.userAWindow1, windows.userCWindow1),
     };
     const report: EnterpriseWindowRegressionReport = {
       timestamp: new Date().toISOString(),
@@ -765,6 +896,7 @@ export async function runEnterpriseWindowRegression(
         D2: scenarioPassed(scenarios.D2),
         D4: scenarioPassed(scenarios.D4),
         D5: scenarioPassed(scenarios.D5),
+        D6: scenarioPassed(scenarios.D6),
       },
       uploadRoot,
       tracePath,
@@ -774,7 +906,8 @@ export async function runEnterpriseWindowRegression(
         'D2 covers a deterministic long-SQL window at the run/event metadata layer without invoking a real LLM provider.',
         'D4 covers the lease state contract and frontend proxy target stability around a simulated trace_processor crash; TraceProcessorService restart backoff and single-supervisor behavior are covered by traceProcessorLeaseProcessorRouting tests.',
         'D5 covers TraceProcessorLease holder grace and pageshow-style reacquire semantics after offline heartbeat expiry; frontend stale-lease reload signaling is covered by HttpRpcEngine unit tests.',
-        'Production backend proxy and queue behavior remain future §0.7 D1/D2/D4/D5 final-acceptance work against a live browser and trace_processor_shell.',
+        'D6 covers the persisted AgentEvent replay contract after a conclusion cursor; the live stream route path is covered by agentRoutesRbac tests.',
+        'Production backend proxy and queue behavior remain future §0.7 D1/D2/D4/D5/D6 final-acceptance work against a live browser and trace_processor_shell.',
       ],
     };
     report.passed = allChecksPassed(report);

--- a/docs/features/enterprise-multi-tenant/README.md
+++ b/docs/features/enterprise-multi-tenant/README.md
@@ -110,7 +110,7 @@
 - [ ] D3 A 前端 timeline，B 跑 full agent → A WebSocket 走 lease；P0 不被 P2 长任务无限阻塞
 - [x] D4 trace_processor_shell crash → leaseId 稳定；前端不持有旧 port；supervisor 单点重启
 - [x] D5 浏览器断网 / 休眠 30 分钟后恢复 → frontend grace 生效；reacquire lease 或自动 reload
-- [ ] D6 SSE 在 conclusion 后、analysis_completed 前断开 → AgentEvent replay 能补回 reportUrl
+- [x] D6 SSE 在 conclusion 后、analysis_completed 前断开 → AgentEvent replay 能补回 reportUrl
 - [ ] D7 手动 cleanup / delete → running run / active lease / 正在生成的 report 被 draining 保护
 - [ ] D8 Provider 配置在 session 中途变更 → resume 校验 ProviderSnapshot hash，不复用错误 SDK session
 - [ ] D9 后端进程重启 → pending/running/terminal run 状态、events、trace metadata 可恢复或转 failed


### PR DESCRIPTION
Base PR: #103

Root commit: 4e301dd9

## Summary
- Add D6 to the enterprise multi-tenant window regression script.
- Simulate disconnect after the conclusion cursor and verify persisted AgentEvent replay returns analysis_completed with reportUrl.
- Verify replay is tenant/workspace scoped and mark README §0.7 D6 as checked.

## Verification
- cd backend && npx jest --runInBand --forceExit src/scripts/__tests__/verifyEnterpriseMultiTenantWindows.test.ts
- cd backend && npx jest --runInBand --forceExit src/routes/__tests__/agentRoutesRbac.test.ts
- cd backend && npm run typecheck
- git diff --check
- npm run verify:pr