### PR TITLE
test(enterprise): pin concurrency coverage matrix

### DIFF
--- a/backend/src/routes/__tests__/agentRoutesRbac.test.ts
+++ b/backend/src/routes/__tests__/agentRoutesRbac.test.ts
@@ -62,6 +62,19 @@ function analystHeaders(req: request.Test): request.Test {
     .set('X-SmartPerfetto-SSO-Scopes', 'trace:read,trace:write,agent:run,report:read');
 }
 
+function scopedAnalystHeaders(
+  req: request.Test,
+  options: { userId: string; workspaceId: string; email?: string },
+): request.Test {
+  return req
+    .set('X-SmartPerfetto-SSO-User-Id', options.userId)
+    .set('X-SmartPerfetto-SSO-Email', options.email ?? `${options.userId}@example.test`)
+    .set('X-SmartPerfetto-SSO-Tenant-Id', 'tenant-a')
+    .set('X-SmartPerfetto-SSO-Workspace-Id', options.workspaceId)
+    .set('X-SmartPerfetto-SSO-Roles', 'analyst')
+    .set('X-SmartPerfetto-SSO-Scopes', 'trace:read,trace:write,agent:run,report:read');
+}
+
 function restoreEnvValue(key: string, value: string | undefined): void {
   if (value === undefined) {
     delete process.env[key];
@@ -378,6 +391,145 @@ describe('agent route RBAC', () => {
         userId: 'analyst-user',
       }, { traceId })).toHaveLength(1);
     } finally {
+      leaseStore?.close();
+      setTraceProcessorLeaseStoreForTests(null);
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps concurrent analyzes isolated when one user cancels their own run', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'smartperfetto-agent-concurrency-'));
+    let leaseStore: ReturnType<typeof getTraceProcessorLeaseStore> | null = null;
+    const sessionIds: string[] = [];
+    try {
+      const traces = new Map<string, { traceId: string; workspaceId: string; userId: string; tracePath: string }>();
+      for (const item of [
+        { traceId: 'trace-concurrent-a', workspaceId: 'workspace-a', userId: 'analyst-a' },
+        { traceId: 'trace-concurrent-b', workspaceId: 'workspace-b', userId: 'analyst-b' },
+      ]) {
+        const tracePath = path.join(tmpDir, `${item.traceId}.trace`);
+        await fs.writeFile(tracePath, `${item.traceId} bytes`);
+        traces.set(item.traceId, { ...item, tracePath });
+      }
+
+      delete process.env.SMARTPERFETTO_API_KEY;
+      process.env.SMARTPERFETTO_SSO_TRUSTED_HEADERS = 'true';
+      process.env[ENTERPRISE_FEATURE_FLAG_ENV] = 'true';
+      process.env[ENTERPRISE_DB_PATH_ENV] = path.join(tmpDir, 'enterprise.sqlite');
+      process.env[ENTERPRISE_DATA_DIR_ENV] = path.join(tmpDir, 'data');
+      process.env.UPLOAD_DIR = path.join(tmpDir, 'uploads');
+
+      for (const item of traces.values()) {
+        await writeTraceMetadata({
+          id: item.traceId,
+          filename: `${item.traceId}.trace`,
+          size: 16,
+          uploadedAt: new Date().toISOString(),
+          status: 'ready',
+          path: item.tracePath,
+          tenantId: 'tenant-a',
+          workspaceId: item.workspaceId,
+          userId: item.userId,
+        });
+      }
+
+      setTraceProcessorServiceForTests({
+        getOrLoadTrace: jest.fn(async (traceId: string) => {
+          const item = traces.get(traceId);
+          if (!item) throw new Error(`missing trace fixture: ${traceId}`);
+          return {
+            id: item.traceId,
+            filename: `${item.traceId}.trace`,
+            size: 16,
+            filePath: item.tracePath,
+            uploadTime: new Date(),
+            status: 'ready',
+          };
+        }),
+        getTrace: jest.fn((traceId: string) => {
+          const item = traces.get(traceId);
+          if (!item) return undefined;
+          return {
+            id: item.traceId,
+            filename: `${item.traceId}.trace`,
+            size: 16,
+            filePath: item.tracePath,
+            uploadTime: new Date(),
+            status: 'ready',
+          };
+        }),
+        ensureProcessorForLease: jest.fn(async () => undefined),
+        runWithLease: jest.fn(() => new Promise<unknown>(() => undefined)),
+        query: jest.fn(async () => ({ columns: [], rows: [], durationMs: 1 })),
+      } as any);
+
+      const app = makeApp();
+      const [analyzeA, analyzeB] = await Promise.all([
+        scopedAnalystHeaders(
+          request(app).post('/api/agent/v1/analyze'),
+          { userId: 'analyst-a', workspaceId: 'workspace-a' },
+        ).send({ traceId: 'trace-concurrent-a', query: 'analyze trace a' }),
+        scopedAnalystHeaders(
+          request(app).post('/api/agent/v1/analyze'),
+          { userId: 'analyst-b', workspaceId: 'workspace-b' },
+        ).send({ traceId: 'trace-concurrent-b', query: 'analyze trace b' }),
+      ]);
+
+      expect(analyzeA.status).toBe(200);
+      expect(analyzeB.status).toBe(200);
+      sessionIds.push(analyzeA.body.sessionId, analyzeB.body.sessionId);
+      expect(analyzeA.body.sessionId).not.toBe(analyzeB.body.sessionId);
+      expect(analyzeA.body.runId).not.toBe(analyzeB.body.runId);
+
+      const [cancelA, statusB] = await Promise.all([
+        scopedAnalystHeaders(
+          request(app).post(`/api/agent/v1/${analyzeA.body.sessionId}/cancel`),
+          { userId: 'analyst-a', workspaceId: 'workspace-a' },
+        ),
+        scopedAnalystHeaders(
+          request(app).get(`/api/agent/v1/${analyzeB.body.sessionId}/status`),
+          { userId: 'analyst-b', workspaceId: 'workspace-b' },
+        ),
+      ]);
+
+      expect(cancelA.status).toBe(200);
+      expect(cancelA.body).toEqual(expect.objectContaining({
+        sessionId: analyzeA.body.sessionId,
+        status: 'failed',
+      }));
+      expect(statusB.status).toBe(200);
+      expect(statusB.body).toEqual(expect.objectContaining({
+        sessionId: analyzeB.body.sessionId,
+        status: 'running',
+      }));
+
+      const crossStatus = await scopedAnalystHeaders(
+        request(app).get(`/api/agent/v1/${analyzeB.body.sessionId}/status`),
+        { userId: 'analyst-a', workspaceId: 'workspace-a' },
+      );
+      expect(crossStatus.status).toBe(404);
+
+      const cancelB = await scopedAnalystHeaders(
+        request(app).post(`/api/agent/v1/${analyzeB.body.sessionId}/cancel`),
+        { userId: 'analyst-b', workspaceId: 'workspace-b' },
+      );
+      expect(cancelB.status).toBe(200);
+
+      leaseStore = getTraceProcessorLeaseStore();
+      expect(leaseStore.listLeases({
+        tenantId: 'tenant-a',
+        workspaceId: 'workspace-a',
+        userId: 'analyst-a',
+      }, { traceId: 'trace-concurrent-a' })).toHaveLength(1);
+      expect(leaseStore.listLeases({
+        tenantId: 'tenant-a',
+        workspaceId: 'workspace-b',
+        userId: 'analyst-b',
+      }, { traceId: 'trace-concurrent-b' })).toHaveLength(1);
+    } finally {
+      for (const sessionId of sessionIds) {
+        sessionContextManager.remove(sessionId);
+      }
       leaseStore?.close();
       setTraceProcessorLeaseStoreForTests(null);
       await fs.rm(tmpDir, { recursive: true, force: true });

--- a/backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts
+++ b/backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts
@@ -67,14 +67,29 @@ function restoreEnvValue(key: string, value: string | undefined): void {
   }
 }
 
-function ssoHeaders(req: request.Test, workspaceId = 'workspace-a'): request.Test {
+function scopedSsoHeaders(
+  req: request.Test,
+  options: {
+    userId?: string;
+    email?: string;
+    tenantId?: string;
+    workspaceId?: string;
+    roles?: string;
+    scopes?: string;
+  } = {},
+): request.Test {
+  const userId = options.userId ?? 'user-a';
   return req
-    .set('X-SmartPerfetto-SSO-User-Id', 'user-a')
-    .set('X-SmartPerfetto-SSO-Email', 'user-a@example.test')
-    .set('X-SmartPerfetto-SSO-Tenant-Id', 'tenant-a')
-    .set('X-SmartPerfetto-SSO-Workspace-Id', workspaceId)
-    .set('X-SmartPerfetto-SSO-Roles', 'analyst')
-    .set('X-SmartPerfetto-SSO-Scopes', 'trace:read,trace:write,trace:download');
+    .set('X-SmartPerfetto-SSO-User-Id', userId)
+    .set('X-SmartPerfetto-SSO-Email', options.email ?? `${userId}@example.test`)
+    .set('X-SmartPerfetto-SSO-Tenant-Id', options.tenantId ?? 'tenant-a')
+    .set('X-SmartPerfetto-SSO-Workspace-Id', options.workspaceId ?? 'workspace-a')
+    .set('X-SmartPerfetto-SSO-Roles', options.roles ?? 'analyst')
+    .set('X-SmartPerfetto-SSO-Scopes', options.scopes ?? 'trace:read,trace:write,trace:download');
+}
+
+function ssoHeaders(req: request.Test, workspaceId = 'workspace-a'): request.Test {
+  return scopedSsoHeaders(req, { workspaceId });
 }
 
 function adminHeaders(req: request.Test, workspaceId = 'workspace-a'): request.Test {
@@ -355,6 +370,60 @@ describe('enterprise trace metadata routes', () => {
       'workspace-b',
     );
     expect(otherWorkspaceRes.status).toBe(404);
+  });
+
+  it('keeps simultaneous user uploads scoped while concurrent cleanup is blocked by active holders', async () => {
+    const app = makeApp();
+
+    const [uploadA, uploadB] = await Promise.all([
+      scopedSsoHeaders(
+        request(app)
+          .post('/api/traces/upload')
+          .attach('file', Buffer.from('trace-a'), 'same-name.trace'),
+        { userId: 'user-a', workspaceId: 'workspace-a' },
+      ),
+      scopedSsoHeaders(
+        request(app)
+          .post('/api/traces/upload')
+          .attach('file', Buffer.from('trace-b'), 'same-name.trace'),
+        { userId: 'user-b', workspaceId: 'workspace-b' },
+      ),
+    ]);
+
+    expect(uploadA.status).toBe(200);
+    expect(uploadB.status).toBe(200);
+    const traceA = uploadA.body.trace.id as string;
+    const traceB = uploadB.body.trace.id as string;
+    expect(traceA).not.toBe(traceB);
+
+    await expect(fs.readFile(
+      path.join(dataDir, 'tenant-a', 'workspace-a', 'traces', `${traceA}.trace`),
+      'utf-8',
+    )).resolves.toBe('trace-a');
+    await expect(fs.readFile(
+      path.join(dataDir, 'tenant-a', 'workspace-b', 'traces', `${traceB}.trace`),
+      'utf-8',
+    )).resolves.toBe('trace-b');
+
+    const [listA, listB, cleanupA] = await Promise.all([
+      scopedSsoHeaders(request(app).get('/api/traces'), { userId: 'user-a', workspaceId: 'workspace-a' }),
+      scopedSsoHeaders(request(app).get('/api/traces'), { userId: 'user-b', workspaceId: 'workspace-b' }),
+      adminHeaders(request(app).post('/api/traces/cleanup'), 'workspace-a'),
+    ]);
+
+    expect(listA.status).toBe(200);
+    expect(listA.body.traces.map((trace: any) => trace.id)).toEqual([traceA]);
+    expect(listB.status).toBe(200);
+    expect(listB.body.traces.map((trace: any) => trace.id)).toEqual([traceB]);
+    expect(cleanupA.status).toBe(409);
+    expect(cleanupA.body.blockedLeases).toEqual([
+      expect.objectContaining({
+        traceId: traceA,
+        holderCount: 1,
+        holderTypes: ['frontend_http_rpc'],
+      }),
+    ]);
+    expect(fakeTraceProcessorService.cleanupProcessorsForTraces).not.toHaveBeenCalled();
   });
 
   it('rejects uploads that exceed workspace trace quota before metadata is committed', async () => {

--- a/backend/src/routes/__tests__/traceProcessorProxyRoutes.test.ts
+++ b/backend/src/routes/__tests__/traceProcessorProxyRoutes.test.ts
@@ -287,6 +287,54 @@ describe('trace processor lease proxy routes', () => {
     );
   });
 
+  it('preserves scoped lease routing for concurrent proxy queries', async () => {
+    const app = makeApp();
+    queryRawMock.mockImplementation(async (_traceId: string, body: Buffer) => {
+      if (body.equals(Buffer.from([1, 2, 3]))) {
+        await new Promise(resolve => setTimeout(resolve, 10));
+      }
+      return Buffer.from(body);
+    });
+
+    const [firstQuery, secondQuery] = await Promise.all([
+      ssoHeaders(
+        request(app)
+          .post(`/api/tp/${lease.id}/query`)
+          .set('Content-Type', 'application/x-protobuf')
+          .send(Buffer.from([1, 2, 3]))
+          .buffer(true)
+          .parse(binaryParser),
+      ),
+      ssoHeaders(
+        request(app)
+          .post(`/api/tp/${lease.id}/query`)
+          .set('Content-Type', 'application/x-protobuf')
+          .send(Buffer.from([4, 5, 6]))
+          .buffer(true)
+          .parse(binaryParser),
+      ),
+    ]);
+
+    expect(firstQuery.status).toBe(200);
+    expect(Buffer.from(firstQuery.body)).toEqual(Buffer.from([1, 2, 3]));
+    expect(secondQuery.status).toBe(200);
+    expect(Buffer.from(secondQuery.body)).toEqual(Buffer.from([4, 5, 6]));
+    expect(queryRawMock).toHaveBeenCalledTimes(2);
+    for (const call of queryRawMock.mock.calls) {
+      expect(call[0]).toBe('trace-a');
+      expect(call[2]).toEqual({
+        priority: 'p0',
+        leaseId: lease.id,
+        leaseMode: 'shared',
+        leaseScope: {
+          tenantId: 'tenant-a',
+          workspaceId: 'workspace-a',
+          userId: 'user-a',
+        },
+      });
+    }
+  });
+
   it('hides leases from other workspaces', async () => {
     const app = makeApp();
 

--- a/docs/features/enterprise-multi-tenant/README.md
+++ b/docs/features/enterprise-multi-tenant/README.md
@@ -94,7 +94,7 @@
 ### 0.6 测试矩阵补全（§20，与主线绑定）
 - [x] 6.1 Unit：RequestContext / RBAC / owner guard / provider resolution / ProviderSnapshot hash
 - [x] 6.2 Integration：trace upload/list/delete/download；agent analyze/resume/respond/stream；report read/delete
-- [ ] 6.3 Concurrency：多用户同时 upload / analyze / query / cancel / cleanup
+- [x] 6.3 Concurrency：多用户同时 upload / analyze / query / cancel / cleanup
 - [x] 6.4 Dual-window e2e：D1-D10 每个场景至少 1 个自动化用例（详见 §0.7）
 - [ ] 6.5 Security：ID 枚举、跨 tenant、无权限访问统一 404
 - [ ] 6.6 Runtime：lease acquire / release / heartbeat / stale / crash recovery
@@ -145,6 +145,7 @@
 - [x] `docs/features/enterprise-multi-tenant/admin-control-plane.md`（§0.5.1 tenant/workspace/member/provider/quota 管理面契约与验证）
 - [x] `docs/features/enterprise-multi-tenant/unit-coverage-matrix.md`（§0.6.1 Unit 覆盖证据与 test:core 固定入口）
 - [x] `docs/features/enterprise-multi-tenant/integration-coverage-matrix.md`（§0.6.2 Integration 主链路覆盖证据与 test:core 固定入口）
+- [x] `docs/features/enterprise-multi-tenant/concurrency-coverage-matrix.md`（§0.6.3 多用户并发 upload/analyze/query/cancel/cleanup 覆盖证据）
 
 ### 0.10 PR / 提交收尾（每次 PR 都要走）
 - [ ] 每个主线 / 子主线一个独立 PR；不跨主线串改动

--- a/docs/features/enterprise-multi-tenant/concurrency-coverage-matrix.md
+++ b/docs/features/enterprise-multi-tenant/concurrency-coverage-matrix.md
@@ -1,0 +1,31 @@
+# Enterprise Concurrency Coverage Matrix
+
+本文件记录 §0.6.3 的并发测试覆盖证据。范围限定为多用户同时触发的主链路：upload、analyze、query、cancel、cleanup。
+
+## Scope
+
+| §0.6.3 链路 | 自动证据 | 覆盖的不变量 |
+| --- | --- | --- |
+| 多用户同时 upload | `backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts` | 两个用户同时上传同名 trace 时生成不同 traceId，文件分别落到 `data/{tenantId}/{workspaceId}/traces/`，列表只返回当前 workspace 的 trace。 |
+| upload 与 cleanup 并发 | `backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts` | workspace admin cleanup 只扫描当前 workspace；当该 workspace 存在 active frontend holder 时返回 409，不清理其他 workspace 的并发上传结果。 |
+| 多用户同时 analyze | `backend/src/routes/__tests__/agentRoutesRbac.test.ts` | 两个 workspace 的分析请求同时创建独立 session/run/lease；一个用户取消自己的 run 不影响另一个 workspace 的 running run。 |
+| cancel 隔离 | `backend/src/routes/__tests__/agentRoutesRbac.test.ts` | `POST /api/agent/v1/:sessionId/cancel` 只作用于当前 RequestContext 可访问 session；跨 workspace status 查询统一返回 404。 |
+| 并发 query | `backend/src/routes/__tests__/traceProcessorProxyRoutes.test.ts` | 两个并发 `/api/tp/:leaseId/query` 请求都通过同一个 scoped lease 进入 P0 routing，每个响应返回自己的 protobuf body，不串请求上下文。 |
+
+## Verification
+
+最小回归：
+
+```bash
+cd backend && npx jest --runInBand --forceExit \
+  src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts \
+  src/routes/__tests__/agentRoutesRbac.test.ts \
+  src/routes/__tests__/traceProcessorProxyRoutes.test.ts
+```
+
+PR gate 中的固定入口：
+
+```bash
+cd backend && npm run test:core
+npm run verify:pr
+```


### PR DESCRIPTION
## Summary
- Pin §0.6.3 concurrency coverage with a dedicated matrix document.
- Add concurrent multi-user trace upload coverage, including scoped list isolation and cleanup blocking.
- Add concurrent agent analyze/cancel coverage across workspaces.
- Add concurrent trace processor proxy query coverage through a scoped lease.
- Mark README §0.6.3 complete and register the new evidence document in §0.9.

## Verification
- cd backend && npx jest --runInBand --forceExit src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts src/routes/__tests__/agentRoutesRbac.test.ts src/routes/__tests__/traceProcessorProxyRoutes.test.ts
- cd backend && npm run typecheck
- git diff --check
- cd backend && npm run test:core
- npm run verify:pr