### PR TITLE
chore: batch compatible dependency updates

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,10 +9,8 @@
       "version": "1.0.39",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@ai-sdk/openai-compatible": "2.0.51",
         "@anthropic-ai/claude-agent-sdk": "^0.3.153",
-        "@earendil-works/pi-agent-core": "0.79.6",
-        "@openai/agents": "^0.11.5",
+        "@openai/agents": "^0.13.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/js-yaml": "^4.0.9",
         "better-sqlite3": "^12.10.0",
@@ -2556,29 +2554,29 @@
       "optional": true
     },
     "node_modules/@openai/agents": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.11.6.tgz",
-      "integrity": "sha512-YLwycYJQ65ETEq1SzjdFO6U9VhWHOKKIVh6wZCd/FmTZoqYq9UF/5uvX+wF8cZ58J+wIyyLynPdCmzEEov2rhw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.13.0.tgz",
+      "integrity": "sha512-8rMgMPSJR7fDVX/4nn6vCwqmJvmtR754U0scsrsoMo9iHyfTDdtyPQALoMaqMDeLCJsWV4BFvdEeevgbCbeDdw==",
       "license": "MIT",
       "dependencies": {
-        "@openai/agents-core": "0.11.6",
-        "@openai/agents-openai": "0.11.6",
-        "@openai/agents-realtime": "0.11.6",
+        "@openai/agents-core": "0.13.0",
+        "@openai/agents-openai": "0.13.0",
+        "@openai/agents-realtime": "0.13.0",
         "debug": "^4.4.0",
-        "openai": "^6.35.0"
+        "openai": "^6.42.0"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
       }
     },
     "node_modules/@openai/agents-core": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.11.6.tgz",
-      "integrity": "sha512-jWeo4mF+zjp9R80OPg+9prAnwF53dIpok2ymp9OkC3DpK2qcqBO8CfoEgocNp+E5HXXFW4uvCaY0olNCCcmTFw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.13.0.tgz",
+      "integrity": "sha512-Y1ld/hKE1wa9UqII6fcN7FbPxUhAeREndX76xMfFj6cAJWMl8LkwV6cyNuq3rXuWr1h7YkVCPhK4Do4VoVKwCw==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
-        "openai": "^6.35.0"
+        "openai": "^6.42.0"
       },
       "optionalDependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0"
@@ -2593,29 +2591,29 @@
       }
     },
     "node_modules/@openai/agents-openai": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.11.6.tgz",
-      "integrity": "sha512-63zXy+EPmg3WErLO12jLEjCTqGBZ/f0ApsW/t5wpccqUYCtImIT6IYZDgGM+zSEafHNGJmNOwGtEqHjz/Pyl+A==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.13.0.tgz",
+      "integrity": "sha512-cKlRgXnIOpJtDiI0l4JGp4SX9eQj6H2UPVKZNGH1ERJI3HG5TBmhxVIOm+XBKtiKyg4jEd0ES9LFSvy2Tygmxg==",
       "license": "MIT",
       "dependencies": {
-        "@openai/agents-core": "0.11.6",
+        "@openai/agents-core": "0.13.0",
         "debug": "^4.4.0",
-        "openai": "^6.35.0"
+        "openai": "^6.42.0"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
       }
     },
     "node_modules/@openai/agents-realtime": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.11.6.tgz",
-      "integrity": "sha512-jw4lLO6B2xyCBtgLtAXZmqhjEAqSLO1EtJzfwfrZuzGpPgs4nJBQ+O7ybtdPPKt8iWdIOlrYRDqxhBHv7Qqo7w==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.13.0.tgz",
+      "integrity": "sha512-DVKNCsTXcxjjCcufWSbTRjQzm8adm1cV9BwOjU0yGXTAA9+ohS1gWj82np0dsD8hIvGjMQpeZlnQjTKpcl3QRg==",
       "license": "MIT",
       "dependencies": {
-        "@openai/agents-core": "0.11.6",
+        "@openai/agents-core": "0.13.0",
         "@types/ws": "^8.18.1",
         "debug": "^4.4.0",
-        "ws": "^8.18.1"
+        "ws": "^8.21.0"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
@@ -3117,9 +3115,9 @@
       "license": "MIT"
     },
     "node_modules/@types/multer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
