### PR TITLE
fix(codebase): lazy-read SMARTPERFETTO_CODEBASE_ROOTS to fix ESM module init timing

### DIFF
--- a/backend/src/services/codebase/pathSecurityGate.ts
+++ b/backend/src/services/codebase/pathSecurityGate.ts
@@ -106,14 +106,15 @@ function shouldExclude(relativePath: string, basename: string, excludeNames: str
 }
 
 export class PathSecurityGate {
-  private readonly allowlistRoots: string[];
+  // null means "read from env at call time" (supports dotenv loaded after module init)
+  private readonly allowlistRootsOverride: string[] | null;
   private readonly excludeNames: string[];
   private readonly allowedExtensions: Set<string>;
   private readonly maxFileBytes: number;
   private readonly maxFiles: number;
 
   constructor(options: PathSecurityGateOptions = {}) {
-    this.allowlistRoots = options.allowlistRoots ?? configuredAllowlistRoots();
+    this.allowlistRootsOverride = options.allowlistRoots ?? null;
     this.excludeNames = options.excludeNames ?? DEFAULT_EXCLUDES;
     this.allowedExtensions = new Set(options.allowedExtensions ?? DEFAULT_EXTENSIONS);
     this.maxFileBytes = options.maxFileBytes ?? 200 * 1024;
@@ -121,6 +122,9 @@ export class PathSecurityGate {
   }
 
   preview(rootPath: string): PathPreviewResult {
+    // Read env lazily so SMARTPERFETTO_CODEBASE_ROOTS set via dotenv (loaded after
+    // module init in ESM) is visible on the first real request.
+    const allowlistRoots = this.allowlistRootsOverride ?? configuredAllowlistRoots();
     const rootRealpath = safeRealpath(rootPath);
     if (!rootRealpath) {
       return {
@@ -132,7 +136,7 @@ export class PathSecurityGate {
         blockedReason: 'root_not_found',
       };
     }
-    if (this.allowlistRoots.length === 0 || !isWithinAllowlist(rootRealpath, this.allowlistRoots)) {
+    if (allowlistRoots.length === 0 || !isWithinAllowlist(rootRealpath, allowlistRoots)) {
       return {
         rootPath,
         rootRealpath,


### PR DESCRIPTION
## Problem

`PathSecurityGate` is constructed at module initialization time in `ragAdminRoutes.ts`:

```ts
const ragAdminRoutes = createRagAdminRoutes(); // module top-level
export default ragAdminRoutes;
```

Because tsx runs with an ESM loader (`--import tsx/dist/loader.mjs`), all static imports in `index.ts` are evaluated **before** the module body runs — including `dotenv.config()`. So `SMARTPERFETTO_CODEBASE_ROOTS` is not yet in `process.env` when `PathSecurityGate` reads it in the constructor, and `allowlistRoots` is always initialized as `[]`.

Result: every codebase registration attempt returns `root_outside_allowlist`, even when `SMARTPERFETTO_CODEBASE_ROOTS` is correctly set in `.env`.

## Fix

Defer env var reading from construction time to call time. When `options.allowlistRoots` is not explicitly provided, store `null` and call `configuredAllowlistRoots()` inside `preview()` on each invocation. Explicit values passed via options (tests / DI) are unaffected.

## Test

1. Add `SMARTPERFETTO_CODEBASE_ROOTS=/some/local/path` to `backend/.env`
2. Start with `./start.sh` (no shell env var override)
3. Open Settings → Codebases → Register a path under the allowed root
4. Before fix: `root_outside_allowlist`; After fix: `blocked: false`