### PR TITLE
fix(agent): allow new requests to preempt active analysis sessions

### DIFF
--- a/backend/src/agentv3/claudeRuntime.ts
+++ b/backend/src/agentv3/claudeRuntime.ts
@@ -384,6 +384,10 @@ export class ClaudeRuntime extends EventEmitter implements IOrchestrator {
   private sessionUncertaintyFlags: Map<string, UncertaintyFlag[]> = new Map();
   /** Guard against concurrent analyze() calls for the same session. */
   private activeAnalyses: Set<string> = new Set();
+  /** Abort controllers for active analyses — allows preempting any phase. */
+  private analysisAbortControllers: Map<string, AbortController> = new Map();
+  /** SDK close functions for active analyses — terminates the SDK subprocess. */
+  private analysisSdkClosers: Map<string, () => void> = new Map();
 
   constructor(traceProcessorService: TraceProcessorService, config?: Partial<ClaudeAgentConfig>) {
     super();
@@ -475,11 +479,20 @@ export class ClaudeRuntime extends EventEmitter implements IOrchestrator {
     traceId: string,
     options: AnalysisOptions = {},
   ): Promise<AnalysisResult> {
-    // Prevent concurrent analyze() calls for the same session
+    // Preempt any existing analysis for this session (user moved on)
     if (this.activeAnalyses.has(sessionId)) {
-      throw new Error(`Analysis already in progress for session ${sessionId}`);
+      const prevAbort = this.analysisAbortControllers.get(sessionId);
+      if (prevAbort) prevAbort.abort();
+      const prevCloser = this.analysisSdkClosers.get(sessionId);
+      if (prevCloser) { try { prevCloser(); } catch { /* already closed */ } }
+      this.activeAnalyses.delete(sessionId);
+      this.analysisAbortControllers.delete(sessionId);
+      this.analysisSdkClosers.delete(sessionId);
+      console.log(`[ClaudeRuntime] Session ${sessionId}: preempted previous analysis for new request`);
     }
     this.activeAnalyses.add(sessionId);
+    const analysisAbort = new AbortController();
+    this.analysisAbortControllers.set(sessionId, analysisAbort);
 
     const startTime = Date.now();
     const allFindings: Finding[][] = [];
@@ -651,6 +664,9 @@ export class ClaudeRuntime extends EventEmitter implements IOrchestrator {
         outputLanguage: this.config.outputLanguage,
       });
 
+      // Register SDK closer so a preempting request can terminate this subprocess.
+      this.analysisSdkClosers.set(sessionId, closeSdk);
+
       let finalResult: string | undefined;
       let terminationReason: AnalysisResult['terminationReason'];
       let terminationMessage: string | undefined;
@@ -780,7 +796,7 @@ export class ClaudeRuntime extends EventEmitter implements IOrchestrator {
 
       const processStream = async () => {
         for await (const msg of stream) {
-          if (timedOut) break; // P0-1: Actually cancel stream on timeout
+          if (timedOut || analysisAbort.signal.aborted) break;
 
           // Detect SDK auto-compact boundary — conversation history was summarized
           if ((msg as any).type === 'system' && (msg as any).subtype === 'compact_boundary') {
@@ -1118,7 +1134,22 @@ export class ClaudeRuntime extends EventEmitter implements IOrchestrator {
       try {
         await Promise.race([processStream(), timeoutPromise]);
       } catch (err) {
-        if (timedOut) {
+        if (analysisAbort.signal.aborted) {
+          console.log(`[ClaudeRuntime] Session ${sessionId}: analysis preempted by new request`);
+          return {
+            sessionId,
+            success: true,
+            findings: mergeFindings(allFindings),
+            hypotheses: [],
+            conclusion: getAccumulatedAnswer() || '',
+            confidence: 0,
+            rounds,
+            totalDurationMs: Date.now() - startTime,
+            partial: true,
+            terminationReason: 'preempted' as any,
+            terminationMessage: 'Analysis preempted by new user request',
+          };
+        } else if (timedOut) {
           console.error('[ClaudeRuntime] Analysis safety timeout reached — SDK subprocess has been closed');
           this.emitUpdate({
             type: 'progress',
@@ -1138,6 +1169,23 @@ export class ClaudeRuntime extends EventEmitter implements IOrchestrator {
       } finally {
         if (safetyTimer) clearTimeout(safetyTimer);
         closeSdk();
+      }
+
+      // If preempted while stream was running, exit early
+      if (analysisAbort.signal.aborted) {
+        return {
+          sessionId,
+          success: true,
+          findings: mergeFindings(allFindings),
+          hypotheses: [],
+          conclusion: getAccumulatedAnswer() || '',
+          confidence: 0,
+          rounds,
+          totalDurationMs: Date.now() - startTime,
+          partial: true,
+          terminationReason: 'preempted' as any,
+          terminationMessage: 'Analysis preempted by new user request',
+        };
       }
 
       // Use SDK terminal result if available; fall back to accumulated streamed answer tokens.
@@ -1183,12 +1231,13 @@ export class ClaudeRuntime extends EventEmitter implements IOrchestrator {
       // Run unconditionally when enabled — plan adherence, hypothesis resolution,
       // and conclusion-length checks must fire even when zero findings are extracted.
       console.log(`[ClaudeRuntime] Pre-verification: conclusionText=${conclusionText.length} chars, sdkSessionId=${sdkSessionId ? 'set' : 'MISSING'}, enableVerification=${runtimeConfig.enableVerification}`);
-      if (runtimeConfig.enableVerification) {
+      if (runtimeConfig.enableVerification && !analysisAbort.signal.aborted) {
         const MAX_CORRECTION_ATTEMPTS = 2;
         let previousErrorSignatures = new Set<string>();
 
         try {
           for (let attempt = 0; attempt < MAX_CORRECTION_ATTEMPTS; attempt++) {
+            if (analysisAbort.signal.aborted) break;
             const verification = await verifyConclusion(mergedFindings, conclusionText, {
               emitUpdate: (update) => this.emitUpdate(update),
               enableLLM: true,
@@ -1239,6 +1288,8 @@ export class ClaudeRuntime extends EventEmitter implements IOrchestrator {
               },
               timestamp: Date.now(),
             });
+
+            if (analysisAbort.signal.aborted) break;
 
             try {
               const correctionPrompt = generateCorrectionPrompt(
@@ -1587,6 +1638,8 @@ export class ClaudeRuntime extends EventEmitter implements IOrchestrator {
       };
     } finally {
       this.activeAnalyses.delete(sessionId);
+      this.analysisAbortControllers.delete(sessionId);
+      this.analysisSdkClosers.delete(sessionId);
       runSnapshots.release(sessionId);
       // Notes persistence now handled by unified SessionStateSnapshot in the route layer.
       // No separate disk I/O needed here.
@@ -1969,6 +2022,12 @@ export class ClaudeRuntime extends EventEmitter implements IOrchestrator {
     this.sessionHypotheses.delete(sessionId);
     this.sessionUncertaintyFlags.delete(sessionId);
     this.activeAnalyses.delete(sessionId);
+    const abortCtrl = this.analysisAbortControllers.get(sessionId);
+    if (abortCtrl) abortCtrl.abort();
+    this.analysisAbortControllers.delete(sessionId);
+    const closer = this.analysisSdkClosers.get(sessionId);
+    if (closer) { try { closer(); } catch { /* already closed */ } }
+    this.analysisSdkClosers.delete(sessionId);
     if (enterpriseSessionMapDbWritesEnabled()) {
       try {
         deleteClaudeSessionMapRuntimeSnapshots(sessionId);
@@ -2140,6 +2199,10 @@ export class ClaudeRuntime extends EventEmitter implements IOrchestrator {
     this.sessionHypotheses.clear();
     this.sessionUncertaintyFlags.clear();
     this.activeAnalyses.clear();
+    for (const ctrl of this.analysisAbortControllers.values()) ctrl.abort();
+    this.analysisAbortControllers.clear();
+    for (const closer of this.analysisSdkClosers.values()) { try { closer(); } catch { /* */ } }
+    this.analysisSdkClosers.clear();
   }
 
   private emitUpdate(update: StreamingUpdate): void {


### PR DESCRIPTION
## Summary

- Fix the "Analysis already in progress" error that occurs when users send a follow-up message while AI analysis is still running (during SDK processing or verification phase)
- Replace the hard-reject concurrency lock with full preemption: terminate the running SDK subprocess and let the new request proceed immediately
- The preempted analysis returns a partial result gracefully instead of leaving the session in a broken state

## Problem

After the AI shows its conclusion text (streamed via `answer_token` events), the backend may still be in the SDK finalization loop or verification phase. If the user sends a new message during this window, the `activeAnalyses` guard throws an error → SSE `error` event → red "AI: Error" in the status bar.

This was documented in the user guide (飞书文档) as a known issue with a workaround of "wait until the status bar clears before sending the next message."

## Solution

Store an `AbortController` and the SDK `closeSdk()` function per active session. When a new request arrives for a session that already has an active analysis:

1. Signal abort via `AbortController`
2. Kill the SDK subprocess via stored `closeSdk()`
3. Clean up state and allow the new analysis to start

The abort signal is checked at multiple points:
- In the `for-await` stream processing loop
- After stream completion (before verification)
- Before each verification attempt
- Before each correction retry

## Test plan

- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] Automated test: send two requests to same session 2s apart → second succeeds, backend logs show "preempted previous analysis for new request"
- [x] No SSE `error` events for the second request
- [ ] Manual browser test: load trace → run full analysis → send follow-up while "分析中..." is showing → should work without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)