-      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7468,15 +7466,27 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.44.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.44.0.tgz",
-      "integrity": "sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA==",
+      "version": "6.46.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.46.0.tgz",
+      "integrity": "sha512-DFg6jEPT2RO+oAyXtddeUJU8zkGy1OQ1AjGzNIJUMQG03TTqvCpy9tBpQ+2VVVnvrl3E56F8GEin2JYtWpITtA==",
       "license": "Apache-2.0",
       "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
         "ws": {
           "optional": true
         },
@@ -7486,9 +7496,9 @@
       }
     },
     "node_modules/opencode-ai": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.17.6.tgz",
-      "integrity": "sha512-pJpt21bapyvQ5Mye0M0IY3VGGDF48ddRdV7goyEVuNTtGo1OFmyuMCFsWX4ALbj8bHf+ebwTtVtCa2fwoI+uEQ==",
+      "version": "1.17.15",
+      "resolved": "https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.17.15.tgz",
+      "integrity": "sha512-iM9c/ulim4kqiWliJhrAPwFD7o5wbnoqvg2iL7tzf7YM5Ytg7H7F81bUdFIegB6GQJSqbvEa9RnvDB7/CsCvSA==",
       "cpu": [
         "arm64",
         "x64"
@@ -7505,24 +7515,24 @@
         "opencode": "bin/opencode.exe"
       },
       "optionalDependencies": {
-        "opencode-darwin-arm64": "1.17.6",
-        "opencode-darwin-x64": "1.17.6",
-        "opencode-darwin-x64-baseline": "1.17.6",
-        "opencode-linux-arm64": "1.17.6",
-        "opencode-linux-arm64-musl": "1.17.6",
-        "opencode-linux-x64": "1.17.6",
-        "opencode-linux-x64-baseline": "1.17.6",
-        "opencode-linux-x64-baseline-musl": "1.17.6",
-        "opencode-linux-x64-musl": "1.17.6",
-        "opencode-windows-arm64": "1.17.6",
-        "opencode-windows-x64": "1.17.6",
-        "opencode-windows-x64-baseline": "1.17.6"
+        "opencode-darwin-arm64": "1.17.15",
+        "opencode-darwin-x64": "1.17.15",
+        "opencode-darwin-x64-baseline": "1.17.15",
+        "opencode-linux-arm64": "1.17.15",
+        "opencode-linux-arm64-musl": "1.17.15",
+        "opencode-linux-x64": "1.17.15",
+        "opencode-linux-x64-baseline": "1.17.15",
+        "opencode-linux-x64-baseline-musl": "1.17.15",
+        "opencode-linux-x64-musl": "1.17.15",
+        "opencode-windows-arm64": "1.17.15",
+        "opencode-windows-x64": "1.17.15",
+        "opencode-windows-x64-baseline": "1.17.15"
       }
     },
     "node_modules/opencode-darwin-arm64": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.17.6.tgz",
-      "integrity": "sha512-GMrdcxuhM+ohJ53nphg0lOOu0yTVBy+KYQM3f8CxwOHJBxF7+kVsiZPzOBJWXEOkFfPT5ZPY/FJPdZNcrzSaVA==",
+      "version": "1.17.15",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.17.15.tgz",
+      "integrity": "sha512-OfC3+9fNXx1sMADuZKgnVQKaKXnDn3Pon0wzhDs4qLZ6WvOTPzgQtohlztzU3MNz6+p3t8RXtYF3AfTKrubNiQ==",
       "cpu": [
         "arm64"
       ],
@@ -7532,9 +7542,9 @@
       ]
     },
     "node_modules/opencode-darwin-x64": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.17.6.tgz",
-      "integrity": "sha512-Y2Hi5n4Q1BtqTVyIjxciaTEC8CxMD6+bIIZoNSi6we/jhiC5NPOhBbCQFlu6bcFnP2En9T0GvAiz73hvMDCPnA==",
+      "version": "1.17.15",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.17.15.tgz",
+      "integrity": "sha512-FwHay55Y1Cacdfg9JgW2Z69K0SfDrmkOWE+mP/C2zbhLYZbR1cyv1Fhh/pKMx5rydIJqMjd4ZNUNElwRqCn5yw==",
       "cpu": [
         "x64"
       ],
