### PR TITLE
Fix OpenAI tool schema for skill params

### DIFF
--- a/backend/src/agentOpenAI/__tests__/openAiToolAdapter.test.ts
+++ b/backend/src/agentOpenAI/__tests__/openAiToolAdapter.test.ts
@@ -35,7 +35,11 @@ describe('createOpenAIToolsFromMcpDefinitions', () => {
     expect(functionTool.parameters.properties.params.anyOf).toEqual(
       expect.arrayContaining([expect.objectContaining({ type: 'null' })]),
     );
+    expect(functionTool.parameters.properties.params.anyOf).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'string' })]),
+    );
     expect(JSON.stringify(functionTool.parameters)).not.toContain('propertyNames');
+    expect(JSON.stringify(functionTool.parameters)).not.toContain('"additionalProperties":{}');
 
     let output = await functionTool.invoke(
       {} as any,

--- a/backend/src/agentOpenAI/openAiToolAdapter.ts
+++ b/backend/src/agentOpenAI/openAiToolAdapter.ts
@@ -34,13 +34,37 @@ function stringifyToolResult(result: unknown): string {
   return typeof result === 'string' ? result : JSON.stringify(result);
 }
 
-function sanitizeJsonSchema(value: unknown): unknown {
+/** 判断 schema 是否来自 z.record(z.string(), z.any()) 这类开放参数对象。 */
+function isOpenRecordAnySchema(entries: Array<[string, unknown]>): boolean {
+  const record = Object.fromEntries(entries) as Record<string, unknown>;
+  const additionalProperties = record.additionalProperties;
+  return record.type === 'object'
+    && (!('properties' in record) || Object.keys(record.properties as Record<string, unknown> || {}).length === 0)
+    && !!additionalProperties
+    && typeof additionalProperties === 'object'
+    && !Array.isArray(additionalProperties)
+    && Object.keys(additionalProperties as Record<string, unknown>).length === 0;
+}
+
+/** 清理 Zod 生成但 OpenAI function schema 不接受的 JSON Schema 片段。 */
+function sanitizeJsonSchema(value: unknown, parentKey?: string): unknown {
   if (Array.isArray(value)) {
     return value.map((item) => sanitizeJsonSchema(item));
   }
 
   if (!value || typeof value !== 'object') {
     return value;
+  }
+
+  const entries = Object.entries(value);
+  if (isOpenRecordAnySchema(entries)) {
+    const description = (value as Record<string, unknown>).description;
+    return {
+      type: 'string',
+      ...(typeof description === 'string'
+        ? { description: `${description} Pass as a JSON object string.` }
+        : { description: 'JSON object string.' }),
+    };
   }
 
   const sanitized: Record<string, unknown> = {};
@@ -51,7 +75,10 @@ function sanitizeJsonSchema(value: unknown): unknown {
     if (key === '$schema' || key === 'propertyNames') {
       continue;
     }
-    sanitized[key] = sanitizeJsonSchema(nested);
+    const sanitizedNested = sanitizeJsonSchema(nested, key);
+    if (sanitizedNested !== undefined) {
+      sanitized[key] = sanitizedNested;
+    }
   }
   return sanitized;
 }


### PR DESCRIPTION
<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
  <!-- Copyright (C) 2024-2026 Gracker (Chris) | SmartPerfetto -->

  ## Summary

  - Fix OpenAI Agents SDK tool schema generation for open `z.record(z.string(), z.any())` parameters.
  - Convert unrestricted record params to JSON string parameters in the OpenAI adapter, relying on existing runtime argument normalization to parse them back into objects.
  - Add regression coverage for `invoke_skill.params` so generated schemas no longer include `additionalProperties: {}`.

  ## Linked Issue

  N/A

  ## Change Type

  - [ ] feat (new capability)
  - [x] fix (bug fix, no API change)
  - [ ] refactor (internal cleanup, no behavior change)
  - [ ] docs (documentation only)
  - [ ] chore (build, CI, tooling, dependency updates)
  - [ ] skill / strategy (YAML skill or `.strategy.md` / `.template.md`)

  ## Affected Areas

  - [ ] `backend/src/agentv3/` (primary runtime: ClaudeRuntime, MCP server, verifier)
  - [ ] `backend/skills/` (YAML skills)
  - [ ] `backend/strategies/` (`*.strategy.md`, `.template.md`, `knowledge-*`)
  - [ ] `perfetto/ui/src/plugins/com.smartperfetto.AIAssistant/` (frontend)
  - [ ] `scripts/` / `backend/scripts/` (tooling, generators)
  - [ ] `.github/workflows/` (CI)
  - [x] Tests only

  ## Done Conditions

  - [ ] `npm run verify:pr` from repo root → green
  - [x] I included any extra targeted test command needed for this change in the test plan below
  - [x] New `.ts` / `.yaml` / `.sh` / `.strategy.md` files carry SPDX AGPL v3 header

  ## Test Plan

  - `cd backend && npm test -- --runInBand src/agentOpenAI/__tests__/openAiToolAdapter.test.ts`
  - `cd backend && npm run typecheck`

  ## Risk / Rollback

  - Risk: Models now see unrestricted skill params as a JSON string in the OpenAI tool schema, so malformed JSON could reduce tool-call quality. Existing argument normalization already
  parses JSON object strings back into objects before invoking the MCP tool handler.
  - Rollback: Revert this commit to restore the previous Zod-to-JSON-schema behavior.

  ## Notes for Reviewers

  - Root cause: OpenAI strict function schema validation rejects the empty schema generated under `additionalProperties` for `z.record(z.string(), z.any())`.
  - This keeps the SmartPerfetto MCP tool contract unchanged and only adapts the schema exposed through the OpenAI Agents SDK.
  只是测试了OpenAI adapter