### PR TITLE
feat(enterprise): add tenant tombstone purge flow

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -37,6 +37,7 @@ import caseRoutes from './routes/caseRoutes';
 import ragAdminRoutes from './routes/ragAdminRoutes';
 import enterpriseAuthRoutes from './routes/enterpriseAuthRoutes';
 import enterpriseApiKeyRoutes from './routes/enterpriseApiKeyRoutes';
+import enterpriseTenantRoutes from './routes/enterpriseTenantRoutes';
 import traceProcessorProxyRoutes, { handleTraceProcessorProxyUpgrade } from './routes/traceProcessorProxyRoutes';
 import {authenticate} from './middleware/auth';
 import {
@@ -161,6 +162,7 @@ app.get('/debug', (req, res) => {
 app.use('/api/sql', sqlRoutes);
 app.use('/api/auth', enterpriseAuthRoutes);
 app.use('/api/auth', enterpriseApiKeyRoutes);
+app.use('/api/tenant', enterpriseTenantRoutes);
 app.use(
   '/api/workspaces/:workspaceId/traces',
   ...workspaceRouteContextMiddleware,

--- a/backend/src/routes/__tests__/agentRoutesRbac.test.ts
+++ b/backend/src/routes/__tests__/agentRoutesRbac.test.ts
@@ -9,7 +9,7 @@ import os from 'os';
 import path from 'path';
 import request from 'supertest';
 import { ENTERPRISE_FEATURE_FLAG_ENV } from '../../config';
-import { ENTERPRISE_DB_PATH_ENV } from '../../services/enterpriseDb';
+import { ENTERPRISE_DB_PATH_ENV, openEnterpriseDb } from '../../services/enterpriseDb';
 import { ENTERPRISE_DATA_DIR_ENV, writeTraceMetadata } from '../../services/traceMetadataStore';
 import {
   persistSerializedAgentEvent,
@@ -97,6 +97,49 @@ describe('agent route RBAC', () => {
     expect(res.status).toBe(403);
     expect(res.body.error).toBe('Forbidden');
     expect(res.body.details).toContain('agent:run');
+  });
+
+  it('rejects analyze requests after tenant tombstone before trace access is evaluated', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'smartperfetto-agent-tombstone-'));
+    try {
+      delete process.env.SMARTPERFETTO_API_KEY;
+      process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS = 'true';
+      process.env[ENTERPRISE_FEATURE_FLAG_ENV] = 'true';
+      process.env[ENTERPRISE_DB_PATH_ENV] = path.join(tmpDir, 'enterprise.sqlite');
+      process.env[ENTERPRISE_DATA_DIR_ENV] = path.join(tmpDir, 'data');
+
+      const db = openEnterpriseDb();
+      const now = Date.now();
+      try {
+        db.prepare(`
+          INSERT INTO organizations (id, name, status, plan, created_at, updated_at)
+          VALUES ('tenant-a', 'Tenant A', 'tombstoned', 'enterprise', ?, ?)
+        `).run(now, now);
+        db.prepare(`
+          INSERT INTO tenant_tombstones
+            (tenant_id, requested_by, requested_at, purge_after, status, proof_hash)
+          VALUES
+            ('tenant-a', NULL, ?, ?, 'tombstoned', NULL)
+        `).run(now, now + 7 * 24 * 60 * 60 * 1000);
+      } finally {
+        db.close();
+      }
+      const traceService = { getOrLoadTrace: jest.fn() };
+      setTraceProcessorServiceForTests(traceService as any);
+
+      const res = await analystHeaders(request(makeApp()).post('/api/agent/v1/analyze'))
+        .send({ traceId: 'trace-a', query: 'analyze this trace' });
+
+      expect(res.status).toBe(423);
+      expect(res.body).toEqual(expect.objectContaining({
+        success: false,
+        code: 'TENANT_TOMBSTONED',
+        status: 'tombstoned',
+      }));
+      expect(traceService.getOrLoadTrace).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it('rejects analyze when the scoped trace processor lease is draining', async () => {

--- a/backend/src/routes/__tests__/enterpriseTenantRoutes.test.ts
+++ b/backend/src/routes/__tests__/enterpriseTenantRoutes.test.ts
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 Gracker (Chris)
+// This file is part of SmartPerfetto. See LICENSE for details.
+
+import express from 'express';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import request from 'supertest';
+
+import { ENTERPRISE_FEATURE_FLAG_ENV } from '../../config';
+import { ENTERPRISE_DB_PATH_ENV, openEnterpriseDb } from '../../services/enterpriseDb';
+import {
+  evaluateTenantMutationPolicy,
+} from '../../services/enterpriseTenantLifecycleService';
+import { ENTERPRISE_DATA_DIR_ENV } from '../../services/traceMetadataStore';
+import tenantRoutes, { resetTenantPurgeJobsForTests } from '../enterpriseTenantRoutes';
+
+const originalEnv = {
+  enterprise: process.env[ENTERPRISE_FEATURE_FLAG_ENV],
+  trustedHeaders: process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS,
+  enterpriseDbPath: process.env[ENTERPRISE_DB_PATH_ENV],
+  enterpriseDataDir: process.env[ENTERPRISE_DATA_DIR_ENV],
+  apiKey: process.env.SMARTPERFETTO_API_KEY,
+};
+
+let tmpDir: string;
+let dbPath: string;
+let dataDir: string;
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/tenant', tenantRoutes);
+  return app;
+}
+
+function restoreEnvValue(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+function adminHeaders(req: request.Test): request.Test {
+  return req
+    .set('X-SmartPerfetto-SSO-User-Id', 'admin-a')
+    .set('X-SmartPerfetto-SSO-Email', 'admin-a@example.test')
+    .set('X-SmartPerfetto-SSO-Tenant-Id', 'tenant-a')
+    .set('X-SmartPerfetto-SSO-Workspace-Id', 'workspace-a')
+    .set('X-SmartPerfetto-SSO-Roles', 'org_admin')
+    .set('X-SmartPerfetto-SSO-Scopes', 'report:read');
+}
+
+function analystHeaders(req: request.Test): request.Test {
+  return req
+    .set('X-SmartPerfetto-SSO-User-Id', 'analyst-a')
+    .set('X-SmartPerfetto-SSO-Email', 'analyst-a@example.test')
+    .set('X-SmartPerfetto-SSO-Tenant-Id', 'tenant-a')
+    .set('X-SmartPerfetto-SSO-Workspace-Id', 'workspace-a')
+    .set('X-SmartPerfetto-SSO-Roles', 'analyst')
+    .set('X-SmartPerfetto-SSO-Scopes', 'trace:read,agent:run');
+}
+
+function readTenantRow(): { status: string } | null {
+  const db = openEnterpriseDb(dbPath);
+  try {
+    return db.prepare<unknown[], { status: string }>(`
+      SELECT status
+      FROM organizations
+      WHERE id = 'tenant-a'
+    `).get() ?? null;
+  } finally {
+    db.close();
+  }
+}
+
+function readTombstone(): {
+  status: string;
+  proof_hash: string | null;
+  purge_after: number;
+} | null {
+  const db = openEnterpriseDb(dbPath);
+  try {
+    return db.prepare<unknown[], {
+      status: string;
+      proof_hash: string | null;
+      purge_after: number;
+    }>(`
+      SELECT status, proof_hash, purge_after
+      FROM tenant_tombstones
+      WHERE tenant_id = 'tenant-a'
+    `).get() ?? null;
+  } finally {
+    db.close();
+  }
+}
+
+function readCount(table: string, where = "tenant_id = 'tenant-a'"): number {
+  const db = openEnterpriseDb(dbPath);
+  try {
+    const row = db.prepare<unknown[], { count: number }>(`
+      SELECT COUNT(*) AS count
+      FROM ${table}
+      WHERE ${where}
+    `).get();
+    return row?.count ?? 0;
+  } finally {
+    db.close();
+  }
+}
+
+async function waitForPurgeJob(
+  app: express.Express,
+  jobId: string,
+): Promise<request.Response> {
+  let last: request.Response | undefined;
+  for (let attempt = 0; attempt < 20; attempt++) {
+    last = await adminHeaders(request(app).get(`/api/tenant/purge/${jobId}`));
+    if (last.body.job.status !== 'running') return last;
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  return last!;
+}
+
+async function seedTenantData(): Promise<void> {
+  const tenantDir = path.join(dataDir, 'tenant-a', 'workspace-a', 'traces');
+  await fs.mkdir(tenantDir, { recursive: true });
+  await fs.writeFile(path.join(tenantDir, 'trace-a.trace'), 'trace');
+
+  const now = 1_800_000_000_000;
+  const db = openEnterpriseDb(dbPath);
+  try {
+    db.prepare(`
+      INSERT INTO organizations (id, name, status, plan, created_at, updated_at)
+      VALUES ('tenant-a', 'Tenant A', 'active', 'enterprise', ?, ?)
+    `).run(now, now);
+    db.prepare(`
+      INSERT INTO workspaces (id, tenant_id, name, created_at, updated_at)
+      VALUES ('workspace-a', 'tenant-a', 'Workspace A', ?, ?)
+    `).run(now, now);
+    db.prepare(`
+      INSERT INTO users (id, tenant_id, email, display_name, idp_subject, created_at, updated_at)
+      VALUES ('admin-a', 'tenant-a', 'admin-a@example.test', 'Admin A', 'sso:admin-a', ?, ?)
+    `).run(now, now);
+    db.prepare(`
+      INSERT INTO trace_assets
+        (id, tenant_id, workspace_id, owner_user_id, local_path, sha256, size_bytes, status, created_at)
+      VALUES
+        ('trace-a', 'tenant-a', 'workspace-a', 'admin-a', ?, 'sha-a', 5, 'ready', ?)
+    `).run(path.join(tenantDir, 'trace-a.trace'), now);
+    db.prepare(`
+      INSERT INTO analysis_sessions
+        (id, tenant_id, workspace_id, trace_id, created_by, title, visibility, status, created_at, updated_at)
+      VALUES
+        ('session-a', 'tenant-a', 'workspace-a', 'trace-a', 'admin-a', 'Session A', 'private', 'completed', ?, ?)
+    `).run(now, now);
+    db.prepare(`
+      INSERT INTO analysis_runs
+        (id, tenant_id, workspace_id, session_id, mode, status, question, started_at, completed_at)
+      VALUES
+        ('run-a', 'tenant-a', 'workspace-a', 'session-a', 'quick', 'completed', 'q', ?, ?)
+    `).run(now, now + 1);
+    db.prepare(`
+      INSERT INTO memory_entries
+        (id, tenant_id, workspace_id, scope, source_run_id, content_json, created_at, updated_at)
+      VALUES
+        ('memory-a', 'tenant-a', 'workspace-a', 'baseline', 'run-a', '{"ok":true}', ?, ?)
+    `).run(now, now);
+    db.prepare(`
+      INSERT INTO provider_snapshots
+        (id, tenant_id, provider_id, snapshot_hash, runtime_kind, resolved_config_json, created_at)
+      VALUES
+        ('snapshot-a', 'tenant-a', 'provider-a', 'hash-a', 'openai-agents-sdk', '{}', ?)
+    `).run(now);
+  } finally {
+    db.close();
+  }
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'smartperfetto-tenant-lifecycle-'));
+  dbPath = path.join(tmpDir, 'enterprise.sqlite');
+  dataDir = path.join(tmpDir, 'data');
+  process.env[ENTERPRISE_FEATURE_FLAG_ENV] = 'true';
+  process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS = 'true';
+  process.env[ENTERPRISE_DB_PATH_ENV] = dbPath;
+  process.env[ENTERPRISE_DATA_DIR_ENV] = dataDir;
+  delete process.env.SMARTPERFETTO_API_KEY;
+  resetTenantPurgeJobsForTests();
+});
+
+afterEach(async () => {
+  resetTenantPurgeJobsForTests();
+  restoreEnvValue(ENTERPRISE_FEATURE_FLAG_ENV, originalEnv.enterprise);
+  restoreEnvValue('SMARTPERFETTO_SSO_TRUSTED_HEADERS', originalEnv.trustedHeaders);
+  restoreEnvValue(ENTERPRISE_DB_PATH_ENV, originalEnv.enterpriseDbPath);
+  restoreEnvValue(ENTERPRISE_DATA_DIR_ENV, originalEnv.enterpriseDataDir);
+  restoreEnvValue('SMARTPERFETTO_API_KEY', originalEnv.apiKey);
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('enterprise tenant lifecycle routes', () => {
+  it('creates a tenant tombstone, records audit state, and blocks new work', async () => {
+    const app = makeApp();
+
+    const denied = await adminHeaders(request(app).post('/api/tenant/tombstone')).send({});
+    expect(denied.status).toBe(400);
+
+    const res = await adminHeaders(request(app).post('/api/tenant/tombstone')).send({
+      confirmTenantId: 'tenant-a',
+      reason: 'customer requested deletion',
+    });
+
+    expect(res.status).toBe(202);
+    expect(res.body.tombstone).toEqual(expect.objectContaining({
+      tenantId: 'tenant-a',
+      requestedBy: 'admin-a',
+      status: 'tombstoned',
+      proofHash: null,
+    }));
+    expect(readTenantRow()?.status).toBe('tombstoned');
+
+    const db = openEnterpriseDb(dbPath);
+    try {
+      const audit = db.prepare<unknown[], { action: string }>(`
+        SELECT action
+        FROM audit_events
+        WHERE tenant_id = 'tenant-a' AND action = 'tenant.tombstoned'
+      `).get();
+      expect(audit?.action).toBe('tenant.tombstoned');
+    } finally {
+      db.close();
+    }
+
+    const decision = evaluateTenantMutationPolicy({
+      tenantId: 'tenant-a',
+      workspaceId: 'workspace-a',
+      userId: 'admin-a',
+      authType: 'sso',
+      roles: ['org_admin'],
+      scopes: ['*'],
+      requestId: 'req-test',
+    });
+    expect(decision.allowed).toBe(false);
+    expect(decision.httpStatus).toBe(423);
+  });
+
+  it('rejects tombstone from non-admin users', async () => {
+    const app = makeApp();
+
+    const res = await analystHeaders(request(app).post('/api/tenant/tombstone')).send({
+      confirmTenantId: 'tenant-a',
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body.details).toBe('Tenant deletion requires org_admin or tenant:delete scope');
+  });
+
+  it('runs async purge after the seven-day window and keeps a proof hash', async () => {
+    await seedTenantData();
+    const app = makeApp();
+
+    await adminHeaders(request(app).post('/api/tenant/tombstone')).send({
+      confirmTenantId: 'tenant-a',
+    }).expect(202);
+    const windowRes = await adminHeaders(request(app).post('/api/tenant/purge')).send({
+      confirmTenantId: 'tenant-a',
+    });
+    expect(windowRes.status).toBe(409);
+    expect(windowRes.body.code).toBe('TENANT_PURGE_WINDOW_ACTIVE');
+
+    const db = openEnterpriseDb(dbPath);
+    try {
+      db.prepare(`
+        UPDATE tenant_tombstones
+        SET purge_after = ?
+        WHERE tenant_id = 'tenant-a'
+      `).run(Date.now() - 1);
+    } finally {
+      db.close();
+    }
+
+    const enqueueRes = await adminHeaders(request(app).post('/api/tenant/purge')).send({
+      confirmTenantId: 'tenant-a',
+    });
+    expect(enqueueRes.status).toBe(202);
+    const jobRes = await waitForPurgeJob(app, enqueueRes.body.jobId);
+
+    expect(jobRes.body.job.status).toBe('completed');
+    expect(jobRes.body.job.proof).toEqual(expect.objectContaining({
+      tenantId: 'tenant-a',
+      purgedBy: 'admin-a',
+      proofHash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      dataPathRemoved: true,
+    }));
+    await expect(fs.access(path.join(dataDir, 'tenant-a'))).rejects.toThrow();
+    expect(readTombstone()).toEqual(expect.objectContaining({
+      status: 'purged',
+      proof_hash: jobRes.body.job.proof.proofHash,
+    }));
+    expect(readTenantRow()?.status).toBe('purged');
+    expect(readCount('workspaces')).toBe(0);
+    expect(readCount('trace_assets')).toBe(0);
+    expect(readCount('analysis_runs')).toBe(0);
+    expect(readCount('memory_entries')).toBe(0);
+    expect(readCount('provider_snapshots')).toBe(0);
+    expect(readCount('audit_events')).toBeGreaterThan(0);
+  });
+
+  it('blocks purge while tenant runs or leases are still active', async () => {
+    await seedTenantData();
+    const db = openEnterpriseDb(dbPath);
+    try {
+      db.prepare(`
+        UPDATE analysis_runs
+        SET status = 'running'
+        WHERE id = 'run-a'
+      `).run();
+    } finally {
+      db.close();
+    }
+    const app = makeApp();
+    await adminHeaders(request(app).post('/api/tenant/tombstone')).send({
+      confirmTenantId: 'tenant-a',
+    }).expect(202);
+    const updateDb = openEnterpriseDb(dbPath);
+    try {
+      updateDb.prepare(`
+        UPDATE tenant_tombstones
+        SET purge_after = ?
+        WHERE tenant_id = 'tenant-a'
+      `).run(Date.now() - 1);
+    } finally {
+      updateDb.close();
+    }
+
+    const enqueueRes = await adminHeaders(request(app).post('/api/tenant/purge')).send({
+      confirmTenantId: 'tenant-a',
+    });
+    const jobRes = await waitForPurgeJob(app, enqueueRes.body.jobId);
+
+    expect(jobRes.body.job.status).toBe('blocked');
+    expect(jobRes.body.job.blockers).toEqual([
+      expect.objectContaining({
+        id: 'run-a',
+        kind: 'analysis_run',
+        status: 'running',
+      }),
+    ]);
+    expect(readTombstone()?.status).toBe('purge_blocked');
+    expect(readCount('trace_assets')).toBe(1);
+  });
+});

--- a/backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts
+++ b/backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts
@@ -200,6 +200,25 @@ function writeWorkspacePolicies(input: {
   }
 }
 
+function writeTenantTombstone(): void {
+  const db = openEnterpriseDb(dbPath);
+  const now = Date.now();
+  try {
+    db.prepare(`
+      INSERT OR IGNORE INTO organizations (id, name, status, plan, created_at, updated_at)
+      VALUES ('tenant-a', 'tenant-a', 'tombstoned', 'enterprise', ?, ?)
+    `).run(now, now);
+    db.prepare(`
+      INSERT INTO tenant_tombstones
+        (tenant_id, requested_by, requested_at, purge_after, status, proof_hash)
+      VALUES
+        ('tenant-a', NULL, ?, ?, 'tombstoned', NULL)
+    `).run(now, now + 7 * 24 * 60 * 60 * 1000);
+  } finally {
+    db.close();
+  }
+}
+
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'smartperfetto-enterprise-trace-routes-'));
   dbPath = path.join(tmpDir, 'enterprise.sqlite');
@@ -348,6 +367,26 @@ describe('enterprise trace metadata routes', () => {
       success: false,
       code: 'TRACE_SIZE_QUOTA_EXCEEDED',
       status: 'quota_exceeded',
+    }));
+    expect(readCount('trace_assets')).toBe(0);
+    expect(fakeTraceProcessorService.initializeUploadWithId).not.toHaveBeenCalled();
+  });
+
+  it('rejects uploads after tenant tombstone before metadata is committed', async () => {
+    const app = makeApp();
+    writeTenantTombstone();
+
+    const res = await ssoHeaders(
+      request(app)
+        .post('/api/traces/upload')
+        .attach('file', Buffer.from('trace'), 'tombstoned.trace'),
+    );
+
+    expect(res.status).toBe(423);
+    expect(res.body).toEqual(expect.objectContaining({
+      success: false,
+      code: 'TENANT_TOMBSTONED',
+      status: 'tombstoned',
     }));
     expect(readCount('trace_assets')).toBe(0);
     expect(fakeTraceProcessorService.initializeUploadWithId).not.toHaveBeenCalled();

--- a/backend/src/routes/agentRoutes.ts
+++ b/backend/src/routes/agentRoutes.ts
@@ -71,6 +71,10 @@ import {
   evaluateAnalysisRunQuota,
   type EnterpriseQuotaDecision,
 } from '../services/enterpriseQuotaPolicyService';
+import {
+  evaluateTenantMutationPolicy,
+  sendTenantMutationDeniedPayload,
+} from '../services/enterpriseTenantLifecycleService';
 import { estimateTraceProcessorRssBytes } from '../services/traceProcessorRamBudget';
 import { TraceProcessorFactory } from '../services/workingTraceProcessor';
 import { registerAgentLogsRoutes } from './agentLogsRoutes';
@@ -1044,6 +1048,12 @@ async function handleAnalyzeRequest(
     const requestedSessionId = requestedSessionIdOverride || bodyRequestedSessionId;
     if (!hasRbacPermission(requestContext, 'agent:run')) {
       sendForbidden(res, 'Starting analysis requires agent:run permission');
+      return;
+    }
+
+    const tenantDecision = evaluateTenantMutationPolicy(requestContext);
+    if (!tenantDecision.allowed) {
+      res.status(tenantDecision.httpStatus).json(sendTenantMutationDeniedPayload(tenantDecision));
       return;
     }
 

--- a/backend/src/routes/enterpriseTenantRoutes.ts
+++ b/backend/src/routes/enterpriseTenantRoutes.ts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 Gracker (Chris)
+// This file is part of SmartPerfetto. See LICENSE for details.
+
+import { Router, type Response } from 'express';
+
+import { authenticate, requireRequestContext, type RequestContext } from '../middleware/auth';
+import { openEnterpriseDb } from '../services/enterpriseDb';
+import {
+  createTenantTombstone,
+  getTenantTombstone,
+  purgeTenantNow,
+  TenantPurgeBlockedError,
+  TenantPurgeWindowError,
+  type TenantPurgeProof,
+} from '../services/enterpriseTenantLifecycleService';
+import { sendForbidden } from '../services/rbac';
+
+interface TenantPurgeJob {
+  id: string;
+  tenantId: string;
+  status: 'running' | 'completed' | 'blocked' | 'failed';
+  createdAt: number;
+  completedAt?: number;
+  proof?: TenantPurgeProof;
+  blockers?: unknown[];
+  error?: string;
+}
+
+const router = Router();
+const tenantPurgeJobs = new Map<string, TenantPurgeJob>();
+
+function canDeleteTenant(context: RequestContext): boolean {
+  return context.scopes.includes('*')
+    || context.scopes.includes('tenant:delete')
+    || context.roles.includes('org_admin');
+}
+
+function requireTenantDeletePermission(context: RequestContext, res: Response): boolean {
+  if (canDeleteTenant(context)) return true;
+  sendForbidden(res, 'Tenant deletion requires org_admin or tenant:delete scope');
+  return false;
+}
+
+function requireTenantConfirmation(body: unknown, tenantId: string): string | null {
+  const input = body && typeof body === 'object' ? body as Record<string, unknown> : {};
+  return input.confirmTenantId === tenantId ? null : 'confirmTenantId must match the request tenant';
+}
+
+router.use(authenticate);
+
+router.post('/tombstone', (req, res) => {
+  const context = requireRequestContext(req);
+  if (!requireTenantDeletePermission(context, res)) return;
+  const confirmationError = requireTenantConfirmation(req.body, context.tenantId);
+  if (confirmationError) {
+    return res.status(400).json({ success: false, error: confirmationError });
+  }
+
+  const db = openEnterpriseDb();
+  try {
+    const reason = typeof req.body?.reason === 'string' ? req.body.reason : undefined;
+    const tombstone = createTenantTombstone(db, context, reason);
+    res.status(202).json({
+      success: true,
+      tombstone,
+    });
+  } catch (error: any) {
+    res.status(500).json({
+      success: false,
+      error: error.message || 'Failed to tombstone tenant',
+    });
+  } finally {
+    db.close();
+  }
+});
+
+router.get('/tombstone', (req, res) => {
+  const context = requireRequestContext(req);
+  if (!requireTenantDeletePermission(context, res)) return;
+
+  const db = openEnterpriseDb();
+  try {
+    res.json({
+      success: true,
+      tombstone: getTenantTombstone(db, context.tenantId),
+    });
+  } finally {
+    db.close();
+  }
+});
+
+router.post('/purge', (req, res) => {
+  const context = requireRequestContext(req);
+  if (!requireTenantDeletePermission(context, res)) return;
+  const confirmationError = requireTenantConfirmation(req.body, context.tenantId);
+  if (confirmationError) {
+    return res.status(400).json({ success: false, error: confirmationError });
+  }
+
+  const db = openEnterpriseDb();
+  try {
+    const tombstone = getTenantTombstone(db, context.tenantId);
+    if (!tombstone) {
+      return res.status(404).json({
+        success: false,
+        error: 'Tenant tombstone not found',
+      });
+    }
+    if (tombstone.purgeAfter > Date.now()) {
+      return res.status(409).json({
+        success: false,
+        code: 'TENANT_PURGE_WINDOW_ACTIVE',
+        error: 'Tenant purge window has not elapsed',
+        purgeAfter: tombstone.purgeAfter,
+      });
+    }
+  } finally {
+    db.close();
+  }
+
+  const jobId = `tenant-purge-${context.tenantId}-${Date.now()}`;
+  const job: TenantPurgeJob = {
+    id: jobId,
+    tenantId: context.tenantId,
+    status: 'running',
+    createdAt: Date.now(),
+  };
+  tenantPurgeJobs.set(jobId, job);
+  setImmediate(async () => {
+    const jobDb = openEnterpriseDb();
+    try {
+      job.proof = await purgeTenantNow(jobDb, context);
+      job.status = 'completed';
+      job.completedAt = Date.now();
+    } catch (error: any) {
+      job.completedAt = Date.now();
+      if (error instanceof TenantPurgeBlockedError) {
+        job.status = 'blocked';
+        job.blockers = error.blockers;
+      } else if (error instanceof TenantPurgeWindowError) {
+        job.status = 'failed';
+        job.error = error.message;
+      } else {
+        job.status = 'failed';
+        job.error = error.message || 'Tenant purge failed';
+      }
+    } finally {
+      jobDb.close();
+    }
+  });
+
+  res.status(202).json({
+    success: true,
+    jobId,
+    status: job.status,
+  });
+});
+
+router.get('/purge/:jobId', (req, res) => {
+  const context = requireRequestContext(req);
+  if (!requireTenantDeletePermission(context, res)) return;
+  const job = tenantPurgeJobs.get(req.params.jobId);
+  if (!job || job.tenantId !== context.tenantId) {
+    return res.status(404).json({
+      success: false,
+      error: 'Tenant purge job not found',
+    });
+  }
+  res.json({
+    success: true,
+    job,
+  });
+});
+
+export function resetTenantPurgeJobsForTests(): void {
+  tenantPurgeJobs.clear();
+}
+
+export default router;

--- a/backend/src/routes/simpleTraceRoutes.ts
+++ b/backend/src/routes/simpleTraceRoutes.ts
@@ -38,6 +38,10 @@ import {
   type EnterpriseQuotaDecision,
 } from '../services/enterpriseQuotaPolicyService';
 import {
+  evaluateTenantMutationPolicy,
+  sendTenantMutationDeniedPayload,
+} from '../services/enterpriseTenantLifecycleService';
+import {
   buildTraceOwnerMetadata,
   deleteTraceMetadata,
   getTraceFilePath,
@@ -690,6 +694,11 @@ router.post(
       }
 
       const file = req.file;
+      const tenantDecision = evaluateTenantMutationPolicy(context);
+      if (!tenantDecision.allowed) {
+        await cleanupFile(file.path);
+        return res.status(tenantDecision.httpStatus).json(sendTenantMutationDeniedPayload(tenantDecision));
+      }
       const quotaDecision = evaluateTraceUploadQuota(context, file.size);
       if (!quotaDecision.allowed) {
         await cleanupFile(file.path);
@@ -745,6 +754,10 @@ router.post('/upload-url', async (req, res) => {
     const context = requireRequestContext(req);
     if (!hasRbacPermission(context, 'trace:write')) {
       return sendForbidden(res, 'Uploading traces requires trace:write permission');
+    }
+    const tenantDecision = evaluateTenantMutationPolicy(context);
+    if (!tenantDecision.allowed) {
+      return res.status(tenantDecision.httpStatus).json(sendTenantMutationDeniedPayload(tenantDecision));
     }
     const rawUrl = typeof req.body?.url === 'string' ? req.body.url : '';
     if (!rawUrl) {

--- a/backend/src/services/enterpriseTenantLifecycleService.ts
+++ b/backend/src/services/enterpriseTenantLifecycleService.ts
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 Gracker (Chris)
+// This file is part of SmartPerfetto. See LICENSE for details.
+
+import crypto from 'crypto';
+import fs from 'fs/promises';
+import path from 'path';
+import type Database from 'better-sqlite3';
+
+import type { RequestContext } from '../middleware/auth';
+import { recordEnterpriseAuditEvent } from './enterpriseAuditService';
+import { openEnterpriseDb } from './enterpriseDb';
+import { resolveEnterpriseDataRoot } from './traceMetadataStore';
+
+const DELETE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+const SAFE_TENANT_SEGMENT_RE = /^[a-zA-Z0-9._:-]+$/;
+const ACTIVE_RUN_STATUSES = ['pending', 'running', 'awaiting_user'];
+const ACTIVE_LEASE_STATES = ['pending', 'starting', 'active', 'draining', 'restarting'];
+
+export type TenantTombstoneStatus = 'tombstoned' | 'purging' | 'purge_blocked' | 'purged';
+
+export interface TenantTombstoneRecord {
+  tenantId: string;
+  requestedBy: string | null;
+  requestedAt: number;
+  purgeAfter: number;
+  status: TenantTombstoneStatus;
+  proofHash: string | null;
+}
+
+export interface TenantMutationDecision {
+  allowed: boolean;
+  httpStatus: number;
+  code: string;
+  status: string;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export interface TenantPurgeProof {
+  tenantId: string;
+  requestedBy: string | null;
+  purgedBy: string;
+  requestedAt: number;
+  purgeAfter: number;
+  purgedAt: number;
+  deletedCounts: Record<string, number>;
+  dataPath: string;
+  dataPathRemoved: boolean;
+  proofHash: string;
+}
+
+interface TenantTombstoneRow {
+  tenant_id: string;
+  requested_by: string | null;
+  requested_at: number;
+  purge_after: number;
+  status: TenantTombstoneStatus;
+  proof_hash: string | null;
+}
+
+interface BlockerRow {
+  id: string;
+  kind: 'analysis_run' | 'trace_processor_lease';
+  status: string;
+  workspace_id: string;
+}
+
+export class TenantPurgeBlockedError extends Error {
+  constructor(readonly blockers: BlockerRow[]) {
+    super('Tenant purge is blocked by active work');
+    this.name = 'TenantPurgeBlockedError';
+  }
+}
+
+export class TenantPurgeWindowError extends Error {
+  constructor(readonly purgeAfter: number) {
+    super('Tenant purge window has not elapsed');
+    this.name = 'TenantPurgeWindowError';
+  }
+}
+
+function sha256(value: string): string {
+  return `sha256:${crypto.createHash('sha256').update(value).digest('hex')}`;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (!value || typeof value !== 'object') return value;
+  const input = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(input).sort()) {
+    const child = input[key];
+    if (child !== undefined) out[key] = canonicalize(child);
+  }
+  return out;
+}
+
+function assertSafeTenantId(tenantId: string): string {
+  if (!SAFE_TENANT_SEGMENT_RE.test(tenantId) || tenantId === '.' || tenantId === '..') {
+    throw new Error(`Unsafe tenant id: ${tenantId}`);
+  }
+  return tenantId;
+}
+
+function rowToRecord(row: TenantTombstoneRow): TenantTombstoneRecord {
+  return {
+    tenantId: row.tenant_id,
+    requestedBy: row.requested_by,
+    requestedAt: row.requested_at,
+    purgeAfter: row.purge_after,
+    status: row.status,
+    proofHash: row.proof_hash,
+  };
+}
+
+function getTenantTombstoneRow(
+  db: Database.Database,
+  tenantId: string,
+): TenantTombstoneRow | null {
+  return db.prepare<unknown[], TenantTombstoneRow>(`
+    SELECT *
+    FROM tenant_tombstones
+    WHERE tenant_id = ?
+    LIMIT 1
+  `).get(tenantId) ?? null;
+}
+
+export function getTenantTombstone(
+  db: Database.Database,
+  tenantId: string,
+): TenantTombstoneRecord | null {
+  const row = getTenantTombstoneRow(db, tenantId);
+  return row ? rowToRecord(row) : null;
+}
+
+function ensureTenantLifecycleGraph(db: Database.Database, context: RequestContext, now: number): void {
+  db.prepare(`
+    INSERT OR IGNORE INTO organizations (id, name, status, plan, created_at, updated_at)
+    VALUES (?, ?, 'active', 'enterprise', ?, ?)
+  `).run(context.tenantId, context.tenantId, now, now);
+  db.prepare(`
+    INSERT OR IGNORE INTO users (id, tenant_id, email, display_name, idp_subject, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    context.userId,
+    context.tenantId,
+    `${context.userId}@tenant.local`,
+    context.userId,
+    `tenant:${context.tenantId}:${context.userId}`,
+    now,
+    now,
+  );
+}
+
+export function createTenantTombstone(
+  db: Database.Database,
+  context: RequestContext,
+  reason?: string,
+  now = Date.now(),
+): TenantTombstoneRecord {
+  assertSafeTenantId(context.tenantId);
+  const purgeAfter = now + DELETE_WINDOW_MS;
+  const tx = db.transaction(() => {
+    ensureTenantLifecycleGraph(db, context, now);
+    db.prepare(`
+      INSERT INTO tenant_tombstones
+        (tenant_id, requested_by, requested_at, purge_after, status, proof_hash)
+      VALUES
+        (?, ?, ?, ?, 'tombstoned', NULL)
+      ON CONFLICT(tenant_id) DO UPDATE SET
+        requested_by = excluded.requested_by,
+        requested_at = excluded.requested_at,
+        purge_after = excluded.purge_after,
+        status = excluded.status,
+        proof_hash = NULL
+    `).run(context.tenantId, context.userId, now, purgeAfter);
+    db.prepare(`
+      UPDATE organizations
+      SET status = 'tombstoned', updated_at = ?
+      WHERE id = ?
+    `).run(now, context.tenantId);
+    recordEnterpriseAuditEvent(db, {
+      tenantId: context.tenantId,
+      actorUserId: context.userId,
+      action: 'tenant.tombstoned',
+      resourceType: 'tenant',
+      resourceId: context.tenantId,
+      metadata: {
+        purgeAfter,
+        reason: reason || undefined,
+        requestId: context.requestId,
+      },
+    });
+  });
+  tx();
+  return rowToRecord(getTenantTombstoneRow(db, context.tenantId)!);
+}
+
+export function evaluateTenantMutationPolicy(context: RequestContext): TenantMutationDecision {
+  const db = openEnterpriseDb();
+  try {
+    const tombstone = getTenantTombstoneRow(db, context.tenantId);
+    if (!tombstone) {
+      return {
+        allowed: true,
+        httpStatus: 200,
+        code: 'TENANT_ACTIVE',
+        status: 'active',
+        message: 'Tenant accepts new work',
+      };
+    }
+    return {
+      allowed: false,
+      httpStatus: 423,
+      code: 'TENANT_TOMBSTONED',
+      status: tombstone.status,
+      message: 'Tenant is tombstoned and does not accept new uploads or analysis runs',
+      details: {
+        tenantId: context.tenantId,
+        requestedAt: tombstone.requested_at,
+        purgeAfter: tombstone.purge_after,
+        proofHash: tombstone.proof_hash,
+      },
+    };
+  } finally {
+    db.close();
+  }
+}
+
+export function sendTenantMutationDeniedPayload(decision: TenantMutationDecision): Record<string, unknown> {
+  return {
+    success: false,
+    code: decision.code,
+    status: decision.status,
+    error: decision.message,
+    details: decision.details,
+  };
+}
+
+function getPurgeBlockers(db: Database.Database, tenantId: string): BlockerRow[] {
+  const activeRuns = db.prepare<unknown[], BlockerRow>(`
+    SELECT id, 'analysis_run' AS kind, status, workspace_id
+    FROM analysis_runs
+    WHERE tenant_id = ?
+      AND status IN (${ACTIVE_RUN_STATUSES.map(() => '?').join(', ')})
+    ORDER BY workspace_id ASC, id ASC
+  `).all(tenantId, ...ACTIVE_RUN_STATUSES);
+  const activeLeases = db.prepare<unknown[], BlockerRow>(`
+    SELECT id, 'trace_processor_lease' AS kind, state AS status, workspace_id
+    FROM trace_processor_leases
+    WHERE tenant_id = ?
+      AND state IN (${ACTIVE_LEASE_STATES.map(() => '?').join(', ')})
+    ORDER BY workspace_id ASC, id ASC
+  `).all(tenantId, ...ACTIVE_LEASE_STATES);
+  return [...activeRuns, ...activeLeases];
+}
+
+function countRows(db: Database.Database, table: string, tenantId: string): number {
+  const row = db.prepare<unknown[], { count: number }>(`
+    SELECT COUNT(*) AS count
+    FROM ${table}
+    WHERE tenant_id = ?
+  `).get(tenantId);
+  return row?.count ?? 0;
+}
+
+function collectDeletedCounts(db: Database.Database, tenantId: string): Record<string, number> {
+  const holderCount = db.prepare<unknown[], { count: number }>(`
+    SELECT COUNT(*) AS count
+    FROM trace_processor_holders h
+    JOIN trace_processor_leases l ON l.id = h.lease_id
+    WHERE l.tenant_id = ?
+  `).get(tenantId)?.count ?? 0;
+  return {
+    workspaces: countRows(db, 'workspaces', tenantId),
+    users: countRows(db, 'users', tenantId),
+    apiKeys: countRows(db, 'api_keys', tenantId),
+    traceAssets: countRows(db, 'trace_assets', tenantId),
+    traceProcessorLeases: countRows(db, 'trace_processor_leases', tenantId),
+    traceProcessorHolders: holderCount,
+    analysisSessions: countRows(db, 'analysis_sessions', tenantId),
+    analysisRuns: countRows(db, 'analysis_runs', tenantId),
+    conversationTurns: countRows(db, 'conversation_turns', tenantId),
+    reportArtifacts: countRows(db, 'report_artifacts', tenantId),
+    memoryEntries: countRows(db, 'memory_entries', tenantId),
+    skillRegistryEntries: countRows(db, 'skill_registry_entries', tenantId),
+    providerCredentials: countRows(db, 'provider_credentials', tenantId),
+    providerSnapshots: countRows(db, 'provider_snapshots', tenantId),
+  };
+}
+
+function tenantDataPath(tenantId: string): string {
+  const safeTenantId = assertSafeTenantId(tenantId);
+  const root = path.resolve(resolveEnterpriseDataRoot());
+  const target = path.resolve(root, safeTenantId);
+  if (target !== root && !target.startsWith(`${root}${path.sep}`)) {
+    throw new Error(`Resolved tenant data path escapes data root: ${target}`);
+  }
+  return target;
+}
+
+async function removeTenantDataPath(tenantId: string): Promise<{ path: string; removed: boolean }> {
+  const target = tenantDataPath(tenantId);
+  await fs.rm(target, { recursive: true, force: true });
+  return { path: target, removed: true };
+}
+
+export async function purgeTenantNow(
+  db: Database.Database,
+  context: RequestContext,
+  now = Date.now(),
+): Promise<TenantPurgeProof> {
+  assertSafeTenantId(context.tenantId);
+  const tombstone = getTenantTombstoneRow(db, context.tenantId);
+  if (!tombstone || tombstone.status === 'purged') {
+    throw new Error('Tenant tombstone not found');
+  }
+  if (tombstone.purge_after > now) {
+    throw new TenantPurgeWindowError(tombstone.purge_after);
+  }
+
+  const blockers = getPurgeBlockers(db, context.tenantId);
+  if (blockers.length > 0) {
+    db.prepare(`
+      UPDATE tenant_tombstones
+      SET status = 'purge_blocked'
+      WHERE tenant_id = ?
+    `).run(context.tenantId);
+    recordEnterpriseAuditEvent(db, {
+      tenantId: context.tenantId,
+      action: 'tenant.purge_blocked',
+      resourceType: 'tenant',
+      resourceId: context.tenantId,
+      metadata: {
+        blockers,
+        requestId: context.requestId,
+      },
+    });
+    throw new TenantPurgeBlockedError(blockers);
+  }
+
+  const deletedCounts = collectDeletedCounts(db, context.tenantId);
+  db.prepare(`
+    UPDATE tenant_tombstones
+    SET status = 'purging'
+    WHERE tenant_id = ?
+  `).run(context.tenantId);
+  const dataRemoval = await removeTenantDataPath(context.tenantId);
+  const proofWithoutHash = {
+    tenantId: context.tenantId,
+    requestedBy: tombstone.requested_by,
+    purgedBy: context.userId,
+    requestedAt: tombstone.requested_at,
+    purgeAfter: tombstone.purge_after,
+    purgedAt: now,
+    deletedCounts,
+    dataPath: dataRemoval.path,
+    dataPathRemoved: dataRemoval.removed,
+  };
+  const proofHash = sha256(stableStringify(proofWithoutHash));
+  const proof: TenantPurgeProof = {
+    ...proofWithoutHash,
+    proofHash,
+  };
+
+  const tx = db.transaction(() => {
+    db.prepare('DELETE FROM provider_snapshots WHERE tenant_id = ?').run(context.tenantId);
+    db.prepare('DELETE FROM provider_credentials WHERE tenant_id = ?').run(context.tenantId);
+    db.prepare('DELETE FROM api_keys WHERE tenant_id = ?').run(context.tenantId);
+    db.prepare('DELETE FROM memory_entries WHERE tenant_id = ?').run(context.tenantId);
+    db.prepare('DELETE FROM skill_registry_entries WHERE tenant_id = ?').run(context.tenantId);
+    db.prepare('DELETE FROM workspaces WHERE tenant_id = ?').run(context.tenantId);
+    db.prepare('DELETE FROM users WHERE tenant_id = ?').run(context.tenantId);
+    db.prepare(`
+      UPDATE organizations
+      SET status = 'purged', updated_at = ?
+      WHERE id = ?
+    `).run(now, context.tenantId);
+    db.prepare(`
+      UPDATE tenant_tombstones
+      SET status = 'purged', proof_hash = ?
+      WHERE tenant_id = ?
+    `).run(proofHash, context.tenantId);
+    recordEnterpriseAuditEvent(db, {
+      tenantId: context.tenantId,
+      action: 'tenant.purged',
+      resourceType: 'tenant',
+      resourceId: context.tenantId,
+      metadata: {
+        proof,
+        requestId: context.requestId,
+      },
+    });
+  });
+  tx();
+  return proof;
+}

--- a/docs/features/enterprise-multi-tenant/README.md
+++ b/docs/features/enterprise-multi-tenant/README.md
@@ -79,7 +79,7 @@
 - [x] 5.2 `audit_events` 表 + 关键操作埋点（trace / report / provider / memory / cleanup / delete / promote）
 - [x] 5.3 配额 / 预算 / retention policy（§16.1，含 quota_exceeded 终态）
 - [x] 5.4 Tenant export bundle（§16.2，含 SHA256 + tenant identity proof）
-- [ ] 5.5 Tenant tombstone + 7 天硬删窗口 + async purge + audit proof（§16.3）
+- [x] 5.5 Tenant tombstone + 7 天硬删窗口 + async purge + audit proof（§16.3）
 - [ ] 5.6 Custom skill v1 处置（§14.3）：禁用 write endpoint 或修 loader 闭环
 - [ ] 5.7 Legacy AI route 处置（§14.4 表）
   - [ ] 5.7.1 `/api/agent/v1/llm` DeepSeek proxy
@@ -1002,6 +1002,14 @@ request delete
 ```
 
 删除完成后输出删除证明：操作者、时间、资源数量、数据指纹 hash。
+
+当前实现：
+
+- `POST /api/tenant/tombstone` 要求 `org_admin` 或 `tenant:delete` scope，并要求 `confirmTenantId` 显式匹配。
+- tombstone 会写入 `tenant_tombstones`，将 organization 状态置为 `tombstoned`，并写入 `tenant.tombstoned` audit event。
+- trace upload 与 agent analyze 在 tenant tombstone 后返回 `TENANT_TOMBSTONED`，拒绝新 upload / run。
+- `POST /api/tenant/purge` 在 7 天窗口后创建 async purge job；`GET /api/tenant/purge/:jobId` 查询结果。
+- purge 会在无 active run / lease 时删除 tenant data 目录和 tenant-scoped DB 行，保留 tombstone、organization purged 状态与 audit proof，写入 proof hash。
 
 ## 17. 迁移策略
 


### PR DESCRIPTION
## Summary
- Complete enterprise multi-tenant §0.5.5 tenant tombstone and purge flow.
- Add `/api/tenant/tombstone` and `/api/tenant/purge` with confirm-tenant guard, admin/delete permission checks, 7-day purge window, async purge job polling, and purge proof hash.
- Block tenant mutations after tombstone for trace uploads and agent analyze requests, and block purge while active runs or trace-processor leases remain.
- Document the completed slice in `docs/features/enterprise-multi-tenant/README.md`.

## Verification
- `cd backend && PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npx jest --runInBand --forceExit src/routes/__tests__/enterpriseTenantRoutes.test.ts src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts src/routes/__tests__/agentRoutesRbac.test.ts`
- `cd backend && PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npm run typecheck`
- `git diff --check`
- `cd backend && PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npm run test:scene-trace-regression`
- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npm run verify:pr`