@@ -7544,9 +7554,9 @@
       ]
     },
     "node_modules/opencode-darwin-x64-baseline": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.17.6.tgz",
-      "integrity": "sha512-tKO9RcTD+jALhfyM+gUliNa9DsBgPr+CAlvUtAl7VtcTXOtUf1F2BgY51OFVjdmMKdzLyM2HOdf1ELxq5dYWpg==",
+      "version": "1.17.15",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.17.15.tgz",
+      "integrity": "sha512-fQia93jsY9UnBqGnW1ZUMiMo8tJNVwSP4LfG0ZewwOse0tfXg/0ihzYCi+ZnMeF283tULa4Qz3m+QZZZ4gUj+w==",
       "cpu": [
         "x64"
       ],
@@ -7556,9 +7566,9 @@
       ]
     },
     "node_modules/opencode-linux-arm64": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.17.6.tgz",
-      "integrity": "sha512-I29+BqsG878YtfRfuwLRvt8sCFdlkIyXaPk/iZ9ToaiY/NXWld9AmKlePLKSdrkNbGYo+haXrBhH0D4QxVh1NQ==",
+      "version": "1.17.15",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.17.15.tgz",
+      "integrity": "sha512-UxKsYCFSFLRWOr8lRQy7R+7YKt0toaBbrMEgo+aKz2JQ8dLcuWDr8p++kZzbjMMn6eqfvUP1JVtjFJMcvSF0Tw==",
       "cpu": [
         "arm64"
       ],
@@ -7568,11 +7578,14 @@
       ]
     },
     "node_modules/opencode-linux-arm64-musl": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.17.6.tgz",
-      "integrity": "sha512-rMoV+DMHMkzx3ZMbhlbRRsHwF7IcGjKQokjmN7VOkX/K8hghZvF7d3wD2YPeOldZHHzucdGOHYR5dqWqfP0moQ==",
+      "version": "1.17.15",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.17.15.tgz",
+      "integrity": "sha512-eTMangPt2s6lIgaECx0UUfgVNQYQ7py6stto8n8LhIZXZ1GpoJpSxk3F6vU0LeplCNms+hxsqacuTwniq/d3qA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "optional": true,
       "os": [
@@ -7580,9 +7593,9 @@
       ]
     },
     "node_modules/opencode-linux-x64": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.17.6.tgz",
-      "integrity": "sha512-J+3Vn/+4zg3BnpMSanGiIJ6SPmKnVnRsyFpfZzAoVOli9aShSYI7zWpy7KCy9zn6JYkMWa1v+hdW+0Ou1Wr0Vw==",
+      "version": "1.17.15",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.17.15.tgz",
+      "integrity": "sha512-qFVYvLYGW4RElqrJ0mfhQJWFu4lYS/hwT/Izag+r4Q5EbmlLZcmnXOeA+tXkDjA6R2MCxL58NkNgs1QDM2bTqw==",
       "cpu": [
         "x64"
       ],
@@ -7592,9 +7605,9 @@
       ]
     },
     "node_modules/opencode-linux-x64-baseline": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.17.6.tgz",
-      "integrity": "sha512-jkn0j/v1cZ9MaIX10uC/PVI3UFc1zGK4s0ZQQR/4bLCrCZ1EeXwSRQJxeCAwLgEeepZbLuZhnPEyBf9Uy0cw+Q==",
+      "version": "1.17.15",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.17.15.tgz",
+      "integrity": "sha512-jUPpE5SqnzOpgu+s0IrivU/UK3l7JKZtSuEKpgtrcdntAqZ7W0LtiUsCIo18d8ryubg3HSnGdmLZwesKdtpOSA==",
       "cpu": [
         "x64"
       ],
@@ -7604,11 +7617,14 @@
       ]
     },
     "node_modules/opencode-linux-x64-baseline-musl": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.17.6.tgz",
