### PR TITLE
fix(enterprise): block active trace deletes

### DIFF
--- a/backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts
+++ b/backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts
@@ -655,7 +655,7 @@ describe('enterprise trace metadata routes', () => {
       userId: 'user-a',
     };
     const store = getTraceProcessorLeaseStore();
-    const lease = store.listLeases(scope, { traceId })[0];
+    const lease = store.listLeases(scope, { traceId })[0]!;
     for (const holder of lease.holders) {
       store.releaseHolder(scope, lease.id, holder.holderType, holder.holderRef);
     }
@@ -684,6 +684,83 @@ describe('enterprise trace metadata routes', () => {
     expect(readAuditActions()).toContain('trace_cleanup_completed');
   });
 
+  it('blocks enterprise trace delete while runs, active leases, or report holders still own the trace', async () => {
+    const app = makeApp();
+    const sourceTracePath = path.join(tmpDir, 'active-delete.trace');
+    await fs.writeFile(sourceTracePath, 'active-delete');
+
+    const uploadRes = await ssoHeaders(
+      request(app)
+        .post('/api/traces/upload')
+        .attach('file', sourceTracePath),
+    );
+    expect(uploadRes.status).toBe(200);
+    const traceId = uploadRes.body.trace.id as string;
+    const row = readTraceAsset(traceId);
+    expect(row).not.toBeNull();
+
+    const now = Date.now();
+    const sessionId = 'session-active-delete';
+    const runId = 'run-active-delete';
+    const db = openEnterpriseDb(dbPath);
+    try {
+      db.prepare(`
+        INSERT INTO analysis_sessions
+          (id, tenant_id, workspace_id, trace_id, created_by, title, visibility, status, created_at, updated_at)
+        VALUES (?, 'tenant-a', 'workspace-a', ?, 'user-a', 'active delete', 'private', 'running', ?, ?)
+      `).run(sessionId, traceId, now, now);
+      db.prepare(`
+        INSERT INTO analysis_runs
+          (id, tenant_id, workspace_id, session_id, mode, status, question, started_at)
+        VALUES (?, 'tenant-a', 'workspace-a', ?, 'full', 'running', 'active delete', ?)
+      `).run(runId, sessionId, now);
+    } finally {
+      db.close();
+    }
+
+    const scope = {
+      tenantId: 'tenant-a',
+      workspaceId: 'workspace-a',
+      userId: 'user-a',
+    };
+    const store = getTraceProcessorLeaseStore();
+    const lease = store.listLeases(scope, { traceId })[0]!;
+    store.acquireHolderForLease(scope, lease.id, {
+      holderType: 'report_generation',
+      holderRef: 'report-active-delete',
+      reportId: 'report-active-delete',
+    });
+
+    const deleteRes = await ssoHeaders(request(app).delete(`/api/traces/${traceId}`));
+
+    expect(deleteRes.status).toBe(409);
+    expect(deleteRes.body).toEqual(expect.objectContaining({
+      success: false,
+      error: 'Trace delete blocked by active analysis runs or trace processor leases',
+      activeRuns: [
+        expect.objectContaining({ runId, sessionId, status: 'running' }),
+      ],
+    }));
+    expect(deleteRes.body.blockedLeases).toEqual([
+      expect.objectContaining({
+        traceId,
+        state: 'draining',
+        holderCount: 2,
+        holderTypes: expect.arrayContaining(['frontend_http_rpc', 'report_generation']),
+      }),
+    ]);
+    expect(fakeTraceProcessorService.deleteTrace).not.toHaveBeenCalled();
+    await expect(fs.access(row!.local_path)).resolves.toBeUndefined();
+    expect(readTraceAsset(traceId)).not.toBeNull();
+    expect(readTraceProcessorLeaseRows(traceId)).toEqual([
+      expect.objectContaining({
+        state: 'draining',
+        holder_count: 2,
+      }),
+    ]);
+    expect(readAuditActions()).toContain('trace_delete_blocked');
+  });
+
   it('deletes enterprise trace files and trace_assets metadata through the scoped owner path', async () => {
     const app = makeApp();
     const sourceTracePath = path.join(tmpDir, 'delete-me.trace');
@@ -698,6 +775,16 @@ describe('enterprise trace metadata routes', () => {
     const traceId = uploadRes.body.trace.id as string;
     const row = readTraceAsset(traceId);
     expect(row).not.toBeNull();
+    const scope = {
+      tenantId: 'tenant-a',
+      workspaceId: 'workspace-a',
+      userId: 'user-a',
+    };
+    const store = getTraceProcessorLeaseStore();
+    const lease = store.listLeases(scope, { traceId })[0];
+    for (const holder of lease.holders) {
+      store.releaseHolder(scope, lease.id, holder.holderType, holder.holderRef);
+    }
 
     const deleteRes = await ssoHeaders(request(app).delete(`/api/traces/${traceId}`));
 

--- a/backend/src/routes/simpleTraceRoutes.ts
+++ b/backend/src/routes/simpleTraceRoutes.ts
@@ -57,6 +57,7 @@ export const TRACE_UPLOAD_MAX_BYTES_ENV = 'SMARTPERFETTO_TRACE_UPLOAD_MAX_BYTES'
 const URL_UPLOAD_TIMEOUT_MS = 300000;
 const TEMP_UPLOAD_SUFFIX = '.uploading';
 const CLEANUP_TERMINAL_LEASE_STATES = new Set<TraceProcessorLeaseState>(['released', 'failed']);
+const DELETE_BLOCKING_RUN_STATUSES = new Set(['pending', 'running', 'awaiting_user']);
 
 class TraceUploadTooLargeError extends Error {
   constructor(readonly maxBytes: number) {
@@ -192,6 +193,112 @@ function recordTraceCleanupAudit(
   }
 }
 
+function recordTraceDeleteAudit(
+  context: RequestContext,
+  traceId: string,
+  action: 'trace_delete_blocked',
+  metadata: Record<string, unknown>,
+): void {
+  const db = openEnterpriseDb();
+  try {
+    const actor = db.prepare<unknown[], { id: string }>(`
+      SELECT id FROM users WHERE tenant_id = ? AND id = ? LIMIT 1
+    `).get(context.tenantId, context.userId);
+    recordEnterpriseAuditEvent(db, {
+      tenantId: context.tenantId,
+      workspaceId: context.workspaceId,
+      actorUserId: actor?.id,
+      action,
+      resourceType: 'trace',
+      resourceId: traceId,
+      metadata,
+    });
+  } finally {
+    db.close();
+  }
+}
+
+function summarizeLeaseBlockers(leases: TraceProcessorLeaseRecord[]): Array<{
+  id: string;
+  traceId: string;
+  state: string;
+  holderCount: number;
+  holderTypes: string[];
+}> {
+  return leases.map(lease => ({
+    id: lease.id,
+    traceId: lease.traceId,
+    state: lease.state,
+    holderCount: lease.holderCount,
+    holderTypes: Array.from(new Set(lease.holders.map(holder => holder.holderType))),
+  }));
+}
+
+function listActiveTraceRuns(context: RequestContext, traceId: string): Array<{
+  runId: string;
+  sessionId: string;
+  status: string;
+}> {
+  const db = openEnterpriseDb();
+  try {
+    return db.prepare<unknown[], { run_id: string; session_id: string; status: string }>(`
+      SELECT r.id AS run_id, r.session_id, r.status
+      FROM analysis_runs r
+      JOIN analysis_sessions s
+        ON s.tenant_id = r.tenant_id
+       AND s.workspace_id = r.workspace_id
+       AND s.id = r.session_id
+      WHERE r.tenant_id = ?
+        AND r.workspace_id = ?
+        AND s.trace_id = ?
+      ORDER BY r.started_at ASC, r.id ASC
+    `).all(context.tenantId, context.workspaceId, traceId)
+      .filter(row => DELETE_BLOCKING_RUN_STATUSES.has(row.status))
+      .map(row => ({
+        runId: row.run_id,
+        sessionId: row.session_id,
+        status: row.status,
+      }));
+  } finally {
+    db.close();
+  }
+}
+
+function blockEnterpriseTraceDeleteIfActive(
+  context: RequestContext,
+  traceId: string,
+): {
+  blocked: boolean;
+  blockedLeases: ReturnType<typeof summarizeLeaseBlockers>;
+  activeRuns: Array<{ runId: string; sessionId: string; status: string }>;
+} {
+  const scope = leaseScopeFromContext(context);
+  const store = getTraceProcessorLeaseStore();
+  const activeLeases = store.listLeases(scope, { traceId })
+    .filter(lease => !CLEANUP_TERMINAL_LEASE_STATES.has(lease.state) && lease.holderCount > 0);
+  const drainedLeases = activeLeases.map(lease =>
+    lease.state === 'draining' ? lease : store.beginDraining(scope, lease.id),
+  );
+  const activeRuns = listActiveTraceRuns(context, traceId);
+  const blockedLeases = summarizeLeaseBlockers(drainedLeases);
+  const blocked = blockedLeases.length > 0 || activeRuns.length > 0;
+
+  if (blocked) {
+    recordTraceDeleteAudit(context, traceId, 'trace_delete_blocked', {
+      blockedLeaseCount: blockedLeases.length,
+      activeRunCount: activeRuns.length,
+      blockedLeases,
+      activeRuns,
+    });
+  }
+
+  return {
+    blocked,
+    blockedLeases,
+    activeRuns,
+  };
+}
+
 async function cleanupEnterpriseWorkspaceProcessors(context: RequestContext): Promise<{
   blocked: boolean;
   blockedLeases: Array<{
@@ -212,15 +319,9 @@ async function cleanupEnterpriseWorkspaceProcessors(context: RequestContext): Pr
   const store = getTraceProcessorLeaseStore();
   const leases = store.listLeases(scope)
     .filter(lease => traceIdSet.has(lease.traceId) && !CLEANUP_TERMINAL_LEASE_STATES.has(lease.state));
-  const blockedLeases = leases
-    .filter(lease => lease.holderCount > 0)
-    .map(lease => ({
-      id: lease.id,
-      traceId: lease.traceId,
-      state: lease.state,
-      holderCount: lease.holderCount,
-      holderTypes: Array.from(new Set(lease.holders.map(holder => holder.holderType))),
-    }));
+  const blockedLeases = summarizeLeaseBlockers(
+    leases.filter(lease => lease.holderCount > 0),
+  );
 
   if (blockedLeases.length > 0) {
     recordTraceCleanupAudit(context, 'trace_cleanup_blocked', {
@@ -998,6 +1099,17 @@ router.delete('/:id', async (req, res) => {
     }
     if (!canDeleteTraceResource(metadata, context)) {
       return sendForbidden(res, 'Deleting this trace requires trace delete permission');
+    }
+    if (enterpriseLeasesEnabled()) {
+      const blockers = blockEnterpriseTraceDeleteIfActive(context, id);
+      if (blockers.blocked) {
+        return res.status(409).json({
+          success: false,
+          error: 'Trace delete blocked by active analysis runs or trace processor leases',
+          blockedLeases: blockers.blockedLeases,
+          activeRuns: blockers.activeRuns,
+        });
+      }
     }
     console.log(`[Traces] Deleting trace ${id} and cleaning up resources...`);
 

--- a/backend/src/scripts/__tests__/verifyEnterpriseMultiTenantWindows.test.ts
+++ b/backend/src/scripts/__tests__/verifyEnterpriseMultiTenantWindows.test.ts
@@ -31,7 +31,7 @@ describe('verifyEnterpriseMultiTenantWindows script', () => {
     await fs.rm(tempRoot, { recursive: true, force: true });
   });
 
-  test('covers current D1/D2/D4/D5/D6 isolation invariants without invoking a real provider', async () => {
+  test('covers current D1/D2/D4/D5/D6/D7 isolation invariants without invoking a real provider', async () => {
     const tracePath = path.join(tempRoot, 'fixture.pftrace');
     const uploadRoot = path.join(tempRoot, 'uploads');
     const outputPath = path.join(tempRoot, 'report.json');
@@ -45,13 +45,14 @@ describe('verifyEnterpriseMultiTenantWindows script', () => {
     });
 
     expect(report.passed).toBe(true);
-    expect(report.checks).toEqual({ D1: true, D2: true, D4: true, D5: true, D6: true });
+    expect(report.checks).toEqual({ D1: true, D2: true, D4: true, D5: true, D6: true, D7: true });
     expect(Object.values(report.scenarios.D1.checks)).toEqual(expect.arrayContaining([true]));
     expect(Object.values(report.scenarios.D1.checks).every(Boolean)).toBe(true);
     expect(Object.values(report.scenarios.D2.checks).every(Boolean)).toBe(true);
     expect(Object.values(report.scenarios.D4.checks).every(Boolean)).toBe(true);
     expect(Object.values(report.scenarios.D5.checks).every(Boolean)).toBe(true);
     expect(Object.values(report.scenarios.D6.checks).every(Boolean)).toBe(true);
+    expect(Object.values(report.scenarios.D7.checks).every(Boolean)).toBe(true);
     expect(report.coverageLimitations.join('\n')).toContain('TraceProcessorLease');
     expect(report.scenarios.D6.details).toEqual(expect.objectContaining({
       reportUrl: expect.stringMatching(/^\/api\/reports\//),
@@ -65,6 +66,6 @@ describe('verifyEnterpriseMultiTenantWindows script', () => {
 
     const traceFiles = (await fs.readdir(path.join(uploadRoot, 'traces')))
       .filter(file => file.endsWith('.trace'));
-    expect(traceFiles).toHaveLength(9);
+    expect(traceFiles).toHaveLength(10);
   });
 });

--- a/backend/src/scripts/verifyEnterpriseMultiTenantWindows.ts
+++ b/backend/src/scripts/verifyEnterpriseMultiTenantWindows.ts
@@ -20,7 +20,7 @@ import { TraceProcessorLeaseStore } from '../services/traceProcessorLeaseStore';
 import { ownerFieldsFromContext } from '../services/resourceOwnership';
 import type { RequestContext } from '../middleware/auth';
 
-type ScenarioName = 'D1' | 'D2' | 'D4' | 'D5' | 'D6';
+type ScenarioName = 'D1' | 'D2' | 'D4' | 'D5' | 'D6' | 'D7';
 
 interface VerifyOptions {
   tracePath?: string;
@@ -823,6 +823,97 @@ async function scenarioD6(
   };
 }
 
+async function scenarioD7(
+  db: Database.Database,
+  tracePath: string,
+  userAWindow1: WindowContext,
+): Promise<ScenarioReport> {
+  const upload = await simulateUpload(db, userAWindow1, tracePath, 'd7-user-a-delete-draining.pftrace');
+  const run = createAnalysisRun(db, userAWindow1, upload, 'running');
+  const store = new TraceProcessorLeaseStore(db);
+  const scope = leaseScope(userAWindow1);
+  const windowId = userAWindow1.context.windowId ?? userAWindow1.label;
+  const reportId = `report-${crypto.randomUUID()}`;
+
+  let lease = store.acquireHolder(scope, upload.traceId, {
+    holderType: 'frontend_http_rpc',
+    holderRef: windowId,
+    windowId,
+    frontendVisibility: 'visible',
+    metadata: { scenario: 'D7' },
+  });
+  store.markStarting(scope, lease.id);
+  lease = store.markReady(scope, lease.id);
+  lease = store.acquireHolderForLease(scope, lease.id, {
+    holderType: 'agent_run',
+    holderRef: run.runId,
+    runId: run.runId,
+    sessionId: run.sessionId,
+    metadata: { scenario: 'D7' },
+  });
+  lease = store.acquireHolderForLease(scope, lease.id, {
+    holderType: 'report_generation',
+    holderRef: reportId,
+    reportId,
+    metadata: { scenario: 'D7' },
+  });
+
+  const activeRuns = db.prepare<unknown[], { id: string; status: string }>(`
+    SELECT id, status
+    FROM analysis_runs
+    WHERE tenant_id = ? AND workspace_id = ? AND session_id = ? AND status = 'running'
+  `).all(userAWindow1.context.tenantId, userAWindow1.context.workspaceId, run.sessionId);
+  const activeHolderTypes = Array.from(new Set(lease.holders.map(holder => holder.holderType))).sort();
+  const blockedBeforeDelete = lease.holderCount > 0 || activeRuns.length > 0;
+  const drainingLease = store.beginDraining(scope, lease.id);
+  let newHolderRejected = false;
+  try {
+    store.acquireHolderForLease(scope, drainingLease.id, {
+      holderType: 'manual_register',
+      holderRef: 'port:9810',
+      metadata: { scenario: 'D7' },
+    });
+  } catch {
+    newHolderRejected = true;
+  }
+  const traceAssetStillPresent = scalar<number>(
+    db,
+    'SELECT COUNT(*) AS value FROM trace_assets WHERE id = ?',
+    [upload.traceId],
+  ) === 1;
+  const fileStillPresent = fs.existsSync(upload.localPath);
+
+  const checks = {
+    deleteDetectsRunningRunBeforeRemovingTrace: activeRuns.length === 1
+      && activeRuns[0]?.id === run.runId
+      && activeRuns[0]?.status === 'running',
+    activeLeaseBlocksCleanupOrDelete: blockedBeforeDelete
+      && drainingLease.id === lease.id
+      && drainingLease.state === 'draining'
+      && drainingLease.holderCount === 3,
+    reportGenerationHolderIsProtected: activeHolderTypes.includes('report_generation')
+      && lease.holders.some(holder => holder.holderRef === reportId),
+    drainingLeaseRejectsNewWork: newHolderRejected,
+    blockedDeleteLeavesTraceAssetAndFileIntact: traceAssetStillPresent && fileStillPresent,
+  };
+
+  return {
+    checks,
+    details: {
+      traceId: upload.traceId,
+      run,
+      leaseId: lease.id,
+      activeRuns,
+      activeHolderTypes,
+      drainingState: drainingLease.state,
+      drainingHolderCount: drainingLease.holderCount,
+      newHolderRejected,
+      traceAssetStillPresent,
+      fileStillPresent,
+    },
+  };
+}
+
 function allChecksPassed(report: EnterpriseWindowRegressionReport): boolean {
   return Object.values(report.scenarios).every(scenario =>
     Object.values(scenario.checks).every(Boolean),
@@ -887,6 +978,7 @@ export async function runEnterpriseWindowRegression(
       D4: await scenarioD4(db, tracePath, windows.userAWindow1),
       D5: await scenarioD5(db, tracePath, windows.userAWindow1),
       D6: await scenarioD6(db, tracePath, windows.userAWindow1, windows.userCWindow1),
+      D7: await scenarioD7(db, tracePath, windows.userAWindow1),
     };
     const report: EnterpriseWindowRegressionReport = {
       timestamp: new Date().toISOString(),
@@ -897,6 +989,7 @@ export async function runEnterpriseWindowRegression(
         D4: scenarioPassed(scenarios.D4),
         D5: scenarioPassed(scenarios.D5),
         D6: scenarioPassed(scenarios.D6),
+        D7: scenarioPassed(scenarios.D7),
       },
       uploadRoot,
       tracePath,
@@ -907,7 +1000,8 @@ export async function runEnterpriseWindowRegression(
         'D4 covers the lease state contract and frontend proxy target stability around a simulated trace_processor crash; TraceProcessorService restart backoff and single-supervisor behavior are covered by traceProcessorLeaseProcessorRouting tests.',
         'D5 covers TraceProcessorLease holder grace and pageshow-style reacquire semantics after offline heartbeat expiry; frontend stale-lease reload signaling is covered by HttpRpcEngine unit tests.',
         'D6 covers the persisted AgentEvent replay contract after a conclusion cursor; the live stream route path is covered by agentRoutesRbac tests.',
-        'Production backend proxy and queue behavior remain future §0.7 D1/D2/D4/D5/D6 final-acceptance work against a live browser and trace_processor_shell.',
+        'D7 covers running run, active lease, report_generation holder, and draining rejection invariants; actual route blocking is covered by enterpriseTraceMetadataRoutes tests.',
+        'Production backend proxy and queue behavior remain future §0.7 D1/D2/D4/D5/D6/D7 final-acceptance work against a live browser and trace_processor_shell.',
       ],
     };
     report.passed = allChecksPassed(report);

--- a/docs/features/enterprise-multi-tenant/README.md
+++ b/docs/features/enterprise-multi-tenant/README.md
@@ -111,7 +111,7 @@
 - [x] D4 trace_processor_shell crash → leaseId 稳定；前端不持有旧 port；supervisor 单点重启
 - [x] D5 浏览器断网 / 休眠 30 分钟后恢复 → frontend grace 生效；reacquire lease 或自动 reload
 - [x] D6 SSE 在 conclusion 后、analysis_completed 前断开 → AgentEvent replay 能补回 reportUrl
-- [ ] D7 手动 cleanup / delete → running run / active lease / 正在生成的 report 被 draining 保护
+- [x] D7 手动 cleanup / delete → running run / active lease / 正在生成的 report 被 draining 保护
 - [ ] D8 Provider 配置在 session 中途变更 → resume 校验 ProviderSnapshot hash，不复用错误 SDK session
 - [ ] D9 后端进程重启 → pending/running/terminal run 状态、events、trace metadata 可恢复或转 failed
 - [ ] D10 机器内存接近上限 → admission 拒绝新 lease，不通过 OOM 杀已有窗口


### PR DESCRIPTION
Base PR: #104

Root commit: 08ec5e8d

## Summary
- Block enterprise DELETE /api/traces/:id when active analysis runs or trace processor lease holders still own the trace.
- Move active leases into draining on blocked delete so new holders are rejected while existing holders finish or release.
- Add D7 to the enterprise window regression script and mark README §0.7 D7 as checked.

## Verification
- cd backend && npx jest --runInBand --forceExit src/scripts/__tests__/verifyEnterpriseMultiTenantWindows.test.ts
- cd backend && npx jest --runInBand --forceExit src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts
- cd backend && npm run typecheck
- git diff --check
- npm run verify:pr