### PR TITLE
fix: stop killing client processes during port cleanup

### DIFF
--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -78,16 +78,20 @@ kill_pid_and_children() {
 kill_processes_on_port() {
   local port="$1"
   local pids
-  pids=$(lsof -ti:"$port" 2>/dev/null || true)
+  # -sTCP:LISTEN restricts the match to the server bound to this port.
+  # Without it, lsof returns every process with a TCP socket on this port,
+  # including connected clients (e.g. a Claude Code CLI keeping an SSE
+  # connection open against the backend), and they would all be killed.
+  pids=$(lsof -ti "tcp:$port" -sTCP:LISTEN 2>/dev/null || true)
   if [ -z "$pids" ]; then
     return 0
   fi
 
-  echo "Stopping processes on port $port: $pids"
+  echo "Stopping listener on port $port: $pids"
   echo "$pids" | xargs kill 2>/dev/null || true
   sleep 1
 
-  pids=$(lsof -ti:"$port" 2>/dev/null || true)
+  pids=$(lsof -ti "tcp:$port" -sTCP:LISTEN 2>/dev/null || true)
   if [ -n "$pids" ]; then
     echo "$pids" | xargs kill -9 2>/dev/null || true
   fi

--- a/scripts/stop-dev.sh
+++ b/scripts/stop-dev.sh
@@ -29,15 +29,17 @@ if [ -f "$PROJECT_ROOT/.frontend.pid" ]; then
   rm -f "$PROJECT_ROOT/.frontend.pid"
 fi
 
-# Kill processes on ports
+# Kill processes listening on ports (NOT connected clients — `-sTCP:LISTEN`
+# avoids SIGKILL'ing a Claude Code CLI that has an SSE/keep-alive socket
+# open against the backend).
 echo "Cleaning up port 3000..."
-PORT_3000_PIDS=$(lsof -ti:3000 2>/dev/null || true)
+PORT_3000_PIDS=$(lsof -ti tcp:3000 -sTCP:LISTEN 2>/dev/null || true)
 if [ -n "$PORT_3000_PIDS" ]; then
   echo "$PORT_3000_PIDS" | xargs kill -9 2>/dev/null || true
 fi
 
 echo "Cleaning up port 10000..."
-PORT_10000_PIDS=$(lsof -ti:10000 2>/dev/null || true)
+PORT_10000_PIDS=$(lsof -ti tcp:10000 -sTCP:LISTEN 2>/dev/null || true)
 if [ -n "$PORT_10000_PIDS" ]; then
   echo "$PORT_10000_PIDS" | xargs kill -9 2>/dev/null || true
 fi

--- a/start.sh
+++ b/start.sh
@@ -88,9 +88,13 @@ kill_pid_and_children() {
 kill_processes_on_port() {
   local port="$1"
   local pids
-  pids=$(lsof -ti ":$port" 2>/dev/null || true)
+  # -sTCP:LISTEN restricts the match to the server bound to this port.
+  # Without it, lsof returns every process with a TCP socket on this port,
+  # including connected clients (e.g. a Claude Code CLI keeping an SSE
+  # connection open against the backend), and they would all be SIGKILL'd.
+  pids=$(lsof -ti "tcp:$port" -sTCP:LISTEN 2>/dev/null || true)
   if [ -n "$pids" ]; then
-    echo "Stopping processes on port $port: $pids"
+    echo "Stopping listener on port $port: $pids"
     echo "$pids" | xargs kill -9 2>/dev/null || true
   fi
 }


### PR DESCRIPTION
start.sh, scripts/start-dev.sh, and scripts/stop-dev.sh used `lsof -ti :PORT` to discover targets, which returns every process with a TCP socket on that port — including connected clients. A Claude Code CLI that was holding an SSE / keep-alive connection to the backend on :3000 would therefore be SIGKILL'd alongside the actual listener whenever ./start.sh was re-run, breaking the user's foreground assistant session.

Restrict the lookup to `lsof -ti tcp:PORT -sTCP:LISTEN` so only the server bound to the port is targeted. Verified live: PID 65881 (a `claude` process) was correctly excluded by the new filter while PID 65423 (the backend listener) remained the sole target.

Also export CLAUDE_BINARY_PATH from start.sh so the backend Agent SDK can locate the user-installed Claude Code CLI when spawning subprocesses.

<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
<!-- Copyright (C) 2024-2026 Gracker (Chris) | SmartPerfetto -->

## Summary

<!-- 1-3 bullet points: what changed and why. -->

-
-

## Linked Issue

<!-- Link a GitHub issue if applicable, e.g., Fixes #123 -->

## Change Type

<!-- Check all that apply -->

- [ ] feat (new capability)
- [ ] fix (bug fix, no API change)
- [ ] refactor (internal cleanup, no behavior change)
- [ ] docs (documentation only)
- [ ] chore (build, CI, tooling, dependency updates)
- [ ] skill / strategy (YAML skill or `.strategy.md` / `.template.md`)

## Contributor / AI Context

<!-- This project is often edited with AI agents. Keep review context explicit. -->

- [ ] I read `AGENTS.md` before making this change
- [ ] I read the relevant `.claude/rules/*` file(s) for the affected area
- [ ] For non-trivial changes, I used an independent read-only review pass or documented why it was unavailable

## Affected Areas

<!-- Check all that apply. This helps reviewers route attention. -->

- [ ] Web UI / committed `frontend/`
- [ ] CLI / `smp`
- [ ] Docker / portable package
- [ ] HTTP/SSE API
- [ ] Reports / exports / analysis-result snapshots
- [ ] `backend/src/agentv3/` or `backend/src/agentOpenAI/` (agent runtime)
- [ ] MCP tool registry / tool adapters
- [ ] Provider Manager / runtime selection / session resume
- [ ] `backend/skills/` (YAML skills)
- [ ] `backend/strategies/` (`*.strategy.md`, `.template.md`, `knowledge-*`)
- [ ] Code-aware analysis / CodeRef / source lookup
- [ ] `perfetto/ui/src/plugins/com.smartperfetto.AIAssistant/` (frontend)
- [ ] `scripts/` / `backend/scripts/` (tooling, generators)
- [ ] `.github/workflows/` (CI)
- [ ] Docs only
- [ ] Tests only

## Done Conditions

<!-- All code changes must satisfy these. Check after running. -->

- [ ] I preserved unrelated local changes
- [ ] I did not hardcode prompt content, MCP tool lists, Skill counts, or scene lists
- [ ] I kept chat/report/CLI/snapshot evidence boundaries intact where AI output is affected
- [ ] I included any extra targeted test command needed for this change in the test plan below
- [ ] New `.ts` / `.yaml` / `.sh` / `.strategy.md` files carry SPDX AGPL v3 header

## Test Plan

<!-- How did you verify this change? What would a reviewer run? Use `.claude/rules/testing.md`. -->

-

<!-- Examples:
- Docs-only, not runtime-read: `git diff --check`
- Skill YAML: `cd backend && npm run validate:skills` plus scene trace regression
- Strategy/template: `cd backend && npm run validate:strategies` plus scene trace regression
- Runtime/MCP/provider/session/report: `cd backend && npm run test:scene-trace-regression`
- Before landing: `npm run verify:pr`
-->

## Risk / Rollback

<!-- What could break? How do we back this out if it ships wrong? -->

-

## Notes for Reviewers

<!-- Anything else: design decisions, tradeoffs considered, follow-up work -->

-
