### PR TITLE
feat(enterprise): audit key control-plane actions

### DIFF
--- a/backend/src/routes/__tests__/enterpriseReportRoutes.test.ts
+++ b/backend/src/routes/__tests__/enterpriseReportRoutes.test.ts
@@ -9,6 +9,7 @@ import os from 'os';
 import path from 'path';
 import request from 'supertest';
 import { ENTERPRISE_FEATURE_FLAG_ENV } from '../../config';
+import { listEnterpriseAuditEvents } from '../../services/enterpriseAuditService';
 import { ENTERPRISE_DB_PATH_ENV, openEnterpriseDb } from '../../services/enterpriseDb';
 import { ENTERPRISE_DATA_DIR_ENV } from '../../services/traceMetadataStore';
 import reportRoutes, { persistReport, reportStore } from '../reportRoutes';
@@ -70,6 +71,15 @@ function readReportArtifact(reportId: string): ReportArtifactRow | null {
       FROM report_artifacts
       WHERE id = ?
     `).get(reportId) || null;
+  } finally {
+    db.close();
+  }
+}
+
+function readAuditActions(): string[] {
+  const db = openEnterpriseDb(dbPath);
+  try {
+    return listEnterpriseAuditEvents(db).map(event => event.action);
   } finally {
     db.close();
   }
@@ -145,6 +155,14 @@ describe('enterprise report routes', () => {
     expect(getRes.status).toBe(200);
     expect(getRes.text).toContain('enterprise report');
 
+    const exportRes = await ssoHeaders(request(app).get(`/api/reports/${reportId}/export`));
+    expect(exportRes.status).toBe(200);
+    expect(exportRes.text).toContain('enterprise report');
+    expect(readAuditActions()).toEqual(expect.arrayContaining([
+      'report.read',
+      'report.exported',
+    ]));
+
     const otherWorkspaceRes = await ssoHeaders(
       request(app).get(`/api/reports/${reportId}`),
       'workspace-b',
@@ -178,5 +196,6 @@ describe('enterprise report routes', () => {
     expect(readReportArtifact(reportId)).toBeNull();
     await expect(fs.access(row!.local_path)).rejects.toThrow();
     await expect(fs.access(path.dirname(row!.local_path))).rejects.toThrow();
+    expect(readAuditActions()).toContain('report.deleted');
   });
 });

--- a/backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts
+++ b/backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts
@@ -287,6 +287,13 @@ describe('enterprise trace metadata routes', () => {
     expect(listRes.status).toBe(200);
     expect(listRes.body.traces.map((trace: any) => trace.id)).toEqual([traceId]);
 
+    const ownTraceRes = await ssoHeaders(request(app).get(`/api/traces/${traceId}`));
+    expect(ownTraceRes.status).toBe(200);
+    expect(readAuditActions()).toEqual(expect.arrayContaining([
+      'trace.uploaded',
+      'trace.read',
+    ]));
+
     const otherWorkspaceRes = await ssoHeaders(
       request(app).get(`/api/traces/${traceId}`),
       'workspace-b',
@@ -792,5 +799,9 @@ describe('enterprise trace metadata routes', () => {
     expect(fakeTraceProcessorService.deleteTrace).toHaveBeenCalledWith(traceId);
     await expect(fs.access(row!.local_path)).rejects.toThrow();
     expect(readTraceAsset(traceId)).toBeNull();
+    expect(readAuditActions()).toEqual(expect.arrayContaining([
+      'trace.uploaded',
+      'trace.deleted',
+    ]));
   });
 });

--- a/backend/src/routes/__tests__/memoryRoutes.test.ts
+++ b/backend/src/routes/__tests__/memoryRoutes.test.ts
@@ -10,12 +10,25 @@ import {describe, it, expect, beforeEach, afterEach} from '@jest/globals';
 import express from 'express';
 import request from 'supertest';
 
+import {ENTERPRISE_FEATURE_FLAG_ENV} from '../../config';
 import {createMemoryRoutes} from '../memoryRoutes';
 import {ProjectMemory} from '../../agentv3/projectMemory';
+import {listEnterpriseAuditEvents} from '../../services/enterpriseAuditService';
+import {
+  ENTERPRISE_DB_PATH_ENV,
+  openEnterpriseDb,
+} from '../../services/enterpriseDb';
 import {
   type MemoryPromotionPolicy,
   type ProjectMemoryEntry,
 } from '../../types/sparkContracts';
+
+const originalEnv = {
+  enterprise: process.env[ENTERPRISE_FEATURE_FLAG_ENV],
+  trustedHeaders: process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS,
+  enterpriseDbPath: process.env[ENTERPRISE_DB_PATH_ENV],
+  apiKey: process.env.SMARTPERFETTO_API_KEY,
+};
 
 let tmpDir: string;
 let memory: ProjectMemory;
@@ -30,10 +43,41 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  restoreEnvValue(ENTERPRISE_FEATURE_FLAG_ENV, originalEnv.enterprise);
+  restoreEnvValue('SMARTPERFETTO_SSO_TRUSTED_HEADERS', originalEnv.trustedHeaders);
+  restoreEnvValue(ENTERPRISE_DB_PATH_ENV, originalEnv.enterpriseDbPath);
+  restoreEnvValue('SMARTPERFETTO_API_KEY', originalEnv.apiKey);
   if (fs.existsSync(tmpDir)) {
     fs.rmSync(tmpDir, {recursive: true, force: true});
   }
 });
+
+function restoreEnvValue(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+function ssoHeaders(req: request.Test): request.Test {
+  return req
+    .set('X-SmartPerfetto-SSO-User-Id', 'memory-admin')
+    .set('X-SmartPerfetto-SSO-Email', 'memory-admin@example.test')
+    .set('X-SmartPerfetto-SSO-Tenant-Id', 'tenant-a')
+    .set('X-SmartPerfetto-SSO-Workspace-Id', 'workspace-a')
+    .set('X-SmartPerfetto-SSO-Roles', 'workspace_admin')
+    .set('X-SmartPerfetto-SSO-Scopes', 'audit:read');
+}
+
+function readEnterpriseAuditActions(dbPath: string): string[] {
+  const db = openEnterpriseDb(dbPath);
+  try {
+    return listEnterpriseAuditEvents(db).map(event => event.action);
+  } finally {
+    db.close();
+  }
+}
 
 function makeEntry(
   overrides: Partial<ProjectMemoryEntry> = {},
@@ -147,6 +191,34 @@ describe('POST /api/memory/promote', () => {
     expect(res.status).toBe(200);
     expect(res.body.entry.scope).toBe('world');
     expect(res.body.entry.promotionPolicy.trigger).toBe('reviewer_approval');
+  });
+
+  it('records enterprise audit events for promotion and deletion', async () => {
+    const dbPath = path.join(tmpDir, 'enterprise.sqlite');
+    process.env[ENTERPRISE_FEATURE_FLAG_ENV] = 'true';
+    process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS = 'true';
+    process.env[ENTERPRISE_DB_PATH_ENV] = dbPath;
+    delete process.env.SMARTPERFETTO_API_KEY;
+
+    memory.saveProjectMemoryEntry(makeEntry({entryId: 'a', scope: 'project'}), {
+      tenantId: 'tenant-a',
+      workspaceId: 'workspace-a',
+      userId: 'memory-admin',
+    });
+    const promoteRes = await ssoHeaders(
+      request(app)
+        .post('/api/memory/promote')
+        .send({entryId: 'a', policy: REVIEWER_POLICY}),
+    );
+    expect(promoteRes.status).toBe(200);
+
+    const deleteRes = await ssoHeaders(request(app).delete('/api/memory/a'));
+    expect(deleteRes.status).toBe(200);
+
+    expect(readEnterpriseAuditActions(dbPath)).toEqual(expect.arrayContaining([
+      'memory.promoted',
+      'memory.deleted',
+    ]));
   });
 
   it('400 on missing body fields', async () => {

--- a/backend/src/routes/memoryRoutes.ts
+++ b/backend/src/routes/memoryRoutes.ts
@@ -32,6 +32,7 @@ import {Router, type Router as ExpressRouter} from 'express';
 
 import {authenticate, requireRequestContext} from '../middleware/auth';
 import {ProjectMemory} from '../agentv3/projectMemory';
+import {recordEnterpriseAuditEventForContext} from '../services/enterpriseAuditService';
 import {knowledgeScopeFromRequestContext} from '../services/scopedKnowledgeStore';
 import type {MemoryPromotionPolicy} from '../types/sparkContracts';
 
@@ -114,6 +115,17 @@ export function createMemoryRoutes(memory?: ProjectMemory): ExpressRouter {
     try {
       m.promoteEntry(entryId, policy, storageScope);
       const entry = m.getProjectMemoryEntry(entryId, storageScope);
+      recordEnterpriseAuditEventForContext(requireRequestContext(req), {
+        action: 'memory.promoted',
+        resourceType: 'memory',
+        resourceId: entryId,
+        metadata: {
+          fromScope: policy.fromScope,
+          toScope: policy.toScope,
+          trigger: policy.trigger,
+          reviewer: policy.reviewer,
+        },
+      });
       return res.status(200).json({success: true, entry});
     } catch (err) {
       return res.status(400).json({
@@ -133,6 +145,11 @@ export function createMemoryRoutes(memory?: ProjectMemory): ExpressRouter {
         error: `Entry '${req.params.entryId}' not found`,
       });
     }
+    recordEnterpriseAuditEventForContext(requireRequestContext(req), {
+      action: 'memory.deleted',
+      resourceType: 'memory',
+      resourceId: req.params.entryId,
+    });
     res.json({success: true});
   });
 

--- a/backend/src/routes/providerRoutes.ts
+++ b/backend/src/routes/providerRoutes.ts
@@ -5,7 +5,8 @@ import express from 'express';
 import { getProviderService, officialTemplates } from '../services/providerManager';
 import type { AgentRuntimeKind, ProviderCreateInput, ProviderScope, ProviderUpdateInput } from '../services/providerManager';
 import { testProviderConnection } from '../services/providerManager/connectionTester';
-import { authenticate, requireRequestContext } from '../middleware/auth';
+import { authenticate, requireRequestContext, type RequestContext } from '../middleware/auth';
+import { recordEnterpriseAuditEventForContext } from '../services/enterpriseAuditService';
 
 const router = express.Router();
 
@@ -18,6 +19,29 @@ function providerScopeForRequest(req: express.Request): ProviderScope {
     workspaceId: context.workspaceId,
     userId: context.userId,
   };
+}
+
+function recordProviderAudit(
+  context: RequestContext,
+  action:
+    | 'provider.read'
+    | 'provider.created'
+    | 'provider.updated'
+    | 'provider.deleted'
+    | 'provider.activated'
+    | 'provider.deactivated'
+    | 'provider.runtime_switched'
+    | 'provider.secret_rotated'
+    | 'provider.connection_tested',
+  providerId: string | undefined,
+  metadata: Record<string, unknown> = {},
+): void {
+  recordEnterpriseAuditEventForContext(context, {
+    action,
+    resourceType: 'provider',
+    resourceId: providerId,
+    metadata,
+  });
 }
 
 router.get('/', (req, res) => {
@@ -43,8 +67,13 @@ router.get('/effective', (req, res) => {
 
 router.get('/:id', (req, res) => {
   const svc = getProviderService();
+  const context = requireRequestContext(req);
   const provider = svc.get(req.params.id, providerScopeForRequest(req));
   if (!provider) return res.status(404).json({ success: false, error: 'Provider not found' });
+  recordProviderAudit(context, 'provider.read', provider.id, {
+    type: provider.type,
+    active: provider.isActive,
+  });
   res.json({ success: true, provider });
 });
 
@@ -52,8 +81,14 @@ router.post('/', (req, res) => {
   try {
     const svc = getProviderService();
     const input: ProviderCreateInput = req.body;
+    const context = requireRequestContext(req);
     const scope = providerScopeForRequest(req);
     const provider = svc.create(input, scope);
+    recordProviderAudit(context, 'provider.created', provider.id, {
+      type: provider.type,
+      category: provider.category,
+      runtime: provider.connection.agentRuntime,
+    });
     res.status(201).json({ success: true, provider: svc.get(provider.id, scope) });
   } catch (err: any) {
     res.status(400).json({ success: false, error: err.message });
@@ -64,8 +99,13 @@ router.patch('/:id', (req, res) => {
   try {
     const svc = getProviderService();
     const input: ProviderUpdateInput = req.body;
+    const context = requireRequestContext(req);
     const scope = providerScopeForRequest(req);
-    svc.update(req.params.id, input, scope);
+    const updated = svc.update(req.params.id, input, scope);
+    recordProviderAudit(context, 'provider.updated', updated.id, {
+      type: updated.type,
+      changedFields: Object.keys(input),
+    });
     res.json({ success: true, provider: svc.get(req.params.id, scope) });
   } catch (err: any) {
     const status = err.message.includes('not found') ? 404 : 400;
@@ -76,7 +116,13 @@ router.patch('/:id', (req, res) => {
 router.delete('/:id', (req, res) => {
   try {
     const svc = getProviderService();
-    svc.delete(req.params.id, providerScopeForRequest(req));
+    const context = requireRequestContext(req);
+    const scope = providerScopeForRequest(req);
+    const existing = svc.get(req.params.id, scope);
+    svc.delete(req.params.id, scope);
+    recordProviderAudit(context, 'provider.deleted', req.params.id, {
+      type: existing?.type,
+    });
     res.json({ success: true });
   } catch (err: any) {
     const status = err.message.includes('not found') ? 404 : 400;
@@ -86,14 +132,26 @@ router.delete('/:id', (req, res) => {
 
 router.post('/deactivate', (req, res) => {
   const svc = getProviderService();
-  svc.deactivateAll(providerScopeForRequest(req));
+  const context = requireRequestContext(req);
+  const scope = providerScopeForRequest(req);
+  const active = svc.list(scope).find(provider => provider.isActive);
+  svc.deactivateAll(scope);
+  recordProviderAudit(context, 'provider.deactivated', active?.id, {
+    type: active?.type,
+  });
   res.json({ success: true });
 });
 
 router.post('/:id/activate', (req, res) => {
   try {
     const svc = getProviderService();
-    svc.activate(req.params.id, providerScopeForRequest(req));
+    const context = requireRequestContext(req);
+    const scope = providerScopeForRequest(req);
+    svc.activate(req.params.id, scope);
+    const provider = svc.get(req.params.id, scope);
+    recordProviderAudit(context, 'provider.activated', req.params.id, {
+      type: provider?.type,
+    });
     res.json({ success: true });
   } catch (err: any) {
     const status = err.message.includes('not found') ? 404 : 400;
@@ -108,8 +166,13 @@ router.post('/:id/runtime', (req, res) => {
     if (runtime !== 'claude-agent-sdk' && runtime !== 'openai-agents-sdk') {
       return res.status(400).json({ success: false, error: 'Invalid agentRuntime' });
     }
+    const context = requireRequestContext(req);
     const scope = providerScopeForRequest(req);
-    svc.switchAgentRuntime(req.params.id, runtime, scope);
+    const provider = svc.switchAgentRuntime(req.params.id, runtime, scope);
+    recordProviderAudit(context, 'provider.runtime_switched', req.params.id, {
+      type: provider.type,
+      runtime,
+    });
     res.json({ success: true, provider: svc.get(req.params.id, scope) });
   } catch (err: any) {
     const status = err.message.includes('not found') ? 404 : 400;
@@ -120,8 +183,14 @@ router.post('/:id/runtime', (req, res) => {
 router.post('/:id/rotate-secret', (req, res) => {
   try {
     const svc = getProviderService();
+    const context = requireRequestContext(req);
     const scope = providerScopeForRequest(req);
     const secretVersion = svc.rotateSecret(req.params.id, scope);
+    const provider = svc.get(req.params.id, scope);
+    recordProviderAudit(context, 'provider.secret_rotated', req.params.id, {
+      type: provider?.type,
+      secretVersion,
+    });
     res.json({ success: true, secretVersion, provider: svc.get(req.params.id, scope) });
   } catch (err: any) {
     const status = err.message.includes('not found') ? 404 : 400;
@@ -131,10 +200,15 @@ router.post('/:id/rotate-secret', (req, res) => {
 
 router.post('/:id/test', async (req, res) => {
   const svc = getProviderService();
+  const context = requireRequestContext(req);
   const provider = svc.getRaw(req.params.id, providerScopeForRequest(req));
   if (!provider) return res.status(404).json({ success: false, error: 'Provider not found' });
 
   const result = await testProviderConnection(provider);
+  recordProviderAudit(context, 'provider.connection_tested', req.params.id, {
+    type: provider.type,
+    success: result.success,
+  });
   res.json({ success: true, result });
 });
 

--- a/backend/src/routes/reportRoutes.ts
+++ b/backend/src/routes/reportRoutes.ts
@@ -14,8 +14,9 @@ import crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import type Database from 'better-sqlite3';
-import { attachRequestContext, requireRequestContext } from '../middleware/auth';
+import { attachRequestContext, requireRequestContext, type RequestContext } from '../middleware/auth';
 import { openEnterpriseDb } from '../services/enterpriseDb';
+import { recordEnterpriseAuditEventForContext } from '../services/enterpriseAuditService';
 import {
   enterpriseDbReadAuthorityEnabled,
   enterpriseDbWritesEnabled,
@@ -70,6 +71,25 @@ interface ReportArtifactRow {
   created_by: string | null;
   created_at: number;
   expires_at: number | null;
+}
+
+function recordReportAudit(
+  context: RequestContext,
+  action: 'report.read' | 'report.exported' | 'report.deleted',
+  reportId: string,
+  report: PersistedReport,
+): void {
+  recordEnterpriseAuditEventForContext(context, {
+    action,
+    resourceType: 'report',
+    resourceId: reportId,
+    metadata: {
+      sessionId: report.sessionId,
+      runId: report.runId,
+      traceId: report.traceId,
+      visibility: report.visibility,
+    },
+  });
 }
 
 const SAFE_REPORT_ID_RE = /^[a-zA-Z0-9._:-]+$/;
@@ -507,6 +527,7 @@ reportCleanupInterval.unref?.();
 router.get('/:reportId/export', (req, res) => {
   try {
     const { reportId } = req.params;
+    const context = requireRequestContext(req);
 
     const report = getReportForContext(reportId, req);
     if (!report) {
@@ -522,6 +543,7 @@ router.get('/:reportId/export', (req, res) => {
     res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
     res.setHeader('Pragma', 'no-cache');
     res.setHeader('Expires', '0');
+    recordReportAudit(context, 'report.exported', reportId, report);
     res.send(upgradeLegacyReportHtml(report.html));
   } catch (error: any) {
     console.error('[ReportRoutes] Export report error:', error);
@@ -540,6 +562,7 @@ router.get('/:reportId/export', (req, res) => {
 router.get('/:reportId', (req, res) => {
   try {
     const { reportId } = req.params;
+    const context = requireRequestContext(req);
 
     // Try memory cache first, then disk
     let report = getReportForContext(reportId, req);
@@ -572,6 +595,7 @@ router.get('/:reportId', (req, res) => {
     res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
     res.setHeader('Pragma', 'no-cache');
     res.setHeader('Expires', '0');
+    recordReportAudit(context, 'report.read', reportId, report);
     res.send(upgradeLegacyReportHtml(report.html));
   } catch (error: any) {
     console.error('[ReportRoutes] Get report error:', error);
@@ -605,6 +629,9 @@ router.delete('/:reportId', (req, res) => {
     const deletedFromCache = reportStore.delete(reportId);
     const deletedFromPersistence = deletePersistedReport(reportId);
     const deleted = deletedFromCache || deletedFromPersistence;
+    if (deleted) {
+      recordReportAudit(context, 'report.deleted', reportId, report);
+    }
 
     res.json({
       success: deleted,

--- a/backend/src/routes/simpleTraceRoutes.ts
+++ b/backend/src/routes/simpleTraceRoutes.ts
@@ -18,7 +18,10 @@ import { getTraceProcessorService } from '../services/traceProcessorService';
 import { getPortPool } from '../services/portPool';
 import { TraceProcessorFactory, type TraceProcessorRuntimeStats } from '../services/workingTraceProcessor';
 import { openEnterpriseDb } from '../services/enterpriseDb';
-import { recordEnterpriseAuditEvent } from '../services/enterpriseAuditService';
+import {
+  recordEnterpriseAuditEvent,
+  recordEnterpriseAuditEventForContext,
+} from '../services/enterpriseAuditService';
 import {
   getTraceProcessorLeaseStore,
   type TraceProcessorLeaseRecord,
@@ -216,6 +219,20 @@ function recordTraceDeleteAudit(
   } finally {
     db.close();
   }
+}
+
+function recordTraceAudit(
+  context: RequestContext,
+  action: 'trace.uploaded' | 'trace.read' | 'trace.deleted',
+  traceId: string,
+  metadata: Record<string, unknown>,
+): void {
+  recordEnterpriseAuditEventForContext(context, {
+    action,
+    resourceType: 'trace',
+    resourceId: traceId,
+    metadata,
+  });
 }
 
 function summarizeLeaseBlockers(leases: TraceProcessorLeaseRecord[]): Array<{
@@ -472,6 +489,7 @@ async function finalizeTraceUpload(
   size: number,
   finalPath: string,
   context: RequestContext,
+  uploadSource: 'local' | 'url',
 ): Promise<FinalizedTraceUploadInfo | undefined> {
   const tps = getTraceProcessorService();
 
@@ -491,6 +509,11 @@ async function finalizeTraceUpload(
   };
   await writeTraceMetadata(metadata);
   console.log(`[TraceProcessor] Created metadata for trace: ${traceId}`);
+  recordTraceAudit(context, 'trace.uploaded', traceId, {
+    filename,
+    size,
+    uploadSource,
+  });
 
   if (tps) {
     try {
@@ -662,7 +685,7 @@ router.post(
       console.log(`File uploaded successfully: ${file.originalname} -> ${traceId}`);
 
       // Get trace status and processor port from service
-      const traceInfo = await finalizeTraceUpload(traceId, file.originalname, file.size, finalPath, context);
+      const traceInfo = await finalizeTraceUpload(traceId, file.originalname, file.size, finalPath, context, 'local');
 
       res.json({
         success: true,
@@ -761,7 +784,7 @@ router.post('/upload-url', async (req, res) => {
 
     console.log(`URL trace fetched successfully: ${rawUrl} -> ${traceId}`);
 
-    const traceInfo = await finalizeTraceUpload(traceId, filename, size, finalPath, context);
+    const traceInfo = await finalizeTraceUpload(traceId, filename, size, finalPath, context, 'url');
 
     res.json({
       success: true,
@@ -1059,6 +1082,11 @@ router.get('/:id', async (req, res) => {
 
     const sessionId = typeof req.query.sessionId === 'string' ? req.query.sessionId : undefined;
     const lease = traceInfo?.port ? acquireFrontendTraceLease(context, id, sessionId) : null;
+    recordTraceAudit(context, 'trace.read', id, {
+      filename: metadata.filename,
+      size: metadata.size,
+      hasProcessor: Boolean(traceInfo?.processor),
+    });
 
     res.json({
       success: true,
@@ -1135,6 +1163,10 @@ router.delete('/:id', async (req, res) => {
 
     await deleteTraceMetadata(id);
     console.log(`[Traces] Metadata deleted for ${id}`);
+    recordTraceAudit(context, 'trace.deleted', id, {
+      filename: metadata.filename,
+      size: metadata.size,
+    });
 
     console.log(`[Traces] Trace ${id} fully deleted`);
     res.json({ success: true, message: 'Trace deleted successfully' });

--- a/backend/src/services/enterpriseAuditService.ts
+++ b/backend/src/services/enterpriseAuditService.ts
@@ -4,6 +4,9 @@
 
 import crypto from 'crypto';
 import type Database from 'better-sqlite3';
+import { resolveFeatureConfig } from '../config';
+import type { RequestContext } from '../middleware/auth';
+import { openEnterpriseDb } from './enterpriseDb';
 
 export interface EnterpriseAuditInput {
   tenantId: string;
@@ -24,10 +27,49 @@ export interface EnterpriseAuditRow {
   actor_user_id: string | null;
 }
 
+export interface EnterpriseRequestContextAuditInput {
+  action: string;
+  resourceType: string;
+  resourceId?: string;
+  workspaceId?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+function ensureAuditGraph(db: Database.Database, input: EnterpriseAuditInput): void {
+  const now = Date.now();
+  db.prepare(`
+    INSERT OR IGNORE INTO organizations (id, name, status, plan, created_at, updated_at)
+    VALUES (?, ?, 'active', 'enterprise', ?, ?)
+  `).run(input.tenantId, input.tenantId, now, now);
+
+  if (input.workspaceId) {
+    db.prepare(`
+      INSERT OR IGNORE INTO workspaces (id, tenant_id, name, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(input.workspaceId, input.tenantId, input.workspaceId, now, now);
+  }
+
+  if (input.actorUserId) {
+    db.prepare(`
+      INSERT OR IGNORE INTO users (id, tenant_id, email, display_name, idp_subject, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      input.actorUserId,
+      input.tenantId,
+      `${input.actorUserId}@audit.local`,
+      input.actorUserId,
+      `audit:${input.tenantId}:${input.actorUserId}`,
+      now,
+      now,
+    );
+  }
+}
+
 export function recordEnterpriseAuditEvent(
   db: Database.Database,
   input: EnterpriseAuditInput,
 ): void {
+  ensureAuditGraph(db, input);
   db.prepare(`
     INSERT INTO audit_events
       (id, tenant_id, workspace_id, actor_user_id, action, resource_type, resource_id, metadata_json, created_at)
@@ -43,6 +85,32 @@ export function recordEnterpriseAuditEvent(
     input.metadata ? JSON.stringify(input.metadata) : null,
     Date.now(),
   );
+}
+
+export function recordEnterpriseAuditEventForContext(
+  context: RequestContext,
+  input: EnterpriseRequestContextAuditInput,
+): boolean {
+  if (!resolveFeatureConfig().enterprise) return false;
+
+  const db = openEnterpriseDb();
+  try {
+    recordEnterpriseAuditEvent(db, {
+      tenantId: context.tenantId,
+      workspaceId: input.workspaceId === undefined ? context.workspaceId : input.workspaceId ?? undefined,
+      actorUserId: context.userId,
+      action: input.action,
+      resourceType: input.resourceType,
+      resourceId: input.resourceId,
+      metadata: input.metadata,
+    });
+    return true;
+  } catch (error) {
+    console.warn('[EnterpriseAudit] Failed to record audit event:', (error as Error).message);
+    return false;
+  } finally {
+    db.close();
+  }
 }
 
 export function listEnterpriseAuditEvents(db: Database.Database): EnterpriseAuditRow[] {

--- a/backend/src/services/providerManager/__tests__/providerRoutes.test.ts
+++ b/backend/src/services/providerManager/__tests__/providerRoutes.test.ts
@@ -1,11 +1,28 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import { jest } from '@jest/globals';
 import request from 'supertest';
 import express from 'express';
 import { promises as fsp } from 'fs';
 import os from 'os';
 import path from 'path';
+import { ENTERPRISE_FEATURE_FLAG_ENV } from '../../../config';
+import { listEnterpriseAuditEvents } from '../../enterpriseAuditService';
+import { ENTERPRISE_DB_PATH_ENV, openEnterpriseDb } from '../../enterpriseDb';
+import {
+  SECRET_STORE_ALLOW_LOCAL_MASTER_KEY_ENV,
+  SECRET_STORE_DIR_ENV,
+} from '../localSecretStore';
 import { resetProviderService } from '../index';
+
+const originalEnv = {
+  enterprise: process.env[ENTERPRISE_FEATURE_FLAG_ENV],
+  trustedHeaders: process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS,
+  enterpriseDbPath: process.env[ENTERPRISE_DB_PATH_ENV],
+  secretStoreDir: process.env[SECRET_STORE_DIR_ENV],
+  allowLocalMasterKey: process.env[SECRET_STORE_ALLOW_LOCAL_MASTER_KEY_ENV],
+  apiKey: process.env.SMARTPERFETTO_API_KEY,
+};
 
 describe('Provider Routes', () => {
   let app: express.Express;
@@ -25,9 +42,42 @@ describe('Provider Routes', () => {
 
   afterEach(async () => {
     delete process.env.PROVIDER_DATA_DIR_OVERRIDE;
+    restoreEnvValue(ENTERPRISE_FEATURE_FLAG_ENV, originalEnv.enterprise);
+    restoreEnvValue('SMARTPERFETTO_SSO_TRUSTED_HEADERS', originalEnv.trustedHeaders);
+    restoreEnvValue(ENTERPRISE_DB_PATH_ENV, originalEnv.enterpriseDbPath);
+    restoreEnvValue(SECRET_STORE_DIR_ENV, originalEnv.secretStoreDir);
+    restoreEnvValue(SECRET_STORE_ALLOW_LOCAL_MASTER_KEY_ENV, originalEnv.allowLocalMasterKey);
+    restoreEnvValue('SMARTPERFETTO_API_KEY', originalEnv.apiKey);
     resetProviderService();
     await fsp.rm(dir, { recursive: true, force: true });
   });
+
+  function restoreEnvValue(key: string, value: string | undefined): void {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  function ssoHeaders(req: request.Test): request.Test {
+    return req
+      .set('X-SmartPerfetto-SSO-User-Id', 'provider-admin')
+      .set('X-SmartPerfetto-SSO-Email', 'provider-admin@example.test')
+      .set('X-SmartPerfetto-SSO-Tenant-Id', 'tenant-a')
+      .set('X-SmartPerfetto-SSO-Workspace-Id', 'workspace-a')
+      .set('X-SmartPerfetto-SSO-Roles', 'workspace_admin')
+      .set('X-SmartPerfetto-SSO-Scopes', 'provider:write,audit:read');
+  }
+
+  function readEnterpriseAuditActions(dbPath: string): string[] {
+    const db = openEnterpriseDb(dbPath);
+    try {
+      return listEnterpriseAuditEvents(db).map(event => event.action);
+    } finally {
+      db.close();
+    }
+  }
 
   it('GET /api/v1/providers returns empty list initially', async () => {
     const res = await request(app).get('/api/v1/providers');
@@ -121,5 +171,66 @@ describe('Provider Routes', () => {
 
     expect(runtimeRes.status).toBe(400);
     expect(runtimeRes.body.error).toMatch(/does not support openai-agents-sdk/);
+  });
+
+  it('records enterprise audit events for provider management actions', async () => {
+    const dbPath = path.join(dir, 'enterprise.sqlite');
+    process.env[ENTERPRISE_FEATURE_FLAG_ENV] = 'true';
+    process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS = 'true';
+    process.env[ENTERPRISE_DB_PATH_ENV] = dbPath;
+    process.env[SECRET_STORE_DIR_ENV] = path.join(dir, 'secrets');
+    process.env[SECRET_STORE_ALLOW_LOCAL_MASTER_KEY_ENV] = 'true';
+    delete process.env.SMARTPERFETTO_API_KEY;
+    resetProviderService();
+
+    const createRes = await ssoHeaders(request(app).post('/api/v1/providers')).send({
+      name: 'Audited DeepSeek',
+      category: 'official',
+      type: 'deepseek',
+      models: { primary: 'deepseek-v4-pro', light: 'deepseek-v4-flash' },
+      connection: {
+        apiKey: 'sk-deepseek-audit',
+        agentRuntime: 'claude-agent-sdk',
+        claudeBaseUrl: 'https://api.deepseek.com/anthropic',
+        openaiBaseUrl: 'https://api.deepseek.com/v1',
+      },
+    });
+    expect(createRes.status).toBe(201);
+    const id = createRes.body.provider.id;
+
+    expect(await ssoHeaders(request(app).get(`/api/v1/providers/${id}`))).toHaveProperty('status', 200);
+    expect(await ssoHeaders(request(app).patch(`/api/v1/providers/${id}`)).send({
+      name: 'Audited DeepSeek Updated',
+    })).toHaveProperty('status', 200);
+    expect(await ssoHeaders(request(app).post(`/api/v1/providers/${id}/activate`))).toHaveProperty('status', 200);
+    expect(await ssoHeaders(request(app).post(`/api/v1/providers/${id}/runtime`)).send({
+      agentRuntime: 'openai-agents-sdk',
+    })).toHaveProperty('status', 200);
+    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    try {
+      expect(await ssoHeaders(request(app).post(`/api/v1/providers/${id}/test`))).toHaveProperty('status', 200);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+    expect(await ssoHeaders(request(app).post(`/api/v1/providers/${id}/rotate-secret`))).toHaveProperty('status', 200);
+    expect(await ssoHeaders(request(app).post('/api/v1/providers/deactivate'))).toHaveProperty('status', 200);
+    expect(await ssoHeaders(request(app).delete(`/api/v1/providers/${id}`))).toHaveProperty('status', 200);
+
+    expect(readEnterpriseAuditActions(dbPath)).toEqual(expect.arrayContaining([
+      'provider.created',
+      'provider.read',
+      'provider.updated',
+      'provider.activated',
+      'provider.runtime_switched',
+      'provider.connection_tested',
+      'provider.secret_rotated',
+      'provider.deactivated',
+      'provider.deleted',
+    ]));
   });
 });

--- a/docs/features/enterprise-multi-tenant/README.md
+++ b/docs/features/enterprise-multi-tenant/README.md
@@ -76,7 +76,7 @@
 
 ### 0.5 主线 D：控制面与合规（§18）
 - [ ] 5.1 tenant / workspace / member / provider / quota 管理 UI 与后端 API
-- [ ] 5.2 `audit_events` 表 + 关键操作埋点（trace / report / provider / memory / cleanup / delete / promote）
+- [x] 5.2 `audit_events` 表 + 关键操作埋点（trace / report / provider / memory / cleanup / delete / promote）
 - [ ] 5.3 配额 / 预算 / retention policy（§16.1，含 quota_exceeded 终态）
 - [ ] 5.4 Tenant export bundle（§16.2，含 SHA256 + tenant identity proof）
 - [ ] 5.5 Tenant tombstone + 7 天硬删窗口 + async purge + audit proof（§16.3）


### PR DESCRIPTION
## Summary
- add request-context enterprise audit recording helper with minimal graph bootstrapping for audit FK integrity
- record audit_events for trace upload/read/delete, report read/export/delete, provider lifecycle/secret/runtime/test actions, and memory promote/delete
- cover the new audit actions in route tests and mark enterprise multi-tenant README §0.5.2 complete

## Verification
- cd backend && PATH="/Users/chris/.nvm/versions/node/v24.15.0/bin:/Users/chris/.codex/tmp/arg0/codex-arg0Ggjp4H:/Users/chris/.nvm/versions/node/v20.19.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.config/kaku/zsh/bin:/Users/chris/.opencode/bin:/Users/chris/.bun/bin:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.nvm/versions/node/v20.19.0/bin:/opt/homebrew/share/google-cloud-sdk/bin:/Users/chris/.local/bin:/Users/chris/.local/bin:/Users/chris/.codeium/windsurf/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/chris/.cargo/bin:/Users/chris/tools/Android-sdk/platform-tools/:/Users/chris/tools/TTDeDroid/bin:/Users/chris/tools/depot_tools:/Users/chris/tools/flutter/flutter/bin:/Applications/Warp.app/Contents/Resources/bin" npx jest --runInBand --forceExit src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts src/routes/__tests__/enterpriseReportRoutes.test.ts src/routes/__tests__/memoryRoutes.test.ts src/services/providerManager/__tests__/providerRoutes.test.ts src/services/__tests__/enterpriseSchema.test.ts src/routes/__tests__/enterpriseApiKeyRoutes.test.ts src/routes/__tests__/enterpriseAuthRoutes.test.ts src/services/providerManager/__tests__/enterpriseProviderStore.test.ts
- cd backend && PATH="/Users/chris/.nvm/versions/node/v24.15.0/bin:/Users/chris/.codex/tmp/arg0/codex-arg0Ggjp4H:/Users/chris/.nvm/versions/node/v20.19.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.config/kaku/zsh/bin:/Users/chris/.opencode/bin:/Users/chris/.bun/bin:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.nvm/versions/node/v20.19.0/bin:/opt/homebrew/share/google-cloud-sdk/bin:/Users/chris/.local/bin:/Users/chris/.local/bin:/Users/chris/.codeium/windsurf/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/chris/.cargo/bin:/Users/chris/tools/Android-sdk/platform-tools/:/Users/chris/tools/TTDeDroid/bin:/Users/chris/tools/depot_tools:/Users/chris/tools/flutter/flutter/bin:/Applications/Warp.app/Contents/Resources/bin" npm run typecheck
- git diff --check
- cd backend && PATH="/Users/chris/.nvm/versions/node/v24.15.0/bin:/Users/chris/.codex/tmp/arg0/codex-arg0Ggjp4H:/Users/chris/.nvm/versions/node/v20.19.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.config/kaku/zsh/bin:/Users/chris/.opencode/bin:/Users/chris/.bun/bin:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.nvm/versions/node/v20.19.0/bin:/opt/homebrew/share/google-cloud-sdk/bin:/Users/chris/.local/bin:/Users/chris/.local/bin:/Users/chris/.codeium/windsurf/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/chris/.cargo/bin:/Users/chris/tools/Android-sdk/platform-tools/:/Users/chris/tools/TTDeDroid/bin:/Users/chris/tools/depot_tools:/Users/chris/tools/flutter/flutter/bin:/Applications/Warp.app/Contents/Resources/bin" npm run test:scene-trace-regression
- PATH="/Users/chris/.nvm/versions/node/v24.15.0/bin:/Users/chris/.codex/tmp/arg0/codex-arg0Ggjp4H:/Users/chris/.nvm/versions/node/v20.19.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.config/kaku/zsh/bin:/Users/chris/.opencode/bin:/Users/chris/.bun/bin:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.nvm/versions/node/v20.19.0/bin:/opt/homebrew/share/google-cloud-sdk/bin:/Users/chris/.local/bin:/Users/chris/.local/bin:/Users/chris/.codeium/windsurf/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/chris/.cargo/bin:/Users/chris/tools/Android-sdk/platform-tools/:/Users/chris/tools/TTDeDroid/bin:/Users/chris/tools/depot_tools:/Users/chris/tools/flutter/flutter/bin:/Applications/Warp.app/Contents/Resources/bin" npm run verify:pr