-      "integrity": "sha512-AGAASJviA2BRdXFFYtHMpgjKiTQRS/8URv6okVqC4g85MBhi9FOXghzs0i3puqAhkj0onqe9cZk2shDO2JfnSg==",
+      "version": "1.17.15",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.17.15.tgz",
+      "integrity": "sha512-CtKa0+aG1wjuPMvPoNqj0YNla9kyg38HmmlbBzOpsv1OWzEvWG0gtLlwDtXRsCobbt15euyGJMMfdsf90V3Dcg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "optional": true,
       "os": [
@@ -7616,11 +7632,14 @@
       ]
     },
     "node_modules/opencode-linux-x64-musl": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.17.6.tgz",
-      "integrity": "sha512-jgrjw6X4mlsKxIlX9h1b9YI/c4f0XT+wgn1VfaXSZnssqr6Kvzf3njsIoreVhHnyIKMqngKGKsxlp3sTxn9i/g==",
+      "version": "1.17.15",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.17.15.tgz",
+      "integrity": "sha512-mzmfxauwNOlDyE4w1Q3srUX2HuMiCNj741nHPFRMPqog3kuJnnl/iyNeOdwp7dZYR9cscJKS14EOjBd5IEkC0w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "optional": true,
       "os": [
@@ -7628,9 +7647,9 @@
       ]
     },
     "node_modules/opencode-windows-arm64": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.17.6.tgz",
-      "integrity": "sha512-WGYSRE2hNEsuoKVKHNBIML+OHrwF/UiFQMwrY4zjnz+CC95+Kjr1qM66iPvQyJCbLlmYGHXcx1Gt7qCG55lYpg==",
+      "version": "1.17.15",
+      "resolved": "https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.17.15.tgz",
+      "integrity": "sha512-Bhh8uMKJNa5ciiqrp/RVgGL6/BWyJaVF4DzquP2ft/vxY7FmOYGEhWFphI43HQzRReAZ4/4vw5+D5jo+AnpOyg==",
       "cpu": [
         "arm64"
       ],
@@ -7640,9 +7659,9 @@
       ]
     },
     "node_modules/opencode-windows-x64": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.17.6.tgz",
-      "integrity": "sha512-W0MZV0psmk+9BqdGXa72r6Jq6hwKPdzhgCA66UzdBXJ+A6xqXUrgh5o/P3O8LNS4cUiRHaSDdnIca96ZfLo5SA==",
+      "version": "1.17.15",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.17.15.tgz",
+      "integrity": "sha512-7H1lFbecFZsL1MV6K+5f9eQ9Drpl+opAeHLBwJkUegVhc7KrloZN39W0wUsuHSmv8OjU/wh4fbEfv9MaDCt0fg==",
       "cpu": [
         "x64"
       ],
@@ -7652,9 +7671,9 @@
       ]
     },
     "node_modules/opencode-windows-x64-baseline": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.17.6.tgz",
-      "integrity": "sha512-oR2rl+UzP76KfxCOnV9paaRHRqFMSXrYIkH4ewF0dCrq9djh9cfVsSd9SjVLOcvShIMpIg4SbCsz3GpeN+XAdQ==",
+      "version": "1.17.15",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.17.15.tgz",
+      "integrity": "sha512-yNUPhL3lj5HdIIU9j/C2GLVDk+qnbXJ780XV7NDHMBPrY1J6lZaSc9k3oIwXT1ffRyT+NeRt42gUEboO6W2+DQ==",
       "cpu": [
         "x64"
       ],
@@ -9319,9 +9338,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -116,7 +116,7 @@
   "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.153",
