### PR TITLE
test(enterprise): harden repository ordering

### DIFF
--- a/backend/src/services/__tests__/enterpriseRepository.test.ts
+++ b/backend/src/services/__tests__/enterpriseRepository.test.ts
@@ -213,6 +213,11 @@ describe('enterprise repository scope abstraction', () => {
       {},
       { orderBy: 'id; DROP TABLE trace_assets' },
     )).toThrow('Invalid orderBy column');
+    expect(() => repo.list(
+      { tenantId: 'tenant-a', workspaceId: 'workspace-a' },
+      {},
+      { orderBy: 'id', direction: 'DESC; DROP TABLE trace_assets' as never },
+    )).toThrow('Invalid orderBy direction');
   });
 
   test('does not allow scoped updates to mutate identity columns', () => {

--- a/backend/src/services/enterpriseRepository.ts
+++ b/backend/src/services/enterpriseRepository.ts
@@ -120,6 +120,9 @@ function buildOrderClause(options: ListOptions): string {
   if (!options.orderBy) return '';
   assertIdentifier(options.orderBy, 'orderBy column');
   const direction = options.direction ?? 'ASC';
+  if (direction !== 'ASC' && direction !== 'DESC') {
+    throw new Error(`Invalid orderBy direction: ${String(direction)}`);
+  }
   return ` ORDER BY ${options.orderBy} ${direction}`;
 }
 


### PR DESCRIPTION
## Summary
- Harden the enterprise workspace repository dynamic ORDER BY builder by validating direction at runtime, not only through TypeScript literal types.
- Add coverage that rejects an injected ordering direction while preserving existing tenant/workspace scoped repository assertions.

## TODO
- §0.3.1 SQLite WAL + repository abstraction follow-up hardening; the TODO was already complete, this PR tightens the repository boundary.

## Verification
- `cd backend && PATH="/Users/chris/.nvm/versions/node/v24.15.0/bin:/Users/chris/.codex/tmp/arg0/codex-arg0Ggjp4H:/Users/chris/.nvm/versions/node/v20.19.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.config/kaku/zsh/bin:/Users/chris/.opencode/bin:/Users/chris/.bun/bin:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.nvm/versions/node/v20.19.0/bin:/opt/homebrew/share/google-cloud-sdk/bin:/Users/chris/.local/bin:/Users/chris/.local/bin:/Users/chris/.codeium/windsurf/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/chris/.cargo/bin:/Users/chris/tools/Android-sdk/platform-tools/:/Users/chris/tools/TTDeDroid/bin:/Users/chris/tools/depot_tools:/Users/chris/tools/flutter/flutter/bin:/Applications/Warp.app/Contents/Resources/bin" npx jest src/services/__tests__/enterpriseRepository.test.ts src/services/__tests__/enterpriseDb.test.ts --runInBand` PASS, 2 suites / 11 tests
- `cd backend && PATH="/Users/chris/.nvm/versions/node/v24.15.0/bin:/Users/chris/.codex/tmp/arg0/codex-arg0Ggjp4H:/Users/chris/.nvm/versions/node/v20.19.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.config/kaku/zsh/bin:/Users/chris/.opencode/bin:/Users/chris/.bun/bin:/Users/chris/.antigravity/antigravity/bin:/Users/chris/.nvm/versions/node/v20.19.0/bin:/opt/homebrew/share/google-cloud-sdk/bin:/Users/chris/.local/bin:/Users/chris/.local/bin:/Users/chris/.codeium/windsurf/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/chris/.cargo/bin:/Users/chris/tools/Android-sdk/platform-tools/:/Users/chris/tools/TTDeDroid/bin:/Users/chris/tools/depot_tools:/Users/chris/tools/flutter/flutter/bin:/Applications/Warp.app/Contents/Resources/bin" npm run typecheck` PASS
- `git diff --check` PASS