### PR TITLE
fix(enterprise): harden SQLite repository scoped upserts

### DIFF
--- a/backend/src/routes/simpleTraceRoutes.ts
+++ b/backend/src/routes/simpleTraceRoutes.ts
@@ -43,7 +43,7 @@ import {
 } from '../services/enterpriseTenantLifecycleService';
 import {
   buildTraceOwnerMetadata,
-  deleteTraceMetadata,
+  deleteTraceMetadataForContext,
   getTraceFilePath,
   getWritableTraceDirForContext,
   listTraceMetadataForContext,
@@ -1208,7 +1208,7 @@ router.delete('/:id', async (req, res) => {
       // File might not exist, continue
     }
 
-    await deleteTraceMetadata(id);
+    await deleteTraceMetadataForContext(id, context);
     console.log(`[Traces] Metadata deleted for ${id}`);
     recordTraceAudit(context, 'trace.deleted', id, {
       filename: metadata.filename,

--- a/backend/src/services/__tests__/enterpriseRepository.test.ts
+++ b/backend/src/services/__tests__/enterpriseRepository.test.ts
@@ -6,6 +6,7 @@ import Database from 'better-sqlite3';
 import { type RequestContext } from '../../middleware/auth';
 import { applyEnterpriseMinimalSchema } from '../enterpriseSchema';
 import {
+  ENTERPRISE_WORKSPACE_SCOPED_TABLES,
   buildWorkspaceScopedWhere,
   createEnterpriseWorkspaceRepository,
   repositoryScopeFromRequestContext,
@@ -126,6 +127,61 @@ describe('enterprise repository scope abstraction', () => {
     expect(rows.map(row => row.id)).toEqual(['trace-a']);
   });
 
+  test('declares all id-based workspace scoped core tables as repository tables', () => {
+    expect(ENTERPRISE_WORKSPACE_SCOPED_TABLES).toEqual([
+      'trace_assets',
+      'trace_processor_leases',
+      'analysis_sessions',
+      'analysis_runs',
+      'conversation_turns',
+      'agent_events',
+      'runtime_snapshots',
+      'report_artifacts',
+      'memory_entries',
+      'skill_registry_entries',
+    ]);
+  });
+
+  test('upserts rows without allowing cross-scope ownership moves', () => {
+    const repo = createEnterpriseWorkspaceRepository<TraceAssetRow>(db!, 'trace_assets');
+    const scopeA = { tenantId: 'tenant-a', workspaceId: 'workspace-a' };
+    const scopeB = { tenantId: 'tenant-b', workspaceId: 'workspace-c' };
+
+    expect(repo.upsertById(scopeA, 'trace-new', {
+      local_path: '/tmp/trace-new.pftrace',
+      status: 'ready',
+      created_at: 123,
+    })).toBe(1);
+    expect(repo.getById(scopeA, 'trace-new')).toEqual(expect.objectContaining({
+      id: 'trace-new',
+      tenant_id: 'tenant-a',
+      workspace_id: 'workspace-a',
+      status: 'ready',
+    }));
+
+    expect(repo.upsertById(scopeA, 'trace-new', {
+      local_path: '/tmp/trace-new-v2.pftrace',
+      status: 'archived',
+      created_at: 124,
+    })).toBe(1);
+    expect(repo.getById(scopeA, 'trace-new')).toEqual(expect.objectContaining({
+      local_path: '/tmp/trace-new-v2.pftrace',
+      status: 'archived',
+    }));
+
+    expect(repo.upsertById(scopeA, 'trace-c', {
+      local_path: '/tmp/attempted-move.pftrace',
+      status: 'deleted',
+      created_at: 125,
+    })).toBe(0);
+    expect(repo.getById(scopeA, 'trace-c')).toBeNull();
+    expect(repo.getById(scopeB, 'trace-c')).toEqual(expect.objectContaining({
+      tenant_id: 'tenant-b',
+      workspace_id: 'workspace-c',
+      status: 'ready',
+    }));
+  });
+
   test('get, update, and delete stay scoped by tenant and workspace', () => {
     const repo = createEnterpriseWorkspaceRepository<TraceAssetRow>(db!, 'trace_assets');
     const scopeA = { tenantId: 'tenant-a', workspaceId: 'workspace-a' };
@@ -167,5 +223,11 @@ describe('enterprise repository scope abstraction', () => {
       'trace-a',
       { workspace_id: 'workspace-b' },
     )).toThrow('workspace_id cannot be updated through a scoped repository');
+
+    expect(() => repo.upsertById(
+      { tenantId: 'tenant-a', workspaceId: 'workspace-a' },
+      'trace-a',
+      { tenant_id: 'tenant-b', local_path: '/tmp/x', status: 'ready', created_at: 1 },
+    )).toThrow('tenant_id cannot be written through a scoped repository');
   });
 });

--- a/backend/src/services/enterpriseRepository.ts
+++ b/backend/src/services/enterpriseRepository.ts
@@ -15,19 +15,27 @@ export interface EnterpriseRepositoryScope {
 
 export type EnterpriseWorkspaceScopedTable =
   | 'trace_assets'
+  | 'trace_processor_leases'
   | 'analysis_sessions'
   | 'analysis_runs'
+  | 'conversation_turns'
   | 'agent_events'
   | 'runtime_snapshots'
-  | 'memory_entries';
+  | 'report_artifacts'
+  | 'memory_entries'
+  | 'skill_registry_entries';
 
 export const ENTERPRISE_WORKSPACE_SCOPED_TABLES: readonly EnterpriseWorkspaceScopedTable[] = [
   'trace_assets',
+  'trace_processor_leases',
   'analysis_sessions',
   'analysis_runs',
+  'conversation_turns',
   'agent_events',
   'runtime_snapshots',
+  'report_artifacts',
   'memory_entries',
+  'skill_registry_entries',
 ];
 
 export type EnterpriseQueryCriteria = Record<string, SqliteBindValue | undefined>;
@@ -47,6 +55,7 @@ export interface ListOptions {
 const IDENTIFIER_RE = /^[a-z][a-z0-9_]*$/;
 const SCOPE_COLUMNS = new Set(['tenant_id', 'workspace_id']);
 const IMMUTABLE_UPDATE_COLUMNS = new Set(['id', 'tenant_id', 'workspace_id']);
+const IMMUTABLE_WRITE_COLUMNS = new Set(['id', 'tenant_id', 'workspace_id']);
 
 function assertNonEmptyId(value: string, name: string): void {
   if (!value.trim()) {
@@ -147,6 +156,37 @@ function normalizeUpdateValues(values: EnterpriseUpdateValues): {
   return { assignments, params };
 }
 
+function normalizeWriteValues(values: EnterpriseUpdateValues): {
+  columns: string[];
+  placeholders: string[];
+  updateAssignments: string[];
+  params: Record<string, SqliteBindValue>;
+} {
+  const columns: string[] = [];
+  const placeholders: string[] = [];
+  const updateAssignments: string[] = [];
+  const params: Record<string, SqliteBindValue> = {};
+
+  for (const [column, value] of Object.entries(values)) {
+    if (value === undefined) continue;
+    assertIdentifier(column, 'write column');
+    if (IMMUTABLE_WRITE_COLUMNS.has(column)) {
+      throw new Error(`${column} cannot be written through a scoped repository`);
+    }
+    const paramName = `write_${column}`;
+    columns.push(column);
+    placeholders.push(`@${paramName}`);
+    updateAssignments.push(`${column} = excluded.${column}`);
+    params[paramName] = value;
+  }
+
+  if (columns.length === 0) {
+    throw new Error('At least one write value is required');
+  }
+
+  return { columns, placeholders, updateAssignments, params };
+}
+
 export class EnterpriseWorkspaceRepository<Row extends Record<string, unknown>> {
   constructor(
     private readonly db: Database.Database,
@@ -188,6 +228,29 @@ export class EnterpriseWorkspaceRepository<Row extends Record<string, unknown>> 
     `).run({
       ...where.params,
       ...update.params,
+    });
+    return result.changes;
+  }
+
+  upsertById(scope: EnterpriseRepositoryScope, id: string, values: EnterpriseUpdateValues): number {
+    assertNonEmptyId(id, 'id');
+    assertNonEmptyId(scope.tenantId, 'tenantId');
+    assertNonEmptyId(scope.workspaceId, 'workspaceId');
+    const write = normalizeWriteValues(values);
+    const result = this.db.prepare(`
+      INSERT INTO ${this.table}
+        (id, tenant_id, workspace_id, ${write.columns.join(', ')})
+      VALUES
+        (@insertId, @scopeTenantId, @scopeWorkspaceId, ${write.placeholders.join(', ')})
+      ON CONFLICT(id) DO UPDATE SET
+        ${write.updateAssignments.join(', ')}
+      WHERE tenant_id = @scopeTenantId
+        AND workspace_id = @scopeWorkspaceId
+    `).run({
+      insertId: id,
+      scopeTenantId: scope.tenantId,
+      scopeWorkspaceId: scope.workspaceId,
+      ...write.params,
     });
     return result.changes;
   }

--- a/backend/src/services/traceMetadataStore.ts
+++ b/backend/src/services/traceMetadataStore.ts
@@ -8,6 +8,11 @@ import type Database from 'better-sqlite3';
 import type { RequestContext } from '../middleware/auth';
 import { openEnterpriseDb } from './enterpriseDb';
 import {
+  createEnterpriseWorkspaceRepository,
+  repositoryScopeFromRequestContext,
+  type EnterpriseRepositoryScope,
+} from './enterpriseRepository';
+import {
   enterpriseDbReadAuthorityEnabled,
   enterpriseDbWritesEnabled,
   legacyFilesystemWritesEnabled,
@@ -31,7 +36,7 @@ export interface TraceMetadata extends ResourceOwnerFields {
   expiresAt?: number;
 }
 
-interface TraceAssetRow {
+interface TraceAssetRow extends Record<string, unknown> {
   id: string;
   tenant_id: string;
   workspace_id: string;
@@ -164,6 +169,10 @@ function rowToTraceMetadata(row: TraceAssetRow): TraceMetadata {
   };
 }
 
+function isTraceAssetRowLive(row: TraceAssetRow, now = Date.now()): boolean {
+  return row.expires_at === null || row.expires_at > now;
+}
+
 function withEnterpriseTraceDb<T>(fn: (db: Database.Database) => T): T {
   const db = openEnterpriseDb();
   try {
@@ -250,32 +259,23 @@ function writeEnterpriseTraceMetadata(metadata: TraceMetadata): void {
       'trace',
       createdAt,
     );
-    db.prepare(`
-      INSERT INTO trace_assets
-        (id, tenant_id, workspace_id, owner_user_id, local_path, size_bytes, status, metadata_json, created_at, expires_at)
-      VALUES
-        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(id) DO UPDATE SET
-        tenant_id = excluded.tenant_id,
-        workspace_id = excluded.workspace_id,
-        owner_user_id = excluded.owner_user_id,
-        local_path = excluded.local_path,
-        size_bytes = excluded.size_bytes,
-        status = excluded.status,
-        metadata_json = excluded.metadata_json,
-        expires_at = excluded.expires_at
-    `).run(
+    const repo = createEnterpriseWorkspaceRepository<TraceAssetRow>(db, 'trace_assets');
+    const changes = repo.upsertById(
+      { tenantId, workspaceId, ...(ownerUserId ? { userId: ownerUserId } : {}) },
       metadata.id,
-      tenantId,
-      workspaceId,
-      ownerUserId,
-      enterpriseLocalPathForMetadata(metadata),
-      metadata.size,
-      metadata.status,
-      metadataJsonForRow(metadata),
-      createdAt,
-      expiresAt,
+      {
+        owner_user_id: ownerUserId,
+        local_path: enterpriseLocalPathForMetadata(metadata),
+        size_bytes: metadata.size,
+        status: metadata.status,
+        metadata_json: metadataJsonForRow(metadata),
+        created_at: createdAt,
+        expires_at: expiresAt,
+      },
     );
+    if (changes === 0) {
+      throw new Error('Trace metadata id already exists outside the repository scope');
+    }
   });
 }
 
@@ -304,6 +304,17 @@ function readEnterpriseTraceMetadata(traceId: string): TraceMetadata | null {
         AND (expires_at IS NULL OR expires_at > ?)
     `).get(traceId, Date.now());
     return row ? rowToTraceMetadata(row) : null;
+  });
+}
+
+function readEnterpriseTraceMetadataForScope(
+  traceId: string,
+  scope: EnterpriseRepositoryScope,
+): TraceMetadata | null {
+  return withEnterpriseTraceDb((db) => {
+    const repo = createEnterpriseWorkspaceRepository<TraceAssetRow>(db, 'trace_assets');
+    const row = repo.getById(scope, traceId);
+    return row && isTraceAssetRowLive(row) ? rowToTraceMetadata(row) : null;
   });
 }
 
@@ -366,15 +377,15 @@ export async function listTraceMetadata(): Promise<TraceMetadata[]> {
 export async function listTraceMetadataForContext(context: RequestContext): Promise<TraceMetadata[]> {
   if (enterpriseTraceStoreEnabled()) {
     return withEnterpriseTraceDb((db) => {
-      const rows = db.prepare<unknown[], TraceAssetRow>(`
-        SELECT *
-        FROM trace_assets
-        WHERE tenant_id = ?
-          AND workspace_id = ?
-          AND (expires_at IS NULL OR expires_at > ?)
-        ORDER BY created_at DESC
-      `).all(context.tenantId, context.workspaceId, Date.now());
-      return rows.map(rowToTraceMetadata).filter(metadata => canReadTraceResource(metadata, context));
+      const repo = createEnterpriseWorkspaceRepository<TraceAssetRow>(db, 'trace_assets');
+      const now = Date.now();
+      return repo.list(repositoryScopeFromRequestContext(context), {}, {
+        orderBy: 'created_at',
+        direction: 'DESC',
+      })
+        .filter(row => isTraceAssetRowLive(row, now))
+        .map(rowToTraceMetadata)
+        .filter(metadata => canReadTraceResource(metadata, context));
     });
   }
 
@@ -391,6 +402,27 @@ export async function deleteTraceMetadata(traceId: string): Promise<void> {
   if (enterpriseTraceDbWritesEnabled()) {
     withEnterpriseTraceDb((db) => {
       db.prepare('DELETE FROM trace_assets WHERE id = ?').run(traceId);
+    });
+  }
+  if (!legacyTraceMetadataWritesEnabled()) return;
+  const metadataPath = getTraceMetadataPath(traceId);
+  if (!metadataPath) return;
+  try {
+    await fs.unlink(metadataPath);
+  } catch {
+    // Already deleted.
+  }
+}
+
+export async function deleteTraceMetadataForContext(
+  traceId: string,
+  context: RequestContext,
+): Promise<void> {
+  if (!isSafeTraceId(traceId)) return;
+  if (enterpriseTraceDbWritesEnabled()) {
+    withEnterpriseTraceDb((db) => {
+      createEnterpriseWorkspaceRepository<TraceAssetRow>(db, 'trace_assets')
+        .deleteById(repositoryScopeFromRequestContext(context), traceId);
     });
   }
   if (!legacyTraceMetadataWritesEnabled()) return;
@@ -420,17 +452,10 @@ export async function readTraceMetadataForContext(
 ): Promise<TraceMetadata | null> {
   if (enterpriseTraceStoreEnabled()) {
     if (!isSafeTraceId(traceId)) return null;
-    const metadata = withEnterpriseTraceDb((db) => {
-      const row = db.prepare<unknown[], TraceAssetRow>(`
-        SELECT *
-        FROM trace_assets
-        WHERE id = ?
-          AND tenant_id = ?
-          AND workspace_id = ?
-          AND (expires_at IS NULL OR expires_at > ?)
-      `).get(traceId, context.tenantId, context.workspaceId, Date.now());
-      return row ? rowToTraceMetadata(row) : null;
-    });
+    const metadata = readEnterpriseTraceMetadataForScope(
+      traceId,
+      repositoryScopeFromRequestContext(context),
+    );
     return isTraceMetadataOwnedByContext(metadata, context) ? metadata : null;
   }
 


### PR DESCRIPTION
## Summary
- extend the enterprise workspace repository table allowlist to all id-based workspace-scoped core tables
- add scoped `upsertById` that refuses to move an existing resource id across tenant/workspace boundaries
- route enterprise trace metadata write/list/read/delete through the scoped repository boundary

## Verification
- `cd backend && npx jest --runInBand src/services/__tests__/enterpriseDb.test.ts src/services/__tests__/enterpriseRepository.test.ts src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts src/services/__tests__/enterpriseMigration.test.ts`
- `cd backend && npm run typecheck`
- `git diff --check`
- `npm run verify:pr`

## Notes
- This hardens already-completed §0.3.1; no README TODO state changes are needed.
