### PR TITLE
test(enterprise): pin integration coverage matrix

### DIFF
--- a/backend/src/routes/__tests__/agentRoutesRbac.test.ts
+++ b/backend/src/routes/__tests__/agentRoutesRbac.test.ts
@@ -9,6 +9,7 @@ import os from 'os';
 import path from 'path';
 import request from 'supertest';
 import { ENTERPRISE_FEATURE_FLAG_ENV } from '../../config';
+import { EnhancedSessionContext, sessionContextManager } from '../../agent/context/enhancedSessionContext';
 import { ENTERPRISE_DB_PATH_ENV, openEnterpriseDb } from '../../services/enterpriseDb';
 import { ENTERPRISE_DATA_DIR_ENV, writeTraceMetadata } from '../../services/traceMetadataStore';
 import {
@@ -23,6 +24,7 @@ import {
   getTraceProcessorLeaseStore,
   setTraceProcessorLeaseStoreForTests,
 } from '../../services/traceProcessorLeaseStore';
+import { SessionPersistenceService } from '../../services/sessionPersistenceService';
 import { setTraceProcessorServiceForTests } from '../../services/traceProcessorService';
 import agentRoutes from '../agentRoutes';
 
@@ -72,6 +74,7 @@ afterEach(async () => {
   jest.restoreAllMocks();
   setTraceProcessorServiceForTests(null);
   setTraceProcessorLeaseStoreForTests(null);
+  SessionPersistenceService.resetForTests();
   resetAgentEventStoreForTests();
   resetAnalysisRunStoreForTests();
   if (originalApiKey === undefined) {
@@ -84,6 +87,7 @@ afterEach(async () => {
   restoreEnvValue(ENTERPRISE_DB_PATH_ENV, originalEnterpriseDbPath);
   restoreEnvValue(ENTERPRISE_DATA_DIR_ENV, originalEnterpriseDataDir);
   restoreEnvValue('UPLOAD_DIR', originalUploadDir);
+  sessionContextManager.remove('session-resume-integration');
 });
 
 describe('agent route RBAC', () => {
@@ -376,6 +380,101 @@ describe('agent route RBAC', () => {
     } finally {
       leaseStore?.close();
       setTraceProcessorLeaseStoreForTests(null);
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('resumes a persisted enterprise session and accepts an authorized respond action', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'smartperfetto-agent-resume-'));
+    try {
+      const traceId = 'trace-resume-integration';
+      const sessionId = 'session-resume-integration';
+      const tracePath = path.join(tmpDir, `${traceId}.trace`);
+      await fs.writeFile(tracePath, 'trace bytes');
+      delete process.env.SMARTPERFETTO_API_KEY;
+      process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS = 'true';
+      process.env[ENTERPRISE_FEATURE_FLAG_ENV] = 'true';
+      process.env[ENTERPRISE_DB_PATH_ENV] = path.join(tmpDir, 'enterprise.sqlite');
+      process.env[ENTERPRISE_DATA_DIR_ENV] = path.join(tmpDir, 'data');
+      process.env.UPLOAD_DIR = path.join(tmpDir, 'uploads');
+      SessionPersistenceService.resetForTests();
+
+      await writeTraceMetadata({
+        id: traceId,
+        filename: `${traceId}.trace`,
+        size: 11,
+        uploadedAt: new Date().toISOString(),
+        status: 'ready',
+        path: tracePath,
+        tenantId: 'tenant-a',
+        workspaceId: 'workspace-a',
+        userId: 'analyst-user',
+      });
+      setTraceProcessorServiceForTests({
+        getOrLoadTrace: jest.fn(async () => ({
+          id: traceId,
+          filename: `${traceId}.trace`,
+          size: 11,
+          filePath: tracePath,
+          uploadTime: new Date(),
+          status: 'ready',
+        })),
+      } as any);
+
+      const context = new EnhancedSessionContext(sessionId, traceId);
+      context.addTurn('resume this persisted session', {
+        primaryGoal: 'resume_integration',
+        aspects: ['agent_resume', 'respond'],
+        expectedOutputType: 'diagnosis',
+        complexity: 'moderate',
+      });
+      const persistence = SessionPersistenceService.getInstance();
+      persistence.saveSession({
+        id: sessionId,
+        traceId,
+        traceName: `${traceId}.trace`,
+        question: 'resume this persisted session',
+        createdAt: Date.now() - 1000,
+        updatedAt: Date.now(),
+        messages: [],
+        metadata: {
+          tenantId: 'tenant-a',
+          workspaceId: 'workspace-a',
+          userId: 'analyst-user',
+        },
+      });
+      expect(persistence.saveSessionContext(sessionId, context)).toBe(true);
+
+      const resumeRes = await analystHeaders(request(makeApp()).post('/api/agent/v1/resume'))
+        .send({ sessionId, traceId });
+
+      expect(resumeRes.status).toBe(200);
+      expect(resumeRes.body).toEqual(expect.objectContaining({
+        success: true,
+        sessionId,
+        traceId,
+        restored: true,
+        status: 'completed',
+      }));
+      expect(resumeRes.body.restoredStats).toEqual(expect.objectContaining({
+        turnCount: 1,
+      }));
+
+      const respondRes = await analystHeaders(
+        request(makeApp())
+          .post(`/api/agent/v1/${sessionId}/respond`)
+          .send({ action: 'abort' }),
+      );
+
+      expect(respondRes.status).toBe(200);
+      expect(respondRes.body).toEqual({
+        success: true,
+        sessionId,
+        status: 'failed',
+      });
+    } finally {
+      sessionContextManager.remove('session-resume-integration');
+      SessionPersistenceService.resetForTests();
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
   });

--- a/backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts
+++ b/backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts
@@ -336,6 +336,15 @@ describe('enterprise trace metadata routes', () => {
 
     const ownTraceRes = await ssoHeaders(request(app).get(`/api/traces/${traceId}`));
     expect(ownTraceRes.status).toBe(200);
+
+    const downloadRes = await ssoHeaders(request(app).get(`/api/traces/${traceId}/file`));
+    expect(downloadRes.status).toBe(200);
+    expect(
+      Buffer.isBuffer(downloadRes.body)
+        ? downloadRes.body.toString('utf-8')
+        : downloadRes.text,
+    ).toBe('trace-content');
+
     expect(readAuditActions()).toEqual(expect.arrayContaining([
       'trace.uploaded',
       'trace.read',

--- a/docs/features/enterprise-multi-tenant/README.md
+++ b/docs/features/enterprise-multi-tenant/README.md
@@ -93,7 +93,7 @@
 
 ### 0.6 测试矩阵补全（§20，与主线绑定）
 - [x] 6.1 Unit：RequestContext / RBAC / owner guard / provider resolution / ProviderSnapshot hash
-- [ ] 6.2 Integration：trace upload/list/delete/download；agent analyze/resume/respond/stream；report read/delete
+- [x] 6.2 Integration：trace upload/list/delete/download；agent analyze/resume/respond/stream；report read/delete
 - [ ] 6.3 Concurrency：多用户同时 upload / analyze / query / cancel / cleanup
 - [x] 6.4 Dual-window e2e：D1-D10 每个场景至少 1 个自动化用例（详见 §0.7）
 - [ ] 6.5 Security：ID 枚举、跨 tenant、无权限访问统一 404
@@ -144,6 +144,7 @@
 - [x] `docs/features/enterprise-multi-tenant/runtime-dashboard.md`（§0.5.8 管理员运行时 dashboard API 契约与验证）
 - [x] `docs/features/enterprise-multi-tenant/admin-control-plane.md`（§0.5.1 tenant/workspace/member/provider/quota 管理面契约与验证）
 - [x] `docs/features/enterprise-multi-tenant/unit-coverage-matrix.md`（§0.6.1 Unit 覆盖证据与 test:core 固定入口）
+- [x] `docs/features/enterprise-multi-tenant/integration-coverage-matrix.md`（§0.6.2 Integration 主链路覆盖证据与 test:core 固定入口）
 
 ### 0.10 PR / 提交收尾（每次 PR 都要走）
 - [ ] 每个主线 / 子主线一个独立 PR；不跨主线串改动

--- a/docs/features/enterprise-multi-tenant/integration-coverage-matrix.md
+++ b/docs/features/enterprise-multi-tenant/integration-coverage-matrix.md
@@ -1,0 +1,35 @@
+# Enterprise Integration Coverage Matrix
+
+本文件记录 §0.6.2 的集成测试覆盖证据。范围限定为 README §0.6.2 点名的 HTTP 主链路：trace upload/list/delete/download、agent analyze/resume/respond/stream、report read/delete。
+
+## Scope
+
+| §0.6.2 链路 | 自动证据 | 覆盖的不变量 |
+| --- | --- | --- |
+| trace upload / list / read / download | `backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts` | 上传进入 `data/{tenantId}/{workspaceId}/traces/`，元数据写入 `trace_assets`，列表和单条读取按 RequestContext scope 过滤，`GET /api/traces/:id/file` 返回 scoped trace 文件。 |
+| trace delete | `backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts` | active run、active lease、report holder 会阻断删除；释放 holder 后删除 trace 文件、`trace_assets` 元数据和审计事件。 |
+| agent analyze | `backend/src/routes/__tests__/agentRoutesRbac.test.ts` | 分析请求要求 `agent:run`，会验证 scoped trace、lease draining、full analysis isolated lease，并落 `analysis_runs` 生命周期。 |
+| agent resume / respond | `backend/src/routes/__tests__/agentRoutesRbac.test.ts` | `POST /api/agent/v1/resume` 只恢复当前 workspace 可读的 persisted session 与 trace；恢复后的 live session 可通过 `POST /api/agent/v1/:sessionId/respond` 执行授权动作。 |
+| agent stream | `backend/src/routes/__tests__/agentRoutesRbac.test.ts`、`backend/src/assistant/stream/__tests__/sessionSseReplay.test.ts` | `Last-Event-ID` 后的 persisted terminal event 优先 replay，返回 `analysis_completed` 与 report URL；cursor 解析优先 header。 |
+| report read / export / delete | `backend/src/routes/__tests__/enterpriseReportRoutes.test.ts` | report 写入 `report_artifacts` 与 scoped report 文件；read/export 可从 DB-backed storage 恢复；delete 清理 metadata 与文件并记录审计。 |
+| restart recovery integration | `backend/src/routes/__tests__/enterpriseRestartPersistence.test.ts` | backend in-memory state 丢失后，trace metadata、report、session turns、interrupted analysis run 可从 durable storage 恢复或转 failed。 |
+
+## Verification
+
+最小回归：
+
+```bash
+cd backend && npx jest --runInBand --forceExit \
+  src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts \
+  src/routes/__tests__/agentRoutesRbac.test.ts \
+  src/routes/__tests__/enterpriseReportRoutes.test.ts \
+  src/routes/__tests__/enterpriseRestartPersistence.test.ts \
+  src/assistant/stream/__tests__/sessionSseReplay.test.ts
+```
+
+PR gate 中的固定入口：
+
+```bash
+cd backend && npm run test:core
+npm run verify:pr
+```


### PR DESCRIPTION
## Summary
- Pin §0.6.2 integration coverage with a dedicated matrix document.
- Extend trace integration coverage to assert scoped trace download contents.
- Add persisted enterprise session resume/respond integration coverage.
- Mark README §0.6.2 complete and register the new evidence document in §0.9.

## Verification
- cd backend && npx jest --runInBand --forceExit src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts src/routes/__tests__/agentRoutesRbac.test.ts src/routes/__tests__/enterpriseReportRoutes.test.ts src/routes/__tests__/enterpriseRestartPersistence.test.ts src/assistant/stream/__tests__/sessionSseReplay.test.ts
- cd backend && npm run typecheck
- git diff --check
- cd backend && npm run test:core
- npm run verify:pr