### PR TITLE
fix(rag/codebase): 修复 ingest O(n²) 写盘、async 调用缺 await、排除 .gradle/.idea

### DIFF
--- a/backend/src/cli-user/commands/codebase.ts
+++ b/backend/src/cli-user/commands/codebase.ts
@@ -41,7 +41,7 @@ export async function runCodebasePreviewCommand(args: CodebaseCommandBaseArgs & 
   const rootPath = path.resolve(args.rootPath);
   bootstrap({envFile: args.envFile, sessionDir: args.sessionDir});
   const gate = new PathSecurityGate({allowlistRoots: [rootPath]});
-  const preview = gate.preview(rootPath);
+  const preview = await gate.preview(rootPath);
   console.log(JSON.stringify({
     blocked: preview.blocked,
     blockedReason: preview.blockedReason,
@@ -67,7 +67,7 @@ export async function runCodebaseRegisterCommand(args: CodebaseCommandBaseArgs &
   const rootPath = path.resolve(args.rootPath);
   bootstrap({envFile: args.envFile, sessionDir: args.sessionDir});
   const gate = new PathSecurityGate({allowlistRoots: [rootPath]});
-  const preview = gate.preview(rootPath);
+  const preview = await gate.preview(rootPath);
   if (preview.blocked) {
     console.error(`blocked: ${preview.blockedReason ?? 'path security gate rejected root'}`);
     return 1;
@@ -109,11 +109,11 @@ export async function runCodebaseReindexCommand(args: CodebaseCommandBaseArgs & 
   }
   const store = new RagStore(ragStorePath());
   const gate = new PathSecurityGate({allowlistRoots: [ref.rootRealpath]});
-  const result = ref.kind === 'kernel_source'
+  const result = await (ref.kind === 'kernel_source'
     ? new KernelSourceIngester(store, registry, gate).ingest(args.codebaseId)
     : ref.kind === 'aosp'
       ? new AospSourceIngester(store, registry, gate).ingest(args.codebaseId)
-      : new AppSourceIngester(store, registry, gate).ingest(args.codebaseId);
+      : new AppSourceIngester(store, registry, gate).ingest(args.codebaseId));
   console.log(JSON.stringify(result, null, 2));
   return result.errors.length > 0 ? 1 : 0;
 }

--- a/backend/src/routes/ragAdminRoutes.ts
+++ b/backend/src/routes/ragAdminRoutes.ts
@@ -200,15 +200,15 @@ export function createRagAdminRoutes(store?: RagStore, services: RagAdminRouteSe
     });
   });
 
-  router.post('/codebases/preview', requireCodebaseScope('codebase:manage'), (req, res) => {
+  router.post('/codebases/preview', requireCodebaseScope('codebase:manage'), async (req, res) => {
     const {rootPath} = (req.body ?? {}) as {rootPath?: string};
     if (!rootPath || typeof rootPath !== 'string') {
       return res.status(400).json({success: false, error: '`rootPath` is required'});
     }
-    res.json({success: true, preview: sanitizePreview(gate.preview(rootPath))});
+    res.json({success: true, preview: sanitizePreview(await gate.preview(rootPath))});
   });
 
-  router.post('/codebases/register', requireCodebaseScope('codebase:manage'), (req, res) => {
+  router.post('/codebases/register', requireCodebaseScope('codebase:manage'), async (req, res) => {
     const {
       kind = 'app_source',
       displayName,
@@ -228,7 +228,7 @@ export function createRagAdminRoutes(store?: RagStore, services: RagAdminRouteSe
     if (!rootPath || typeof rootPath !== 'string') {
       return res.status(400).json({success: false, error: '`rootPath` is required'});
     }
-    const preview = gate.preview(rootPath);
+    const preview = await gate.preview(rootPath);
     if (preview.blocked) {
       return res.status(400).json({
         success: false,
@@ -344,18 +344,18 @@ export function createRagAdminRoutes(store?: RagStore, services: RagAdminRouteSe
     });
   });
 
-  router.post('/codebases/:id/reindex', requireCodebaseScope('codebase:manage'), (req, res) => {
+  router.post('/codebases/:id/reindex', requireCodebaseScope('codebase:manage'), async (req, res) => {
     const codebaseId = routeParam(req.params.id);
     const ref = registry.get(codebaseId);
     if (!ref) {
       return res.status(404).json({success: false, error: `Codebase '${codebaseId}' not found`});
     }
     try {
-      const result = ref.kind === 'kernel_source'
+      const result = await (ref.kind === 'kernel_source'
         ? kernelSourceIngester.ingest(codebaseId, req.body ?? {})
         : ref.kind === 'aosp'
           ? aospSourceIngester.ingest(codebaseId, req.body ?? {})
-          : appSourceIngester.ingest(codebaseId, req.body ?? {});
+          : appSourceIngester.ingest(codebaseId, req.body ?? {}));
       res.json({success: true, result});
     } catch (error) {
       res.status(400).json({

--- a/backend/src/services/codebase/pathSecurityGate.ts
+++ b/backend/src/services/codebase/pathSecurityGate.ts
@@ -3,10 +3,13 @@
 // This file is part of SmartPerfetto. See LICENSE for details.
 
 import * as fs from 'fs';
+import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 const DEFAULT_EXCLUDES = [
   '.git',
+  '.gradle',
+  '.idea',
   'node_modules',
   'build',
   'out',
@@ -86,6 +89,14 @@ function safeRealpath(target: string): string | null {
   }
 }
 
+async function safeRealpathAsync(target: string): Promise<string | null> {
+  try {
+    return await fsPromises.realpath(target);
+  } catch {
+    return null;
+  }
+}
+
 export function isWithinAllowlist(target: string, allowlist: string[]): boolean {
   const realTarget = safeRealpath(target);
   if (!realTarget) return false;
@@ -121,11 +132,11 @@ export class PathSecurityGate {
     this.maxFiles = options.maxFiles ?? 50_000;
   }
 
-  preview(rootPath: string): PathPreviewResult {
+  async preview(rootPath: string): Promise<PathPreviewResult> {
     // Read env lazily so SMARTPERFETTO_CODEBASE_ROOTS set via dotenv (loaded after
     // module init in ESM) is visible on the first real request.
     const allowlistRoots = this.allowlistRootsOverride ?? configuredAllowlistRoots();
-    const rootRealpath = safeRealpath(rootPath);
+    const rootRealpath = await safeRealpathAsync(rootPath);
     if (!rootRealpath) {
       return {
         rootPath,
@@ -153,18 +164,28 @@ export class PathSecurityGate {
 
     while (stack.length > 0) {
       const current = stack.pop()!;
-      const entries = fs.readdirSync(current, {withFileTypes: true});
+      const entries = await fsPromises.readdir(current, {withFileTypes: true});
       for (const entry of entries) {
         const fullPath = path.join(current, entry.name);
-        const realPath = safeRealpath(fullPath);
-        if (!realPath || !isWithinAllowlist(realPath, [rootRealpath])) {
+        const realPath = await safeRealpathAsync(fullPath);
+        // Detect symlinks that escape the root without calling isWithinAllowlist
+        // (realPath is already resolved, so a simple relative-path check suffices).
+        if (!realPath) {
           skippedFiles.push({
             relativePath: path.relative(rootRealpath, fullPath),
             reason: 'symlink_outside_root',
           });
           continue;
         }
-        const relativePath = path.relative(rootRealpath, realPath);
+        const rel = path.relative(rootRealpath, realPath);
+        if (rel.startsWith('..') || path.isAbsolute(rel)) {
+          skippedFiles.push({
+            relativePath: path.relative(rootRealpath, fullPath),
+            reason: 'symlink_outside_root',
+          });
+          continue;
+        }
+        const relativePath = rel;
         if (shouldExclude(relativePath, entry.name, this.excludeNames)) {
           if (entry.isFile()) skippedFiles.push({relativePath, reason: 'excluded'});
           continue;
@@ -179,7 +200,7 @@ export class PathSecurityGate {
           skippedFiles.push({relativePath, reason: 'extension_not_allowed'});
           continue;
         }
-        const stat = fs.statSync(realPath);
+        const stat = await fsPromises.stat(realPath);
         if (stat.size > this.maxFileBytes) {
           skippedFiles.push({relativePath, reason: 'file_too_large'});
           continue;

--- a/backend/src/services/rag/aospSourceIngester.ts
+++ b/backend/src/services/rag/aospSourceIngester.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2024-2026 Gracker (Chris)
 // This file is part of SmartPerfetto. See LICENSE for details.
 
-import * as fs from 'fs';
+import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import type {RagStore} from '../ragStore';
@@ -49,7 +49,7 @@ export class AospSourceIngester {
     private readonly gate: PathSecurityGate = new PathSecurityGate(),
   ) {}
 
-  ingest(codebaseId: string, opts: AospSourceIngestOptions = {}): AospSourceIngestResult {
+  async ingest(codebaseId: string, opts: AospSourceIngestOptions = {}): Promise<AospSourceIngestResult> {
     const ref = this.registry.get(codebaseId);
     if (!ref) throw new Error(`Codebase '${codebaseId}' not found`);
     if (ref.kind !== 'aosp') {
@@ -58,7 +58,7 @@ export class AospSourceIngester {
     if (!ref.licenseTag) {
       throw new Error(`AOSP codebase '${codebaseId}' requires licenseTag`);
     }
-    const preview = this.gate.preview(ref.rootRealpath);
+    const preview = await this.gate.preview(ref.rootRealpath);
     if (preview.blocked) {
       this.registry.updateIngestStatus(codebaseId, {
         lastIngestStatus: 'blocked_by_security',
@@ -86,8 +86,9 @@ export class AospSourceIngester {
     const maxChars = opts.maxChunkChars ?? DEFAULT_MAX_CHUNK_CHARS;
     for (const file of filterPreviewFiles(preview, ref, opts)) {
       result.filesProcessed++;
+      await new Promise<void>(r => setImmediate(r));
       try {
-        const content = fs.readFileSync(path.join(ref.rootRealpath, file.relativePath), 'utf-8');
+        const content = await fsPromises.readFile(path.join(ref.rootRealpath, file.relativePath), 'utf-8');
         const chunks = chunkSourceBySymbols(content, maxChars);
         if (chunks.length === 0) {
           result.chunksSkipped++;
@@ -119,6 +120,7 @@ export class AospSourceIngester {
         result.errors.push({filePath: file.relativePath, reason: error instanceof Error ? error.message : String(error)});
       }
     }
+    this.store.flush();
     this.registry.updateIngestStatus(codebaseId, {
       lastIngestStatus: result.errors.length > 0 ? 'partial' : 'ok',
       lastIngestAt: Date.now(),

--- a/backend/src/services/rag/appSourceIngester.ts
+++ b/backend/src/services/rag/appSourceIngester.ts
@@ -3,7 +3,7 @@
 // This file is part of SmartPerfetto. See LICENSE for details.
 
 import {createHash} from 'crypto';
-import * as fs from 'fs';
+import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import type {RagStore} from '../ragStore';
@@ -66,7 +66,7 @@ export class AppSourceIngester {
     private readonly gate: PathSecurityGate = new PathSecurityGate(),
   ) {}
 
-  ingest(codebaseId: string, opts: AppSourceIngestOptions = {}): AppSourceIngestResult {
+  async ingest(codebaseId: string, opts: AppSourceIngestOptions = {}): Promise<AppSourceIngestResult> {
     const ref = this.registry.get(codebaseId);
     if (!ref) {
       throw new Error(`Codebase '${codebaseId}' not found`);
@@ -75,7 +75,7 @@ export class AppSourceIngester {
       throw new Error(`Codebase '${codebaseId}' is kind=${ref.kind}; app source ingestion requires app_source`);
     }
 
-    const preview = this.gate.preview(ref.rootRealpath);
+    const preview = await this.gate.preview(ref.rootRealpath);
     if (preview.blocked) {
       this.registry.updateIngestStatus(codebaseId, {
         lastIngestStatus: 'blocked_by_security',
@@ -107,9 +107,10 @@ export class AppSourceIngester {
 
     for (const file of filterPreviewFiles(preview, ref, opts)) {
       result.filesProcessed++;
+      await new Promise<void>(r => setImmediate(r));
       try {
         const absolutePath = path.join(ref.rootRealpath, file.relativePath);
-        const content = fs.readFileSync(absolutePath, 'utf-8');
+        const content = await fsPromises.readFile(absolutePath, 'utf-8');
         const chunks = chunkSource(content, maxChars);
         if (chunks.length === 0) {
           result.chunksSkipped++;
@@ -147,6 +148,7 @@ export class AppSourceIngester {
       }
     }
 
+    this.store.flush();
     this.registry.updateIngestStatus(codebaseId, {
       lastIngestStatus: result.errors.length > 0 ? 'partial' : 'ok',
       lastIngestAt: Date.now(),

--- a/backend/src/services/rag/kernelSourceIngester.ts
+++ b/backend/src/services/rag/kernelSourceIngester.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2024-2026 Gracker (Chris)
 // This file is part of SmartPerfetto. See LICENSE for details.
 
-import * as fs from 'fs';
+import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import type {RagStore} from '../ragStore';
@@ -63,7 +63,7 @@ export class KernelSourceIngester {
     private readonly gate: PathSecurityGate = new PathSecurityGate(),
   ) {}
 
-  ingest(codebaseId: string, opts: KernelSourceIngestOptions = {}): KernelSourceIngestResult {
+  async ingest(codebaseId: string, opts: KernelSourceIngestOptions = {}): Promise<KernelSourceIngestResult> {
     const ref = this.registry.get(codebaseId);
     if (!ref) {
       throw new Error(`Codebase '${codebaseId}' not found`);
@@ -78,7 +78,7 @@ export class KernelSourceIngester {
       throw new Error(`Kernel codebase '${codebaseId}' requires pathFilters or pathPrefix`);
     }
 
-    const preview = this.gate.preview(ref.rootRealpath);
+    const preview = await this.gate.preview(ref.rootRealpath);
     if (preview.blocked) {
       this.registry.updateIngestStatus(codebaseId, {
         lastIngestStatus: 'blocked_by_security',
@@ -110,9 +110,10 @@ export class KernelSourceIngester {
 
     for (const file of filterPreviewFiles(preview, ref, opts)) {
       result.filesProcessed++;
+      await new Promise<void>(r => setImmediate(r));
       try {
         const absolutePath = path.join(ref.rootRealpath, file.relativePath);
-        const content = fs.readFileSync(absolutePath, 'utf-8');
+        const content = await fsPromises.readFile(absolutePath, 'utf-8');
         const license = ref.licenseTag ?? spdxLicense(content);
         const chunks = chunkSourceBySymbols(content, maxChars);
         if (chunks.length === 0) {
@@ -153,6 +154,7 @@ export class KernelSourceIngester {
       }
     }
 
+    this.store.flush();
     this.registry.updateIngestStatus(codebaseId, {
       lastIngestStatus: result.errors.length > 0 ? 'partial' : 'ok',
       lastIngestAt: Date.now(),

--- a/backend/src/services/ragStore.ts
+++ b/backend/src/services/ragStore.ts
@@ -219,7 +219,6 @@ export class RagStore {
     }
     if (legacyKnowledgeFilesystemWritesEnabled()) {
       this.chunks.set(normalized.chunkId, normalized);
-      this.persist();
     }
     if (enterpriseKnowledgeDbWritesEnabled()) {
       upsertScopedKnowledgeRecord(
@@ -378,6 +377,13 @@ export class RagStore {
       probed,
       retrievedAt: Date.now(),
     };
+  }
+
+  /** Flush in-memory chunks to disk. Call once after a bulk ingest loop. */
+  flush(): void {
+    if (legacyKnowledgeFilesystemWritesEnabled()) {
+      this.persist();
+    }
   }
 
   /** Atomic write: temp file + rename so a crashed process leaves the


### PR DESCRIPTION
## Summary

- **O(n²) 写盘修复**：`RagStore.addChunk()` 原来每次都调 `persist()` 把全量 chunk 序列化写盘。47k chunk 的项目估算累计 I/O 超过 500GB，ingest 需要 30+ 分钟且 CPU 占满。现改为去掉 `addChunk()` 内的 `persist()`，新增 `flush()` 方法，三个 ingester 在 ingest 完成后统一调一次。
- **async 调用缺 await**：`pathSecurityGate.preview()` 和三个 ingester 的 `ingest()` 已改为 async，但 `ragAdminRoutes.ts` 和 CLI `codebase.ts` 漏掉了 `await`，补全。
- **排除无效目录**：`DEFAULT_EXCLUDES` 补加 `.gradle`（Gradle 构建缓存，通常 >600MB）和 `.idea`（IntelliJ 项目元数据），preview 和 ingest 不再扫描这两个目录。

## Test plan

- [ ] `cd backend && npm run typecheck` 通过（无类型错误）
- [ ] 对 keyboard_android 项目触发 reindex，确认 registry 状态变为 `ok`，chunk 数合理
- [ ] 确认 reindex 耗时在秒级而非 30+ 分钟
- [ ] Preview 接口返回 blocked 文件统计正确（.gradle/.idea 不再计入）