### PR TITLE
修复 Windows 启动契约路径断言

### DIFF
--- a/scripts/__tests__/startup-contracts.test.mjs
+++ b/scripts/__tests__/startup-contracts.test.mjs
@@ -14,7 +14,7 @@ const read = (relativePath) => fs.readFileSync(path.join(repoRoot, relativePath)
 test('source launcher re-execs Bash when invoked through sh', () => {
   for (const [scriptPath, expected] of [
     ['start.sh', /Usage: \.\/start\.sh \[--clean\]/],
-    ['scripts/start-dev.sh', /Usage: .*\/scripts\/start-dev\.sh \[OPTIONS\]/],
+    ['scripts/start-dev.sh', /Usage: .*[/\\]scripts[/\\]start-dev\.sh \[OPTIONS\]/],
   ]) {
     const output = execFileSync(
       'sh',


### PR DESCRIPTION
## 修复

- 让 start-dev.sh 帮助输出断言同时接受 POSIX / 与 Windows 反斜杠路径分隔符。
- 不修改启动脚本或 OIDC 运行时代码。

## 验证

- node --test scripts/__tests__/startup-contracts.test.mjs
- POSIX/Windows 合成路径断言
- npm run test:governance（163 passed, 1 platform skip）
- npm run check:frontend-prebuild
- npm run format:check
- npm run lint
- git diff --check