-    "@openai/agents": "^0.11.5",
+    "@openai/agents": "^0.13.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/js-yaml": "^4.0.9",
     "better-sqlite3": "^12.10.0",

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,18 +8,18 @@
       "name": "smart-perfetto",
       "version": "1.0.39",
       "devDependencies": {
-        "@biomejs/biome": "^2.5.2",
+        "@biomejs/biome": "^2.5.3",
         "js-yaml": "^4.3.0",
-        "knip": "^6.23.0"
+        "knip": "^6.26.0"
       },
       "engines": {
         "node": ">=24.0.0 <25.0.0"
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.2.tgz",
-      "integrity": "sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.3.tgz",
+      "integrity": "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -33,20 +33,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.5.2",
-        "@biomejs/cli-darwin-x64": "2.5.2",
-        "@biomejs/cli-linux-arm64": "2.5.2",
-        "@biomejs/cli-linux-arm64-musl": "2.5.2",
-        "@biomejs/cli-linux-x64": "2.5.2",
-        "@biomejs/cli-linux-x64-musl": "2.5.2",
-        "@biomejs/cli-win32-arm64": "2.5.2",
-        "@biomejs/cli-win32-x64": "2.5.2"
+        "@biomejs/cli-darwin-arm64": "2.5.3",
+        "@biomejs/cli-darwin-x64": "2.5.3",
+        "@biomejs/cli-linux-arm64": "2.5.3",
+        "@biomejs/cli-linux-arm64-musl": "2.5.3",
+        "@biomejs/cli-linux-x64": "2.5.3",
+        "@biomejs/cli-linux-x64-musl": "2.5.3",
+        "@biomejs/cli-win32-arm64": "2.5.3",
+        "@biomejs/cli-win32-x64": "2.5.3"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.2.tgz",
-      "integrity": "sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.3.tgz",
+      "integrity": "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==",
       "cpu": [
         "arm64"
       ],
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.2.tgz",
-      "integrity": "sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.3.tgz",
+      "integrity": "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==",
       "cpu": [
         "x64"
       ],
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.2.tgz",
-      "integrity": "sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.3.tgz",
+      "integrity": "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==",
       "cpu": [
         "arm64"
       ],
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.2.tgz",
-      "integrity": "sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.3.tgz",
+      "integrity": "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==",
       "cpu": [
         "arm64"
       ],
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.2.tgz",
-      "integrity": "sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.3.tgz",
+      "integrity": "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==",
       "cpu": [
         "x64"
       ],
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.2.tgz",
-      "integrity": "sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.3.tgz",
+      "integrity": "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==",
       "cpu": [
         "x64"
       ],
@@ -158,9 +158,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.2.tgz",
-      "integrity": "sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.3.tgz",
+      "integrity": "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==",
       "cpu": [
         "arm64"
       ],
@@ -175,9 +175,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.2.tgz",
-      "integrity": "sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.3.tgz",
+      "integrity": "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==",
       "cpu": [
         "x64"
       ],
@@ -1047,9 +1047,9 @@
       }
     },
     "node_modules/knip": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/knip/-/knip-6.23.0.tgz",
-      "integrity": "sha512-2DvAOX2pZWiG4SLvRRxOAU0aWGEn1ZoVblI541xIoXFdHqq2THMZXy66/qcY5WGuW3TXhb9T1x1zd/Hd1u+yqg==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-6.26.0.tgz",
+      "integrity": "sha512-e9eELEEpBpGTd4H4HB7818/DYj9dMzMyUqAddfYwUN/EbSkgIjOuWEF96W/xHsmV0SDrsdXjIM+oZ2xpPzPsBA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "node": "24.15.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.2",
+    "@biomejs/biome": "^2.5.3",
     "js-yaml": "^4.3.0",
-    "knip": "^6.23.0"
+    "knip": "^6.26.0"
   }
 }


### PR DESCRIPTION
## Summary

- update Biome to 2.5.3 and keep its schema URL aligned
- update knip to 6.26.0
- update OpenAI Agents to 0.13.0 and resolve OpenAI SDK 6.46.0
- resolve opencode-ai 1.17.15 and @types/multer 2.2.0
- consolidate the compatible Dependabot updates into one coherent lockfile state

Supersedes #200, #201, #202, #203, #205, and #206 after this PR lands. #204 is intentionally excluded because TypeScript 7 is incompatible with the current ts-jest 29 peer range.

## Verification

- `npm run verify:pr`
- focused OpenAI/OpenCode runtime tests: 5 suites, 151 tests
- `npm run quality` after schema alignment
- `git diff --check`
- `docker build -t smartperfetto-pr-sweep-deps .`

## Simplification

Repository `/simplify` entry and PATH `code-simplifier` were not available; performed manual simplification review and `git diff --check`.