### PR TITLE
feat(enterprise): disable legacy ai routes

### DIFF
--- a/backend/src/agent/core/__tests__/modelRouter.test.ts
+++ b/backend/src/agent/core/__tests__/modelRouter.test.ts
@@ -106,8 +106,10 @@ const createTestModels = (): ModelProfile[] => [
 describe('ModelRouter', () => {
   let router: ModelRouter;
   let testModels: ModelProfile[];
+  const originalEnterprise = process.env.SMARTPERFETTO_ENTERPRISE;
 
   beforeEach(() => {
+    delete process.env.SMARTPERFETTO_ENTERPRISE;
     testModels = createTestModels();
     router = new ModelRouter({
       models: testModels,
@@ -121,6 +123,11 @@ describe('ModelRouter', () => {
 
   afterEach(() => {
     router.resetStats();
+    if (originalEnterprise === undefined) {
+      delete process.env.SMARTPERFETTO_ENTERPRISE;
+    } else {
+      process.env.SMARTPERFETTO_ENTERPRISE = originalEnterprise;
+    }
   });
 
   // ===========================================================================
@@ -819,6 +826,26 @@ describe('ModelRouter', () => {
       // Note: Actual API call will fail without key, but client creation succeeds
       const model = deepseekRouter.getModel('deepseek-test');
       expect(model!.provider).toBe('deepseek');
+    });
+
+    it('should disable the global DeepSeek provider path in enterprise mode', async () => {
+      process.env.SMARTPERFETTO_ENTERPRISE = 'true';
+      const deepseekModel = createMockModel({
+        id: 'deepseek-test',
+        provider: 'deepseek',
+        model: 'deepseek-chat',
+      });
+
+      const deepseekRouter = new ModelRouter({
+        models: [deepseekModel],
+        defaultModel: 'deepseek-test',
+        fallbackChain: ['deepseek-test'],
+      });
+
+      const result = await deepseekRouter.callModel(deepseekModel, 'hello');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('disabled in enterprise mode');
     });
 
     it('should create Anthropic client for anthropic provider', () => {

--- a/backend/src/agent/core/modelRouter.ts
+++ b/backend/src/agent/core/modelRouter.ts
@@ -13,6 +13,7 @@
  */
 
 import { EventEmitter } from 'events';
+import { resolveFeatureConfig } from '../../config';
 import { LLM_REDACTION_VERSION, hashSha256, redactTextForLLM } from '../../utils/llmPrivacy';
 import {
   ModelProvider,
@@ -452,6 +453,12 @@ export class ModelRouter extends EventEmitter {
       (jsonMode ? 'llm_contract_json_only@1.0.0' : 'llm_contract_text@1.0.0');
 
     try {
+      if (model.provider === 'deepseek' && resolveFeatureConfig().enterprise) {
+        throw new Error(
+          'Legacy ModelRouter DeepSeek provider is disabled in enterprise mode; use ProviderSnapshot-backed agent runtime APIs instead.'
+        );
+      }
+
       // 获取或创建 LLM 客户端
       const client = this.getOrCreateClient(model);
 

--- a/backend/src/middleware/enterpriseLegacyAiGuard.ts
+++ b/backend/src/middleware/enterpriseLegacyAiGuard.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 Gracker (Chris)
+// This file is part of SmartPerfetto. See LICENSE for details.
+
+import type { NextFunction, Request, Response } from 'express';
+import { resolveFeatureConfig } from '../config';
+
+export const ENTERPRISE_LEGACY_AI_DISABLED_ERROR = 'disabled_in_enterprise_mode';
+export const ENTERPRISE_LEGACY_AI_DISABLED_CODE = 'LEGACY_AI_DISABLED_IN_ENTERPRISE_MODE';
+
+export function rejectLegacyAiInEnterpriseMode(surface: string) {
+  return (_req: Request, res: Response, next: NextFunction): void => {
+    if (!resolveFeatureConfig().enterprise) {
+      next();
+      return;
+    }
+
+    res.status(404).json({
+      success: false,
+      error: ENTERPRISE_LEGACY_AI_DISABLED_ERROR,
+      code: ENTERPRISE_LEGACY_AI_DISABLED_CODE,
+      details: `${surface} is disabled in enterprise mode; use ProviderSnapshot-backed agent runtime APIs instead.`,
+    });
+  };
+}

--- a/backend/src/routes/__tests__/legacyAiEnterpriseGuard.test.ts
+++ b/backend/src/routes/__tests__/legacyAiEnterpriseGuard.test.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 Gracker (Chris)
+// This file is part of SmartPerfetto. See LICENSE for details.
+
+import express from 'express';
+import request from 'supertest';
+
+import { ENTERPRISE_FEATURE_FLAG_ENV } from '../../config';
+import advancedAIRoutes from '../advancedAIRoutes';
+import aiChatRoutes from '../aiChatRoutes';
+import autoAnalysisRoutes from '../autoAnalysis';
+
+const originalEnv = {
+  enterprise: process.env[ENTERPRISE_FEATURE_FLAG_ENV],
+  apiKey: process.env.SMARTPERFETTO_API_KEY,
+  trustedHeaders: process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS,
+};
+
+function restoreEnvValue(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/agent/v1/llm', aiChatRoutes);
+  app.use('/api/auto-analysis', autoAnalysisRoutes);
+  app.use('/api/advanced-ai', advancedAIRoutes);
+  return app;
+}
+
+describe('legacy AI enterprise guard', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    process.env[ENTERPRISE_FEATURE_FLAG_ENV] = 'true';
+    delete process.env.SMARTPERFETTO_API_KEY;
+    delete process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS;
+    app = makeApp();
+  });
+
+  afterEach(() => {
+    restoreEnvValue(ENTERPRISE_FEATURE_FLAG_ENV, originalEnv.enterprise);
+    restoreEnvValue('SMARTPERFETTO_API_KEY', originalEnv.apiKey);
+    restoreEnvValue('SMARTPERFETTO_SSO_TRUSTED_HEADERS', originalEnv.trustedHeaders);
+  });
+
+  it.each([
+    ['POST', '/api/agent/v1/llm/chat'],
+    ['POST', '/api/agent/v1/llm/completions'],
+    ['POST', '/api/auto-analysis/analyze'],
+    ['GET', '/api/auto-analysis/patterns'],
+    ['POST', '/api/auto-analysis/enhance'],
+    ['POST', '/api/advanced-ai/analyze'],
+    ['GET', '/api/advanced-ai/learning/stats'],
+  ])('returns disabled for %s %s in enterprise mode', async (method, path) => {
+    const res = await request(app)
+      [method.toLowerCase() as 'get' | 'post'](path)
+      .send({})
+      .expect(404);
+
+    expect(res.body).toMatchObject({
+      success: false,
+      error: 'disabled_in_enterprise_mode',
+      code: 'LEGACY_AI_DISABLED_IN_ENTERPRISE_MODE',
+    });
+  });
+});

--- a/backend/src/routes/advancedAIRoutes.ts
+++ b/backend/src/routes/advancedAIRoutes.ts
@@ -18,10 +18,12 @@ import {
   triggerLearning,
 } from '../controllers/advancedAIController';
 import { authenticate } from '../middleware/auth';
+import { rejectLegacyAiInEnterpriseMode } from '../middleware/enterpriseLegacyAiGuard';
 
 const router = Router();
 
 // Apply authentication to all routes
+router.use(rejectLegacyAiInEnterpriseMode('/api/advanced-ai'));
 router.use(authenticate);
 
 // Session management

--- a/backend/src/routes/aiChatRoutes.ts
+++ b/backend/src/routes/aiChatRoutes.ts
@@ -5,6 +5,7 @@
 import express from 'express';
 import OpenAI from 'openai';
 import { authenticate, checkUsage } from '../middleware/auth';
+import { rejectLegacyAiInEnterpriseMode } from '../middleware/enterpriseLegacyAiGuard';
 
 const router = express.Router();
 
@@ -48,6 +49,7 @@ function ensureApiKeyConfigured(_req: express.Request, res: express.Response, ne
 }
 
 // Align with other backend APIs: enforce auth + usage checks.
+router.use(rejectLegacyAiInEnterpriseMode('/api/agent/v1/llm'));
 router.use(ensureApiKeyConfigured);
 router.use(authenticate);
 router.use(checkUsage(false));

--- a/backend/src/routes/autoAnalysis.ts
+++ b/backend/src/routes/autoAnalysis.ts
@@ -5,9 +5,12 @@
 import { Router } from 'express';
 import AutoAnalysisController from '../controllers/autoAnalysisController';
 import { body } from 'express-validator';
+import { rejectLegacyAiInEnterpriseMode } from '../middleware/enterpriseLegacyAiGuard';
 
 const router = Router();
 const controller = new AutoAnalysisController();
+
+router.use(rejectLegacyAiInEnterpriseMode('/api/auto-analysis'));
 
 // POST /api/auto-analysis/analyze - 分析 trace
 router.post(

--- a/docs/features/enterprise-multi-tenant/README.md
+++ b/docs/features/enterprise-multi-tenant/README.md
@@ -81,13 +81,13 @@
 - [x] 5.4 Tenant export bundle（§16.2，含 SHA256 + tenant identity proof）
 - [x] 5.5 Tenant tombstone + 7 天硬删窗口 + async purge + audit proof（§16.3）
 - [x] 5.6 Custom skill v1 处置（§14.3）：禁用 write endpoint 或修 loader 闭环
-- [ ] 5.7 Legacy AI route 处置（§14.4 表）
-  - [ ] 5.7.1 `/api/agent/v1/llm` DeepSeek proxy
-  - [ ] 5.7.2 `/api/advanced-ai`
-  - [ ] 5.7.3 `/api/auto-analysis`
-  - [ ] 5.7.4 `/api/agent/v1/aiChat`
-  - [ ] 5.7.5 `agent/core/ModelRouter` DeepSeek 全局 provider 路径
-  - [ ] 5.7.6 `agentv2` fallback
+- [x] 5.7 Legacy AI route 处置（§14.4 表）
+  - [x] 5.7.1 `/api/agent/v1/llm` DeepSeek proxy
+  - [x] 5.7.2 `/api/advanced-ai`
+  - [x] 5.7.3 `/api/auto-analysis`
+  - [x] 5.7.4 `/api/agent/v1/aiChat`
+  - [x] 5.7.5 `agent/core/ModelRouter` DeepSeek 全局 provider 路径
+  - [x] 5.7.6 `agentv2` fallback
 - [ ] 5.8 管理员运行时 dashboard：active leases / RSS / queue length / events / LLM cost
 - [ ] 5.9 安全审计：ID 枚举、跨 tenant、无权限 provider/report/memory 访问
 
@@ -929,6 +929,13 @@ v1 要求：
 | `/api/agent/v1/aiChat` | `backend/src/routes/aiChatRoutes.ts` | 接入 ProviderSnapshot 和 RequestContext，否则禁用 |
 | `agent/core/ModelRouter` DeepSeek 路径 | `backend/src/agent/core/` | 接入 ProviderSnapshot，禁止全局 provider config |
 | `agentv2` fallback | `backend/src/agentv2` 已处于 legacy/deprecated 方向 | 企业模式禁用 |
+
+当前实现：
+
+- `/api/agent/v1/llm/*`、`/api/advanced-ai/*`、`/api/auto-analysis/*` 在 `SMARTPERFETTO_ENTERPRISE=true` 时返回 `404` + `disabled_in_enterprise_mode`，不再进入 legacy DeepSeek proxy / advanced AI / auto analysis controller。
+- `backend/src/routes/aiChatRoutes.ts` 是当前 `/api/agent/v1/llm` 的实际挂载实现；代码库中没有独立 `/api/agent/v1/aiChat` 挂载，按同一 legacy chat proxy surface 处置。
+- `ModelRouter` 在企业模式下拒绝 `deepseek` provider 调用，避免走 `DEEPSEEK_API_KEY` / `DEEPSEEK_MODEL` 这类全局 provider config；企业路径必须走 ProviderSnapshot-backed runtime。
+- 当前源码树无 `backend/src/agentv2` 文件可挂载，保留为已退役状态。
 
 ## 15. Onboarding Flow
 


### PR DESCRIPTION
## Summary
- Complete enterprise multi-tenant §0.5.7 legacy AI route disposal.
- Add a shared enterprise legacy-AI guard returning `404` + `disabled_in_enterprise_mode` for `/api/agent/v1/llm/*`, `/api/advanced-ai/*`, and `/api/auto-analysis/*`.
- Reject `agent/core/ModelRouter` DeepSeek global provider calls in enterprise mode so enterprise paths must use ProviderSnapshot-backed runtimes.
- Record that `/api/agent/v1/aiChat` has no separate mount beyond the current llm chat proxy, and that `agentv2` has no source-tree entry to mount.
- Update the enterprise README checklist and §14.4 implementation notes.

## Verification
- `cd backend && PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npx jest --runInBand --forceExit src/routes/__tests__/legacyAiEnterpriseGuard.test.ts src/agent/core/__tests__/modelRouter.test.ts`
- `cd backend && PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npm run typecheck`
- `git diff --check`
- `cd backend && PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npm run test:scene-trace-regression`
- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" npm run verify:pr`