### PR TITLE
feat(qoder): support BYOK model routing

### DIFF
--- a/.claude/rules/product-surface.md
+++ b/.claude/rules/product-surface.md
@@ -28,7 +28,7 @@ be checked against the public product surfaces below.
 | `openai-agents-sdk` | OpenAI Responses API, OpenAI-compatible gateways, Ollama/chat-completions endpoints | OpenAI history and last response id in `SessionStateSnapshot` | Requires OpenAI runtime rules; do not validate only Claude env vars |
 | `pi-agent-core` | Custom Provider Manager profiles, Pi model JSON, OpenAI-compatible providers where supported by Pi AI | Pi opaque transcript state in `SessionStateSnapshot` | Keep SmartPerfetto MCP tool allowlists, plan evidence logging, and final verifier parity with the Claude target path |
 | `opencode` | Custom Provider Manager profiles, OpenCode model JSON, OpenAI-compatible providers | OpenCode session id and isolated project/home/config dirs in `SessionStateSnapshot` | Keep the bridge sandboxed and route all SmartPerfetto tools through the shared MCP registry/plan evidence log |
-| `qoder-agent-sdk` | Custom Provider Manager profiles or env, local `qodercli` login, PAT, explicit CLI path | Qoder SDK session id for public runs only | SDK is opt-in; disable built-in tools, project tokens before SSE, and never resume or persist opaque state for private-knowledge runs |
+| `qoder-agent-sdk` | Custom Provider Manager profiles or env, local `qodercli` login, PAT, explicit CLI path, optional `resolveModel` BYOK | Qoder SDK session id for public runs only | SDK is opt-in; BYOK never replaces Qoder auth or enters subprocess env/plaintext snapshots; disable built-in tools, project tokens before SSE, and never resume or persist opaque state for private-knowledge runs |
 
 Provider Manager active profiles override `.env` and system fallback. A
 session keeps its selected provider/runtime. Resume must not silently switch to

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -369,6 +369,19 @@ cd backend
 OPENAI_API_KEY=... npm run verify:e2e:deepseek-startup
 ```
 
+Qoder DeepSeek BYOK startup gate (requires both the DeepSeek provider key and
+Qoder PAT or local `qodercli` login; BYOK does not replace Qoder auth):
+
+```bash
+cd backend
+npm run qoder:install -- --accept-terms
+DEEPSEEK_API_KEY=... QODER_PERSONAL_ACCESS_TOKEN=... \
+  npm run verify:e2e:qoder-deepseek-startup
+```
+
+When Qoder auth is unavailable, record this real-provider gate as unavailable;
+do not treat unit/type/build/PR checks as an authenticated Qoder E2E result.
+
 Agent SSE E2E runs that exercise the OpenAI runtime should use Deepseek by
 default, not GLM. The canonical wrapper is
 `backend/scripts/run-deepseek-agent-e2e.cjs`; it loads `backend/.env`, prefers

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ After the Web UI starts, open **AI Assistant Settings → Providers**, add one
 provider, save it, test it, and activate it. Local source runs may instead use
 an existing Claude Code login from the same terminal. Do not configure every
 runtime for the first launch; choose one provider path and follow the
-[Configuration Guide](docs/getting-started/configuration.en.md).
+[Configuration Guide](docs/getting-started/configuration.en.md). Advanced
+Qoder users can also route models through the documented BYOK policy while
+keeping Qoder PAT or `qodercli` authentication separate.
 
 ### 3. Run Your First Analysis
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -81,7 +81,8 @@ SmartPerfetto 在 Perfetto Trace 之上增加 AI 分析层。加载 Trace、用�
 Web UI 启动后，打开 **AI Assistant 设置 → Providers**，添加一个 Provider，依次保存、
 测试并激活。本地源码运行也可以直接复用同一终端中已有的 Claude Code 登录态。
 第一次启动不需要配置所有 Runtime；只选一条 Provider 路径，按
-[配置指南](docs/getting-started/configuration.md)操作即可。
+[配置指南](docs/getting-started/configuration.md)操作即可。Qoder 高级用户也可以按文档
+配置 BYOK 模型路由；Qoder PAT 或 `qodercli` 认证仍是独立且必需的。
 
 ### 3. 完成第一次分析
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -179,7 +179,7 @@
 # Install strategy:
 # - The SDK is an opt-in optional peer dependency. Install it explicitly only
 #   after reviewing and accepting the Qoder SDK/CLI terms:
-#     npm install --no-save @qoder-ai/qoder-agent-sdk
+#     npm --prefix backend run qoder:install -- --accept-terms
 # - The SDK's postinstall downloads qodercli. Skip with: QODER_SKIP_DOWNLOAD=1
 # - Offline/air-gapped: skip the download and set QODERCLI_PATH to a
 #   pre-installed compatible binary.
@@ -192,8 +192,18 @@
 # QODER_PERSONAL_ACCESS_TOKEN=your_qoder_personal_access_token_here
 # Optional: override the qodercli executable path
 # QODERCLI_PATH=/absolute/path/to/qodercli
+# Optional: load a compatible SDK entry from an explicit absolute path.
+# SMARTPERFETTO_QODER_SDK_MODULE_PATH=/absolute/path/to/@qoder-ai/qoder-agent-sdk/dist/index.js
 # Optional: specify the model (defaults to qodercli's model router)
 # QODER_MODEL=ultimate
+# Optional BYOK model policy. This configures the model provider only; Qoder
+# still requires QODER_PERSONAL_ACCESS_TOKEN or a local qodercli login.
+# Set API key, provider, and QODER_MODEL together; partial BYOK fails closed.
+# QODER_BYOK_API_KEY=your_model_provider_api_key_here
+# QODER_BYOK_PROVIDER=deepseek
+# QODER_BYOK_BASE_URL=https://api.deepseek.com/v1
+# QODER_BYOK_STYLE=openai
+# QODER_LIGHT_MODEL=deepseek-chat
 # Optional: runtime-level prompt; SmartPerfetto analysis contracts still come
 # from backend strategies.
 # SMARTPERFETTO_QODER_SYSTEM_PROMPT=

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "public/**/*",
     "sql/smartperfetto/**/*",
     "prebuilts/**/*",
+    "scripts/install-qoder-sdk.cjs",
     ".env.example",
     "LICENSE",
     "package.json"
@@ -122,7 +123,9 @@
     "verify:e2e:deepseek-external-issue": "node scripts/run-deepseek-agent-e2e.cjs --suite external-issue --runtime all-deepseek",
     "verify:e2e:deepseek-dual-trace": "node scripts/run-deepseek-agent-e2e.cjs --suite dual-trace --runtime all-deepseek",
     "verify:e2e:deepseek-context": "node scripts/run-deepseek-agent-e2e.cjs --suite context --runtime all-deepseek",
+    "verify:e2e:qoder-deepseek-startup": "node scripts/run-deepseek-agent-e2e.cjs --suite startup --runtime qoder-agent-sdk",
     "verify:e2e:openai-startup": "node scripts/run-deepseek-agent-e2e.cjs --suite startup --runtime openai-agents-sdk",
+    "qoder:install": "node scripts/install-qoder-sdk.cjs",
     "generate:frontend-types": "tsx scripts/generateFrontendTypes.ts",
     "check:types": "tsx scripts/checkTypesSync.ts",
     "types": "npm run generate:frontend-types",

--- a/backend/scripts/install-qoder-sdk.cjs
+++ b/backend/scripts/install-qoder-sdk.cjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 Gracker (Chris)
+// This file is part of SmartPerfetto. See LICENSE for details.
+
+const fs = require('fs');
+const path = require('path');
+const {spawnSync} = require('child_process');
+
+const backendRoot = path.resolve(__dirname, '..');
+const packageJson = require(path.join(backendRoot, 'package.json'));
+const sdkName = '@qoder-ai/qoder-agent-sdk';
+const sdkRange = packageJson.peerDependencies?.[sdkName];
+const installRoot = path.join(backendRoot, '.qoder-sdk');
+const sdkEntry = path.join(installRoot, 'node_modules', sdkName, 'dist', 'index.js');
+
+main();
+
+function main() {
+  const args = new Set(process.argv.slice(2));
+  if (args.has('--help') || args.has('-h')) {
+    printUsage();
+    return;
+  }
+  if (!args.has('--accept-terms')) {
+    throw new Error(
+      'Qoder SDK/CLI use is governed by https://qoder.com/product-service. '
+      + 'Review the terms, then rerun with --accept-terms.',
+    );
+  }
+  if (!sdkRange) {
+    throw new Error(`${sdkName} is not declared as an optional peer dependency`);
+  }
+
+  const sdkSpec = `${sdkName}@${sdkRange}`;
+  const npmArgs = [
+    'install',
+    '--prefix', installRoot,
+    '--package-lock=false',
+    sdkSpec,
+    'zod@^4',
+  ];
+  if (args.has('--dry-run')) {
+    console.log(`[qoder-install] ${formatCommand('npm', npmArgs)}`);
+    console.log(`[qoder-install] target=${installRoot}`);
+    return;
+  }
+
+  fs.mkdirSync(installRoot, {recursive: true});
+  const npmExecPath = process.env.npm_execpath;
+  const command = npmExecPath ? process.execPath : 'npm';
+  const commandArgs = npmExecPath ? [npmExecPath, ...npmArgs] : npmArgs;
+  const result = spawnSync(command, commandArgs, {
+    cwd: backendRoot,
+    env: process.env,
+    stdio: 'inherit',
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) process.exit(result.status ?? 1);
+  if (!fs.existsSync(sdkEntry)) {
+    throw new Error(`Qoder SDK install completed without the expected entry: ${sdkEntry}`);
+  }
+
+  const installedPackage = JSON.parse(
+    fs.readFileSync(path.join(installRoot, 'node_modules', sdkName, 'package.json'), 'utf8'),
+  );
+  console.log(`[qoder-install] installed ${sdkName}@${installedPackage.version}`);
+  console.log(`[qoder-install] module=${sdkEntry}`);
+}
+
+function printUsage() {
+  console.log('Usage: npm run qoder:install -- --accept-terms [--dry-run]');
+  console.log('');
+  console.log('Installs the opt-in Qoder Agent SDK into backend/.qoder-sdk.');
+}
+
+function formatCommand(command, args) {
+  return [command, ...args].map(value => JSON.stringify(value)).join(' ');
+}

--- a/backend/scripts/run-deepseek-agent-e2e.cjs
+++ b/backend/scripts/run-deepseek-agent-e2e.cjs
@@ -12,8 +12,6 @@ const backendRoot = path.resolve(__dirname, '..');
 const verifierPath = path.join(backendRoot, 'src/scripts/verifyAgentSseScrolling.ts');
 const tsxCliPath = path.join(backendRoot, 'node_modules/tsx/dist/cli.mjs');
 
-loadBackendEnv();
-
 const DEFAULT_RUNTIME = 'openai-agents-sdk';
 const DEFAULT_TIMEOUT_MS = 20 * 60_000;
 const DEEPSEEK_RUNTIME_KINDS = [
@@ -222,9 +220,10 @@ const suites = {
   },
 };
 
-main();
+if (require.main === module) main();
 
 function main() {
+  loadBackendEnv();
   const options = parseArgs(process.argv.slice(2));
   if (options.help) {
     printUsage();
@@ -277,7 +276,7 @@ function parseArgs(argv) {
     if (arg === '--runtime') {
       const value = argv[i + 1];
       if (!value) {
-        throw new Error('--runtime requires a value: openai-agents-sdk, pi-agent-core, opencode, or all-deepseek');
+        throw new Error('--runtime requires a value: openai-agents-sdk, pi-agent-core, opencode, qoder-agent-sdk, or all-deepseek');
       }
       runtime = parseRuntime(value);
       i += 1;
@@ -315,12 +314,14 @@ function parseRuntime(value) {
     value === 'openai-agents-sdk' ||
     value === 'pi' ||
     value === 'pi-agent-core' ||
-    value === 'opencode'
+    value === 'opencode' ||
+    value === 'qoder' ||
+    value === 'qoder-agent-sdk'
   ) {
     return value;
   }
   throw new Error(
-    `Invalid runtime: ${value}. Expected openai-agents-sdk, pi-agent-core, opencode, or all-deepseek.`,
+    `Invalid runtime: ${value}. Expected openai-agents-sdk, pi-agent-core, opencode, qoder-agent-sdk, or all-deepseek.`,
   );
 }
 
@@ -328,16 +329,19 @@ function resolveRuntimeKinds(value) {
   if (value === 'all' || value === 'all-deepseek') return DEEPSEEK_RUNTIME_KINDS;
   if (value === 'openai') return ['openai-agents-sdk'];
   if (value === 'pi') return ['pi-agent-core'];
+  if (value === 'qoder') return ['qoder-agent-sdk'];
   return [value];
 }
 
 function printUsage() {
-  console.log('Usage: node scripts/run-deepseek-agent-e2e.cjs [--suite all|context|startup|scrolling|external-issue|dual-trace|context-source|context-rag|context-combined] [--runtime openai-agents-sdk|pi-agent-core|opencode|all-deepseek] [--timeout-ms <number>]');
+  console.log('Usage: node scripts/run-deepseek-agent-e2e.cjs [--suite all|context|startup|scrolling|external-issue|dual-trace|context-source|context-rag|context-combined] [--runtime openai-agents-sdk|pi-agent-core|opencode|qoder-agent-sdk|all-deepseek] [--timeout-ms <number>]');
   console.log('');
   console.log('Runs SmartPerfetto Agent SSE E2E with Deepseek-backed SmartPerfetto runtimes.');
   console.log('');
   console.log('Credential precedence: DEEPSEEK_API_KEY, then OPENAI_API_KEY.');
   console.log('OpenAI receives OPENAI_* pins; Pi/OpenCode receive generated Deepseek model JSON unless env already overrides it.');
+  console.log('Qoder receives DeepSeek through resolveModel BYOK and still requires QODER_PERSONAL_ACCESS_TOKEN or qodercli login.');
+  console.log('BYOK does not replace Qoder authentication.');
   console.log(`Each real SSE scenario has a ${DEFAULT_TIMEOUT_MS}ms default timeout; use --timeout-ms to override it.`);
 }
 
@@ -461,6 +465,19 @@ function buildChildEnv(apiKey, runtimeKind, isolatedRoot) {
     };
   }
 
+  if (runtimeKind === 'qoder-agent-sdk') {
+    return {
+      ...baseEnv,
+      SMARTPERFETTO_AGENT_RUNTIME: 'qoder-agent-sdk',
+      QODER_MODEL: deepseekModel,
+      QODER_LIGHT_MODEL: deepseekLightModel,
+      QODER_BYOK_API_KEY: apiKey,
+      QODER_BYOK_PROVIDER: 'deepseek',
+      QODER_BYOK_BASE_URL: deepseekBaseUrl,
+      QODER_BYOK_STYLE: 'openai',
+    };
+  }
+
   throw new Error(`Unsupported runtime: ${runtimeKind}`);
 }
 
@@ -486,3 +503,7 @@ function assertFile(filePath, label) {
     throw new Error(`${label} not found: ${filePath}`);
   }
 }
+
+module.exports = {
+  buildChildEnv,
+};

--- a/backend/src/agentRuntime/__tests__/envCredentialSources.test.ts
+++ b/backend/src/agentRuntime/__tests__/envCredentialSources.test.ts
@@ -48,4 +48,23 @@ describe('env credential source detection', () => {
       'google_vertex_region',
     ]);
   });
+
+  it('reports Qoder BYOK credential source names without returning their values', () => {
+    const sources = collectEnvCredentialSources({
+      QODER_BYOK_API_KEY: 'deepseek-provider-secret',
+      QODER_BYOK_PROVIDER: 'deepseek',
+      QODER_BYOK_BASE_URL: 'https://api.deepseek.com/v1',
+      QODER_BYOK_STYLE: 'openai',
+      SMARTPERFETTO_QODER_SDK_MODULE_PATH: '/opt/qoder-sdk/index.js',
+    }, 'env');
+
+    expect(sources).toEqual([
+      'QODER_BYOK_API_KEY',
+      'QODER_BYOK_PROVIDER',
+      'QODER_BYOK_BASE_URL',
+      'QODER_BYOK_STYLE',
+      'SMARTPERFETTO_QODER_SDK_MODULE_PATH',
+    ]);
+    expect(JSON.stringify(sources)).not.toContain('deepseek-provider-secret');
+  });
 });

--- a/backend/src/agentRuntime/engines/qoder/__tests__/qoderConfig.test.ts
+++ b/backend/src/agentRuntime/engines/qoder/__tests__/qoderConfig.test.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 Gracker (Chris)
+// This file is part of SmartPerfetto. See LICENSE for details.
+
+import {
+  getQoderRuntimeDiagnostics,
+  resolveQoderRuntimeConfig,
+} from '../qoderConfig';
+
+describe('Qoder runtime configuration', () => {
+  it('reports complete BYOK configuration without exposing the API key or URL credentials', () => {
+    const diagnostics = getQoderRuntimeDiagnostics({
+      QODER_PERSONAL_ACCESS_TOKEN: 'qoder-auth-secret',
+      QODER_MODEL: 'deepseek-main',
+      QODER_LIGHT_MODEL: 'deepseek-light',
+      QODER_BYOK_API_KEY: 'deepseek-provider-secret',
+      QODER_BYOK_PROVIDER: 'deepseek',
+      QODER_BYOK_BASE_URL: 'https://user:pass@api.deepseek.com/v1?token=secret#fragment',
+      QODER_BYOK_STYLE: 'openai',
+      SMARTPERFETTO_QODER_SDK_MODULE_PATH: '/opt/qoder-sdk/index.js',
+    });
+
+    expect(diagnostics).toMatchObject({
+      configured: true,
+      providerMode: 'qoder-byok',
+      byokConfigured: true,
+      byokApiKeyConfigured: true,
+      byokProvider: 'deepseek',
+      byokBaseUrl: 'https://api.deepseek.com/v1',
+      byokStyle: 'openai',
+      sdkModule: '/opt/qoder-sdk/index.js',
+    });
+    expect(JSON.stringify(diagnostics)).not.toContain('deepseek-provider-secret');
+    expect(JSON.stringify(diagnostics)).not.toContain('qoder-auth-secret');
+    expect(JSON.stringify(diagnostics)).not.toContain('user:pass');
+    expect(JSON.stringify(diagnostics)).not.toContain('token=secret');
+  });
+
+  it('keeps Qoder authentication and BYOK model credentials as separate configuration', () => {
+    const config = resolveQoderRuntimeConfig({
+      QODER_MODEL: 'deepseek-main',
+      QODER_BYOK_API_KEY: 'deepseek-provider-secret',
+      QODER_BYOK_PROVIDER: 'deepseek',
+    });
+
+    expect(config.hasAccessToken).toBe(false);
+    expect(config.byok).toEqual({
+      apiKey: 'deepseek-provider-secret',
+      provider: 'deepseek',
+      baseUrl: undefined,
+      style: undefined,
+    });
+  });
+});

--- a/backend/src/agentRuntime/engines/qoder/__tests__/qoderRuntime.test.ts
+++ b/backend/src/agentRuntime/engines/qoder/__tests__/qoderRuntime.test.ts
@@ -187,6 +187,8 @@ describe('QoderRuntime', () => {
         DATABASE_URL: 'postgres://secret',
         QODER_PERSONAL_ACCESS_TOKEN: 'test-token',
         QODER_MODEL: 'test-model',
+        QODER_BYOK_API_KEY: 'deepseek-secret',
+        QODER_BYOK_PROVIDER: 'deepseek',
       });
       await runtime.analyze('test', 'session-1', 'trace-1');
 
@@ -197,6 +199,52 @@ describe('QoderRuntime', () => {
       expect(sdkEnv.DATABASE_URL).toBeUndefined();
       expect(sdkEnv.QODER_PERSONAL_ACCESS_TOKEN).toBe('test-token');
       expect(sdkEnv.QODER_MODEL).toBe('test-model');
+      expect(sdkEnv.QODER_BYOK_API_KEY).toBeUndefined();
+      expect(sdkEnv.QODER_BYOK_PROVIDER).toBeUndefined();
+    });
+
+    it('routes Qoder model calls through a complete BYOK model policy', async () => {
+      mockQuery.mockReturnValue(createMockSdkStream([
+        { type: 'result', subtype: 'success', result: '## Final Report\ndone' },
+      ]));
+
+      const runtime = createRuntime({
+        QODER_MODEL: 'deepseek-main',
+        QODER_LIGHT_MODEL: 'deepseek-light',
+        QODER_BYOK_API_KEY: 'deepseek-secret',
+        QODER_BYOK_PROVIDER: 'deepseek',
+        QODER_BYOK_BASE_URL: 'https://api.deepseek.com/v1',
+        QODER_BYOK_STYLE: 'openai',
+      });
+      await runtime.analyze('test', 'session-1', 'trace-1');
+
+      const callArgs = mockQuery.mock.calls[0][0] as any;
+      expect(callArgs.options.model).toBe('deepseek-main');
+      expect(callArgs.options.resolveModel({ purpose: 'main' })).toEqual({
+        model: {
+          provider: 'deepseek',
+          api_key: 'deepseek-secret',
+          model: 'deepseek-main',
+          url: 'https://api.deepseek.com/v1',
+          style: 'openai',
+        },
+      });
+      expect(callArgs.options.resolveModel({ purpose: 'title' })).toEqual({
+        model: expect.objectContaining({ model: 'deepseek-light' }),
+      });
+    });
+
+    it('fails closed before query when Qoder BYOK configuration is incomplete', async () => {
+      const result = await createRuntime({
+        QODER_BYOK_API_KEY: 'deepseek-secret',
+        QODER_MODEL: undefined,
+      }).analyze('test', 'session-1', 'trace-1');
+
+      expect(result.success).toBe(false);
+      expect(result.terminationMessage).toContain('QODER_BYOK_PROVIDER');
+      expect(result.terminationMessage).toContain('QODER_MODEL');
+      expect(result.terminationMessage).not.toContain('deepseek-secret');
+      expect(mockQuery).not.toHaveBeenCalled();
     });
 
     it('does not use repo root as cwd', async () => {
@@ -405,6 +453,25 @@ describe('QoderRuntime', () => {
   });
 
   describe('result handling', () => {
+    it('explains that BYOK does not replace Qoder authentication', async () => {
+      const error = new Error('Qoder CLI process exited with code 41') as Error & { exitCode: number };
+      error.exitCode = 41;
+      mockQuery.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      const result = await createRuntime({
+        QODER_MODEL: 'deepseek-main',
+        QODER_BYOK_API_KEY: 'deepseek-secret',
+        QODER_BYOK_PROVIDER: 'deepseek',
+      }).analyze('test', 'session-1', 'trace-1');
+
+      expect(result.success).toBe(false);
+      expect(result.terminationMessage).toContain('Qoder authentication failed');
+      expect(result.terminationMessage).toContain('does not replace Qoder authentication');
+      expect(result.terminationMessage).not.toContain('deepseek-secret');
+    });
+
     it('uses the shared localized trace-context formatter for the user prompt', async () => {
       mockFormatTraceContext.mockReturnValueOnce('localized trace context');
       mockQuery.mockReturnValue(createMockSdkStream([

--- a/backend/src/agentRuntime/engines/qoder/__tests__/qoderSdkLoader.test.ts
+++ b/backend/src/agentRuntime/engines/qoder/__tests__/qoderSdkLoader.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 Gracker (Chris)
+// This file is part of SmartPerfetto. See LICENSE for details.
+
+import { loadQoderSdkModule } from '../qoderSdkLoader';
+
+describe('Qoder SDK loader', () => {
+  it('honors an explicit SDK module path and explains the opt-in installer on failure', async () => {
+    await expect(loadQoderSdkModule({
+      SMARTPERFETTO_QODER_SDK_MODULE_PATH: '/definitely/missing/qoder-sdk.mjs',
+    })).rejects.toThrow(
+      /qoder:install -- --accept-terms.*SMARTPERFETTO_QODER_SDK_MODULE_PATH/,
+    );
+  });
+});

--- a/backend/src/agentRuntime/engines/qoder/qoderConfig.ts
+++ b/backend/src/agentRuntime/engines/qoder/qoderConfig.ts
@@ -2,9 +2,12 @@
 // Copyright (C) 2024-2026 Gracker (Chris)
 // This file is part of SmartPerfetto. See LICENSE for details.
 
-import type { EngineCapabilities } from '../../runtimeDescriptorTypes';
-import type { RuntimeDiagnosticsPayload } from '../../runtimeDescriptorTypes';
+import fs from 'fs';
+import path from 'path';
+
+import { redactUrlForDiagnostics } from '../../envCredentialSources';
 import { QODER_AGENT_RUNTIME_KIND } from '../../runtimeKinds';
+import type { EngineCapabilities, RuntimeDiagnosticsPayload } from '../../runtimeDescriptorTypes';
 
 export const QODER_PERSONAL_ACCESS_TOKEN_ENV = 'QODER_PERSONAL_ACCESS_TOKEN';
 export const QODER_CLI_PATH_ENV = 'QODERCLI_PATH';
@@ -16,15 +19,30 @@ export const QODER_QUICK_MAX_TURNS_ENV = 'QODER_QUICK_MAX_TURNS';
 export const QODER_FULL_PER_TURN_MS_ENV = 'QODER_FULL_PER_TURN_MS';
 export const QODER_QUICK_PER_TURN_MS_ENV = 'QODER_QUICK_PER_TURN_MS';
 export const QODER_WORKER_RUNTIME_PATH_ENV = 'QODER_WORKER_RUNTIME_PATH';
+export const QODER_SDK_MODULE_PATH_ENV = 'SMARTPERFETTO_QODER_SDK_MODULE_PATH';
+export const QODER_BYOK_API_KEY_ENV = 'QODER_BYOK_API_KEY';
+export const QODER_BYOK_PROVIDER_ENV = 'QODER_BYOK_PROVIDER';
+export const QODER_BYOK_BASE_URL_ENV = 'QODER_BYOK_BASE_URL';
+export const QODER_BYOK_STYLE_ENV = 'QODER_BYOK_STYLE';
 
 type EnvLike = Record<string, string | undefined>;
 
-function qoderSdkInstalled(): boolean {
+export function getLocalQoderSdkModulePath(): string {
+  return path.resolve(
+    __dirname,
+    '../../../../.qoder-sdk/node_modules/@qoder-ai/qoder-agent-sdk/dist/index.js',
+  );
+}
+
+function qoderSdkInstalled(env: EnvLike): boolean {
+  const configuredPath = env[QODER_SDK_MODULE_PATH_ENV]?.trim();
+  if (configuredPath) return fs.existsSync(configuredPath);
+
   try {
     require.resolve('@qoder-ai/qoder-agent-sdk');
     return true;
   } catch {
-    return false;
+    return fs.existsSync(getLocalQoderSdkModulePath());
   }
 }
 
@@ -59,22 +77,47 @@ export function getQoderRuntimeDiagnostics(
   const cliPath = env[QODER_CLI_PATH_ENV]?.trim();
   const model = env[QODER_MODEL_ENV]?.trim();
   const workerRuntimePath = env[QODER_WORKER_RUNTIME_PATH_ENV]?.trim();
+  const sdkModulePath = env[QODER_SDK_MODULE_PATH_ENV]?.trim();
   const systemPrompt = env[QODER_SYSTEM_PROMPT_ENV]?.trim();
+  const byokApiKey = env[QODER_BYOK_API_KEY_ENV]?.trim();
+  const byokProvider = env[QODER_BYOK_PROVIDER_ENV]?.trim();
+  const byokBaseUrl = env[QODER_BYOK_BASE_URL_ENV]?.trim();
+  const byokStyle = env[QODER_BYOK_STYLE_ENV]?.trim();
+  const byokRequested = Boolean(byokApiKey || byokProvider || byokBaseUrl || byokStyle);
+  const byokConfigured = Boolean(byokApiKey && byokProvider && model);
+  const localSdkModulePath = getLocalQoderSdkModulePath();
 
   return {
     runtime: kind,
     configured: Boolean(token) || Boolean(cliPath),
-    sdkInstalled: qoderSdkInstalled(),
+    sdkInstalled: qoderSdkInstalled(env),
     model: model || undefined,
-    providerMode: 'qoder',
+    providerMode: byokConfigured
+      ? 'qoder-byok'
+      : byokRequested
+        ? 'qoder-byok-incomplete'
+        : 'qoder',
     modelConfigured: Boolean(model),
     sdkBinary: cliPath || undefined,
+    sdkModule: sdkModulePath || (fs.existsSync(localSdkModulePath) ? localSdkModulePath : undefined),
     hasAccessToken: Boolean(token),
     hasWorkerRuntime: Boolean(workerRuntimePath),
     hasSystemPrompt: Boolean(systemPrompt),
+    byokConfigured,
+    byokApiKeyConfigured: Boolean(byokApiKey),
+    byokProvider: byokProvider || undefined,
+    byokBaseUrl: redactUrlForDiagnostics(byokBaseUrl),
+    byokStyle: byokStyle || undefined,
     maxTurns: numericEnv(env[QODER_MAX_TURNS_ENV]),
     quickMaxTurns: numericEnv(env[QODER_QUICK_MAX_TURNS_ENV]),
   };
+}
+
+export interface QoderByokConfig {
+  apiKey?: string;
+  provider?: string;
+  baseUrl?: string;
+  style?: string;
 }
 
 export interface QoderRuntimeConfig {
@@ -88,6 +131,7 @@ export interface QoderRuntimeConfig {
   hasAccessToken: boolean;
   cliPath?: string;
   workerRuntimePath?: string;
+  byok: QoderByokConfig;
 }
 
 export function resolveQoderRuntimeConfig(env: EnvLike = process.env): QoderRuntimeConfig {
@@ -102,6 +146,12 @@ export function resolveQoderRuntimeConfig(env: EnvLike = process.env): QoderRunt
     hasAccessToken: Boolean(env[QODER_PERSONAL_ACCESS_TOKEN_ENV]?.trim()),
     cliPath: env[QODER_CLI_PATH_ENV]?.trim() || undefined,
     workerRuntimePath: env[QODER_WORKER_RUNTIME_PATH_ENV]?.trim() || undefined,
+    byok: {
+      apiKey: env[QODER_BYOK_API_KEY_ENV]?.trim() || undefined,
+      provider: env[QODER_BYOK_PROVIDER_ENV]?.trim() || undefined,
+      baseUrl: env[QODER_BYOK_BASE_URL_ENV]?.trim() || undefined,
+      style: env[QODER_BYOK_STYLE_ENV]?.trim() || undefined,
+    },
   };
 }
 

--- a/backend/src/agentRuntime/engines/qoder/qoderRuntime.ts
+++ b/backend/src/agentRuntime/engines/qoder/qoderRuntime.ts
@@ -97,7 +97,12 @@ import { QODER_AGENT_RUNTIME_KIND } from '../../runtimeKinds';
 import {
   QODER_PERSONAL_ACCESS_TOKEN_ENV,
   QODER_CLI_PATH_ENV,
+  QODER_BYOK_API_KEY_ENV,
+  QODER_BYOK_BASE_URL_ENV,
+  QODER_BYOK_PROVIDER_ENV,
+  QODER_BYOK_STYLE_ENV,
   QODER_MODEL_ENV,
+  QODER_SDK_MODULE_PATH_ENV,
   QODER_SYSTEM_PROMPT_ENV,
   resolveQoderRuntimeConfig,
   getQoderEngineCapabilities,
@@ -113,7 +118,12 @@ export {
   QODER_AGENT_RUNTIME_KIND,
   QODER_PERSONAL_ACCESS_TOKEN_ENV,
   QODER_CLI_PATH_ENV,
+  QODER_BYOK_API_KEY_ENV,
+  QODER_BYOK_BASE_URL_ENV,
+  QODER_BYOK_PROVIDER_ENV,
+  QODER_BYOK_STYLE_ENV,
   QODER_MODEL_ENV,
+  QODER_SDK_MODULE_PATH_ENV,
   QODER_SYSTEM_PROMPT_ENV,
   getQoderEngineCapabilities,
   getQoderRuntimeDiagnostics,
@@ -145,6 +155,15 @@ interface QoderSdkOptions {
   mcpServers?: Record<string, unknown>;
   env?: Record<string, string | undefined>;
   stderr?: (data: string) => void;
+  resolveModel?: (context: { purpose: string }) => {
+    model: string | {
+      provider: string;
+      api_key: string;
+      model: string;
+      url?: string;
+      style?: string;
+    };
+  };
 }
 
 /** Minimal shape of the async generator returned by query(). */
@@ -212,6 +231,25 @@ function getMessageType(message: unknown): string | undefined {
   if (!isRecord(message)) return undefined;
   return typeof message.type === 'string' ? message.type : undefined;
 }
+
+function describeQoderSdkError(error: unknown): string {
+  if (isRecord(error) && error.exitCode === 41) {
+    return [
+      'Qoder authentication failed.',
+      'Run `qodercli login` or set a valid QODER_PERSONAL_ACCESS_TOKEN.',
+      'QODER_BYOK_API_KEY configures the model provider but does not replace Qoder authentication.',
+    ].join(' ');
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+const QODER_LIGHT_MODEL_PURPOSES = new Set([
+  'compact',
+  'compression',
+  'suggestion',
+  'title',
+  'utility',
+]);
 
 // ---------------------------------------------------------------------------
 // Session state
@@ -615,6 +653,8 @@ export class QoderRuntime extends EventEmitter implements IOrchestrator {
       : this.config.maxTurns;
 
     try {
+      const resolveModel = this.createModelPolicy();
+
       // Load the Qoder SDK module
       const sdk = await loadQoderSdkModule(this.env) as unknown as QoderSdkModule;
 
@@ -652,6 +692,7 @@ export class QoderRuntime extends EventEmitter implements IOrchestrator {
             console.error('[Qoder SDK stderr]', data);
           }
         },
+        resolveModel,
       };
 
       // Execute the query with timeout
@@ -873,7 +914,7 @@ export class QoderRuntime extends EventEmitter implements IOrchestrator {
       return result;
     } catch (error) {
       const totalDurationMs = Date.now() - startTime;
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = describeQoderSdkError(error);
       const safeErrorMessage = sanitizeCodeAwareText(sessionId, errorMessage);
 
       // Clear stale session on missing-conversation errors so next call starts fresh
@@ -934,6 +975,36 @@ export class QoderRuntime extends EventEmitter implements IOrchestrator {
     }
     // Fall back to local qodercli login state
     return sdk.qodercliAuth();
+  }
+
+  private createModelPolicy(): QoderSdkOptions['resolveModel'] {
+    const { apiKey, provider, baseUrl, style } = this.config.byok;
+    const byokRequested = Boolean(apiKey || provider || baseUrl || style);
+    if (!byokRequested) return undefined;
+
+    const missing = [
+      !apiKey ? QODER_BYOK_API_KEY_ENV : undefined,
+      !provider ? QODER_BYOK_PROVIDER_ENV : undefined,
+      !this.config.model ? QODER_MODEL_ENV : undefined,
+    ].filter((value): value is string => Boolean(value));
+    if (missing.length > 0) {
+      throw new Error(`Qoder BYOK configuration is incomplete; missing ${missing.join(', ')}`);
+    }
+
+    return ({ purpose }) => {
+      const model = QODER_LIGHT_MODEL_PURPOSES.has(purpose)
+        ? this.config.lightModel || this.config.model!
+        : this.config.model!;
+      return {
+        model: {
+          provider: provider!,
+          api_key: apiKey!,
+          model,
+          ...(baseUrl ? { url: baseUrl } : {}),
+          ...(style ? { style } : {}),
+        },
+      };
+    };
   }
 
   // -------------------------------------------------------------------------

--- a/backend/src/agentRuntime/engines/qoder/qoderSdkLoader.ts
+++ b/backend/src/agentRuntime/engines/qoder/qoderSdkLoader.ts
@@ -2,7 +2,14 @@
 // Copyright (C) 2024-2026 Gracker (Chris)
 // This file is part of SmartPerfetto. See LICENSE for details.
 
-import type { EnvLike } from './qoderConfig';
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+import {
+  getLocalQoderSdkModulePath,
+  QODER_SDK_MODULE_PATH_ENV,
+  type EnvLike,
+} from './qoderConfig';
 
 export interface QoderSdkModule {
   query(params: { prompt: string; options?: unknown }): unknown;
@@ -21,14 +28,31 @@ const importEsmModule = new Function(
 export async function loadQoderSdkModule(
   env: EnvLike = process.env,
 ): Promise<QoderSdkModule> {
-  const specifier = '@qoder-ai/qoder-agent-sdk';
-  let module: Partial<QoderSdkModule>;
-  try {
-    module = await importEsmModule(specifier) as Partial<QoderSdkModule>;
-  } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
+  const configuredPath = env[QODER_SDK_MODULE_PATH_ENV]?.trim();
+  const specifiers = configuredPath
+    ? [path.isAbsolute(configuredPath) ? pathToFileURL(configuredPath).href : configuredPath]
+    : [
+        '@qoder-ai/qoder-agent-sdk',
+        pathToFileURL(getLocalQoderSdkModulePath()).href,
+      ];
+
+  let module: Partial<QoderSdkModule> | undefined;
+  let lastError: unknown;
+  for (const specifier of [...new Set(specifiers)]) {
+    try {
+      module = await importEsmModule(specifier) as Partial<QoderSdkModule>;
+      break;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  if (!module) {
+    const detail = lastError instanceof Error ? lastError.message : String(lastError);
     throw new Error(
-      `Qoder Agent SDK is not installed. Review its terms, then explicitly install ${specifier}. ${detail}`,
+      'Qoder Agent SDK is not installed. Review its terms, then run '
+      + '`npm --prefix backend run qoder:install -- --accept-terms` or configure '
+      + `${QODER_SDK_MODULE_PATH_ENV}. ${detail}`,
     );
   }
   if (typeof module.query !== 'function') {

--- a/backend/src/agentRuntime/envCredentialSources.ts
+++ b/backend/src/agentRuntime/envCredentialSources.ts
@@ -93,6 +93,25 @@ export function collectEnvCredentialSources(
   if (hasConcreteEnvValue(env.QODER_MODEL)) {
     sources.push(label(style, 'QODER_MODEL', 'qoder_model'));
   }
+  if (hasConcreteEnvValue(env.QODER_BYOK_API_KEY)) {
+    sources.push(label(style, 'QODER_BYOK_API_KEY', 'qoder_byok_api_key'));
+  }
+  if (hasConcreteEnvValue(env.QODER_BYOK_PROVIDER)) {
+    sources.push(label(style, 'QODER_BYOK_PROVIDER', 'qoder_byok_provider'));
+  }
+  if (hasConcreteEnvValue(env.QODER_BYOK_BASE_URL)) {
+    sources.push(label(style, 'QODER_BYOK_BASE_URL', 'qoder_byok_base_url'));
+  }
+  if (hasConcreteEnvValue(env.QODER_BYOK_STYLE)) {
+    sources.push(label(style, 'QODER_BYOK_STYLE', 'qoder_byok_style'));
+  }
+  if (hasConcreteEnvValue(env.SMARTPERFETTO_QODER_SDK_MODULE_PATH)) {
+    sources.push(label(
+      style,
+      'SMARTPERFETTO_QODER_SDK_MODULE_PATH',
+      'qoder_sdk_module_path',
+    ));
+  }
 
   if (isEnabledEnvFlag(env.CLAUDE_CODE_USE_BEDROCK)) {
     if (hasConcreteEnvValue(env.AWS_BEARER_TOKEN_BEDROCK)) {

--- a/backend/src/agentRuntime/index.ts
+++ b/backend/src/agentRuntime/index.ts
@@ -71,15 +71,21 @@ export {
 } from './engines/opencode';
 export {
   QODER_AGENT_RUNTIME_KIND,
+  QODER_BYOK_API_KEY_ENV,
+  QODER_BYOK_BASE_URL_ENV,
+  QODER_BYOK_PROVIDER_ENV,
+  QODER_BYOK_STYLE_ENV,
   QODER_PERSONAL_ACCESS_TOKEN_ENV,
   QODER_CLI_PATH_ENV,
   QODER_MODEL_ENV,
+  QODER_SDK_MODULE_PATH_ENV,
   QODER_SYSTEM_PROMPT_ENV,
   QoderRuntime,
   createQoderRuntimeDefinition,
   getQoderEngineCapabilities,
   getQoderRuntimeDiagnostics,
   resolveQoderRuntimeConfig,
+  type QoderByokConfig,
   type QoderRuntimeConfig,
   type QoderRuntimeKind,
 } from './engines/qoder';

--- a/backend/src/scripts/__tests__/qoderByokTooling.test.ts
+++ b/backend/src/scripts/__tests__/qoderByokTooling.test.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 Gracker (Chris)
+// This file is part of SmartPerfetto. See LICENSE for details.
+
+import fs from 'fs';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+const backendRoot = path.resolve(__dirname, '../../..');
+const deepseekE2E = require(path.join(backendRoot, 'scripts/run-deepseek-agent-e2e.cjs')) as {
+  buildChildEnv(
+    apiKey: string,
+    runtimeKind: string,
+    isolatedRoot: string,
+  ): Record<string, string | undefined>;
+};
+
+describe('Qoder BYOK tooling', () => {
+  it('documents Qoder as an explicit DeepSeek E2E runtime', () => {
+    const result = spawnSync(
+      process.execPath,
+      [path.join(backendRoot, 'scripts/run-deepseek-agent-e2e.cjs'), '--help'],
+      {cwd: backendRoot, encoding: 'utf8'},
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('qoder-agent-sdk');
+    expect(result.stdout).toContain('QODER_PERSONAL_ACCESS_TOKEN');
+    expect(result.stdout).toContain('BYOK does not replace Qoder authentication');
+  });
+
+  it('maps DeepSeek into Qoder BYOK without replacing Qoder authentication', () => {
+    const keys = [
+      'QODER_PERSONAL_ACCESS_TOKEN',
+      'DEEPSEEK_BASE_URL',
+      'DEEPSEEK_MODEL',
+      'DEEPSEEK_LIGHT_MODEL',
+    ] as const;
+    const original = Object.fromEntries(keys.map(key => [key, process.env[key]]));
+    process.env.QODER_PERSONAL_ACCESS_TOKEN = 'qoder-auth-secret';
+    delete process.env.DEEPSEEK_BASE_URL;
+    delete process.env.DEEPSEEK_MODEL;
+    delete process.env.DEEPSEEK_LIGHT_MODEL;
+    try {
+      const env = deepseekE2E.buildChildEnv(
+        'deepseek-provider-secret',
+        'qoder-agent-sdk',
+        '/tmp/qoder-e2e-test',
+      );
+
+      expect(env).toMatchObject({
+        SMARTPERFETTO_AGENT_RUNTIME: 'qoder-agent-sdk',
+        QODER_PERSONAL_ACCESS_TOKEN: 'qoder-auth-secret',
+        QODER_MODEL: 'deepseek-v4-pro',
+        QODER_LIGHT_MODEL: 'deepseek-v4-flash',
+        QODER_BYOK_API_KEY: 'deepseek-provider-secret',
+        QODER_BYOK_PROVIDER: 'deepseek',
+        QODER_BYOK_BASE_URL: 'https://api.deepseek.com/v1',
+        QODER_BYOK_STYLE: 'openai',
+      });
+      expect(env.QODER_PERSONAL_ACCESS_TOKEN).not.toBe(env.QODER_BYOK_API_KEY);
+    } finally {
+      for (const key of keys) {
+        const value = original[key];
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  });
+
+  it('provides an opt-in installer that requires explicit terms acceptance', () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(backendRoot, 'package.json'), 'utf8'),
+    ) as {scripts?: Record<string, string>};
+    expect(packageJson.scripts?.['qoder:install']).toBe('node scripts/install-qoder-sdk.cjs');
+
+    const result = spawnSync(
+      process.execPath,
+      [path.join(backendRoot, 'scripts/install-qoder-sdk.cjs'), '--help'],
+      {cwd: backendRoot, encoding: 'utf8'},
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('--accept-terms');
+    expect(result.stdout).toContain('backend/.qoder-sdk');
+  });
+});

--- a/backend/src/services/providerManager/__tests__/envIsolation.test.ts
+++ b/backend/src/services/providerManager/__tests__/envIsolation.test.ts
@@ -4,11 +4,24 @@
 
 import {
   clearProviderRuntimeEnv,
+  isQoderByokEnvKey,
   mergeIsolatedProviderEnv,
   providerSubprocessEnv,
 } from '../envIsolation';
 
 describe('provider runtime environment isolation', () => {
+  it('recognizes only the supported Qoder BYOK values as provider-scoped overrides', () => {
+    expect([
+      'QODER_BYOK_API_KEY',
+      'QODER_BYOK_PROVIDER',
+      'QODER_BYOK_BASE_URL',
+      'QODER_BYOK_STYLE',
+    ].every(isQoderByokEnvKey)).toBe(true);
+    expect(isQoderByokEnvKey('QODERCLI_PATH')).toBe(false);
+    expect(isQoderByokEnvKey('SMARTPERFETTO_QODER_SDK_MODULE_PATH')).toBe(false);
+    expect(isQoderByokEnvKey('QODER_WORKER_RUNTIME_PATH')).toBe(false);
+  });
+
   it('clears every runtime family, including Qoder, without touching system env', () => {
     const env: Record<string, string | undefined> = {
       PATH: '/usr/bin',
@@ -34,12 +47,15 @@ describe('provider runtime environment isolation', () => {
     expect(providerSubprocessEnv({
       PATH: '/usr/bin',
       QODER_MODEL: 'qoder-model',
+      QODER_BYOK_API_KEY: 'qoder-byok-secret',
+      QODER_BYOK_PROVIDER: 'deepseek',
       QODERCLI_PATH: '/qodercli',
       SMARTPERFETTO_QODER_SYSTEM_PROMPT: 'qoder prompt',
       UNRELATED_APPLICATION_VALUE: 'exclude',
     })).toEqual({
       PATH: '/usr/bin',
       QODER_MODEL: 'qoder-model',
+      QODER_BYOK_PROVIDER: 'deepseek',
       QODERCLI_PATH: '/qodercli',
       SMARTPERFETTO_QODER_SYSTEM_PROMPT: 'qoder prompt',
     });

--- a/backend/src/services/providerManager/__tests__/providerService.test.ts
+++ b/backend/src/services/providerManager/__tests__/providerService.test.ts
@@ -536,6 +536,97 @@ describe('ProviderService', () => {
       })).toThrow(`Custom provider env override is not allowed: ${key}`);
     });
 
+    it('allows only scoped Qoder BYOK overrides on a Qoder custom provider', () => {
+      const provider = svc.create({
+        ...validInput,
+        type: 'custom',
+        models: {primary: 'deepseek-main', light: 'deepseek-light'},
+        connection: {agentRuntime: 'qoder-agent-sdk'},
+        custom: {
+          envOverrides: {
+            QODER_BYOK_API_KEY: 'managed-deepseek-key',
+            QODER_BYOK_PROVIDER: 'deepseek',
+            QODER_BYOK_BASE_URL: 'https://api.deepseek.com/v1',
+            QODER_BYOK_STYLE: 'openai',
+          },
+        },
+      });
+
+      expect(svc.getEnvForProvider(provider.id)).toMatchObject({
+        QODER_BYOK_API_KEY: 'managed-deepseek-key',
+        QODER_BYOK_PROVIDER: 'deepseek',
+        QODER_BYOK_BASE_URL: 'https://api.deepseek.com/v1',
+        QODER_BYOK_STYLE: 'openai',
+      });
+      expect(svc.get(provider.id)?.custom?.envOverrides?.QODER_BYOK_API_KEY)
+        .toMatch(/^\*{4}/);
+    });
+
+    it.each([
+      'https://user:password@api.deepseek.com/v1',
+      'https://api.deepseek.com/v1?api_key=secret',
+      'https://api.deepseek.com/v1#secret',
+      'ftp://api.deepseek.com/v1',
+      'not-a-url',
+    ])('rejects unsafe Qoder BYOK base URL %s', (baseUrl) => {
+      expect(() => svc.create({
+        ...validInput,
+        type: 'custom',
+        models: {primary: 'deepseek-main', light: 'deepseek-light'},
+        connection: {agentRuntime: 'qoder-agent-sdk'},
+        custom: {envOverrides: {QODER_BYOK_BASE_URL: baseUrl}},
+      })).toThrow('QODER_BYOK_BASE_URL must be an HTTP(S) URL without credentials, query, or fragment');
+    });
+
+    it.each([
+      ['QODER_BYOK_API_KEY', 'managed-deepseek-key'],
+      ['QODER_BYOK_PROVIDER', 'deepseek'],
+      ['QODER_BYOK_BASE_URL', 'https://api.deepseek.com/v1'],
+      ['QODER_BYOK_STYLE', 'openai'],
+    ])('rejects Qoder BYOK override %s for a non-Qoder runtime', (key, value) => {
+      expect(() => svc.create({
+        ...validInput,
+        type: 'custom',
+        models: {primary: 'custom-openai-main', light: 'custom-openai-light'},
+        connection: {agentRuntime: 'openai-agents-sdk'},
+        custom: {envOverrides: {[key]: value}},
+      })).toThrow(`Custom provider env override is not allowed: ${key}`);
+    });
+
+    it('rejects switching away from Qoder while Qoder BYOK overrides remain', () => {
+      const provider = svc.create({
+        ...validInput,
+        type: 'custom',
+        models: {primary: 'deepseek-main', light: 'deepseek-light'},
+        connection: {agentRuntime: 'qoder-agent-sdk'},
+        custom: {
+          envOverrides: {
+            QODER_BYOK_API_KEY: 'managed-deepseek-key',
+            QODER_BYOK_PROVIDER: 'deepseek',
+          },
+        },
+      });
+
+      expect(() => svc.switchAgentRuntime(provider.id, 'opencode')).toThrow(
+        'Custom provider env override is not allowed: QODER_BYOK_API_KEY',
+      );
+      expect(svc.getRawProvider(provider.id)?.connection.agentRuntime).toBe('qoder-agent-sdk');
+    });
+
+    it.each([
+      ['QODERCLI_PATH', '/tmp/hostile-qodercli'],
+      ['SMARTPERFETTO_QODER_SDK_MODULE_PATH', '/tmp/hostile-sdk.mjs'],
+      ['QODER_WORKER_RUNTIME_PATH', '/tmp/hostile-worker.mjs'],
+    ])('rejects Qoder process-control override %s even for Qoder providers', (key, value) => {
+      expect(() => svc.create({
+        ...validInput,
+        type: 'custom',
+        models: {primary: 'qoder-main', light: 'qoder-light'},
+        connection: {agentRuntime: 'qoder-agent-sdk'},
+        custom: {envOverrides: {[key]: value}},
+      })).toThrow(`Custom provider env override is not allowed: ${key}`);
+    });
+
     it('allows Pi provider-scoped credentials on a Pi custom provider', () => {
       const provider = svc.create({
         ...validInput,

--- a/backend/src/services/providerManager/__tests__/providerSnapshot.test.ts
+++ b/backend/src/services/providerManager/__tests__/providerSnapshot.test.ts
@@ -495,6 +495,14 @@ describe('provider runtime snapshot hash', () => {
           qoderModel: 'qoder-connection-model',
           qoderSystemPrompt: 'secret qoder system prompt',
         },
+        custom: {
+          envOverrides: {
+            QODER_BYOK_API_KEY: 'qoder-byok-secret-v1',
+            QODER_BYOK_PROVIDER: 'deepseek',
+            QODER_BYOK_BASE_URL: 'https://api.deepseek.com/v1',
+            QODER_BYOK_STYLE: 'openai',
+          },
+        },
         tuning: {
           fullPerTurnMs: 90000,
           quickPerTurnMs: 45000,
@@ -520,18 +528,39 @@ describe('provider runtime snapshot hash', () => {
         QODER_LIGHT_MODEL: 'qoder-light',
         QODER_FULL_PER_TURN_MS: '90000',
         QODER_QUICK_PER_TURN_MS: '45000',
+        QODER_BYOK_PROVIDER: 'deepseek',
+        QODER_BYOK_BASE_URL: 'https://api.deepseek.com/v1',
+        QODER_BYOK_STYLE: 'openai',
       });
       expect(before.snapshot.environment.QODER_WORKER_RUNTIME_PATH).toBeUndefined();
       expect(before.snapshot.environment.QODER_PERSONAL_ACCESS_TOKEN).toBeUndefined();
       expect(before.snapshot.environment.SMARTPERFETTO_QODER_SYSTEM_PROMPT).toBeUndefined();
+      expect(before.snapshot.environment.QODER_BYOK_API_KEY).toBeUndefined();
       expect(JSON.stringify(before.snapshot)).not.toContain('qoder-secret-token');
       expect(JSON.stringify(before.snapshot)).not.toContain('secret qoder system prompt');
+      expect(JSON.stringify(before.snapshot)).not.toContain('qoder-byok-secret-v1');
 
       svc.update(provider.id, {
         connection: {qoderSystemPrompt: 'changed secret qoder system prompt'},
       });
       expect(resolveProviderRuntimeSnapshot(svc, provider.id).snapshotHash)
         .not.toBe(before.snapshotHash);
+
+      const beforeByokSecret = resolveProviderRuntimeSnapshot(svc, provider.id);
+      svc.update(provider.id, {
+        custom: {
+          envOverrides: {
+            QODER_BYOK_API_KEY: 'qoder-byok-secret-v2',
+            QODER_BYOK_PROVIDER: 'deepseek',
+            QODER_BYOK_BASE_URL: 'https://api.deepseek.com/v1',
+            QODER_BYOK_STYLE: 'openai',
+          },
+        },
+      });
+      const afterByokSecret = resolveProviderRuntimeSnapshot(svc, provider.id);
+      expect(afterByokSecret.snapshotHash).not.toBe(beforeByokSecret.snapshotHash);
+      expect(afterByokSecret.snapshot.secretVersion).not.toBe(beforeByokSecret.snapshot.secretVersion);
+      expect(JSON.stringify(afterByokSecret.snapshot)).not.toContain('qoder-byok-secret-v2');
     } finally {
       if (originalWorkerPath === undefined) delete process.env.QODER_WORKER_RUNTIME_PATH;
       else process.env.QODER_WORKER_RUNTIME_PATH = originalWorkerPath;
@@ -542,6 +571,7 @@ describe('provider runtime snapshot hash', () => {
     const keys = [
       'SMARTPERFETTO_AGENT_RUNTIME',
       'QODER_PERSONAL_ACCESS_TOKEN',
+      'QODER_BYOK_BASE_URL',
       'QODERCLI_PATH',
       'QODER_MODEL',
       'QODER_LIGHT_MODEL',
@@ -553,6 +583,7 @@ describe('provider runtime snapshot hash', () => {
     Object.assign(process.env, {
       SMARTPERFETTO_AGENT_RUNTIME: 'qoder-agent-sdk',
       QODER_PERSONAL_ACCESS_TOKEN: 'ambient-qoder-secret',
+      QODER_BYOK_BASE_URL: 'https://user:password@api.deepseek.com/v1?api_key=first#secret',
       QODERCLI_PATH: '/usr/local/bin/qodercli',
       QODER_MODEL: 'qoder-env-primary',
       QODER_LIGHT_MODEL: 'qoder-env-light',
@@ -575,8 +606,22 @@ describe('provider runtime snapshot hash', () => {
       });
       expect(result.snapshot.resolvedTimeouts.classifierTimeoutMs).toBeUndefined();
       expect(result.snapshot.environment.QODER_PERSONAL_ACCESS_TOKEN).toBeUndefined();
+      expect(result.snapshot.environment.QODER_BYOK_BASE_URL)
+        .toBe('https://api.deepseek.com/v1');
+      expect(result.snapshot.baseUrl).toBe('https://api.deepseek.com/v1');
       expect(result.snapshot.secretVersion).toMatch(/^sha256:/);
       expect(JSON.stringify(result.snapshot)).not.toContain('ambient-qoder-secret');
+      expect(JSON.stringify(result.snapshot)).not.toContain('user:password');
+      expect(JSON.stringify(result.snapshot)).not.toContain('api_key=first');
+
+      process.env.QODER_BYOK_BASE_URL =
+        'https://user:password@api.deepseek.com/v1?api_key=second#secret';
+      const changedSecret = resolveProviderRuntimeSnapshot(svc, null);
+      expect(changedSecret.snapshot.environment.QODER_BYOK_BASE_URL)
+        .toBe(result.snapshot.environment.QODER_BYOK_BASE_URL);
+      expect(changedSecret.snapshot.secretVersion).not.toBe(result.snapshot.secretVersion);
+      expect(changedSecret.snapshotHash).not.toBe(result.snapshotHash);
+      expect(JSON.stringify(changedSecret.snapshot)).not.toContain('api_key=second');
     } finally {
       for (const key of keys) {
         const value = original[key];

--- a/backend/src/services/providerManager/envIsolation.ts
+++ b/backend/src/services/providerManager/envIsolation.ts
@@ -94,6 +94,13 @@ const PI_PROVIDER_ENV_KEYS = new Set([
   'ZAI_CODING_CN_API_KEY',
 ]);
 
+const QODER_BYOK_ENV_KEYS = new Set([
+  'QODER_BYOK_API_KEY',
+  'QODER_BYOK_PROVIDER',
+  'QODER_BYOK_BASE_URL',
+  'QODER_BYOK_STYLE',
+]);
+
 const PROVIDER_ENV_PREFIXES = [
   'ANTHROPIC_',
   'AWS_',
@@ -121,6 +128,13 @@ const SUBPROCESS_SYSTEM_ENV_KEYS = new Set([
   'GOOGLE_APPLICATION_CREDENTIALS',
 ]);
 
+const SUBPROCESS_DENIED_ENV_KEYS = new Set([
+  // This credential is consumed only by Qoder SDK resolveModel(). The Qoder
+  // runtime builds its own SDK environment and must not inherit it through a
+  // generic provider subprocess boundary.
+  'QODER_BYOK_API_KEY',
+]);
+
 /** Explicit environment boundary for third-party provider subprocesses. */
 export function providerSubprocessEnv(
   inheritedEnv: Record<string, string | undefined>,
@@ -128,6 +142,7 @@ export function providerSubprocessEnv(
   const env: Record<string, string | undefined> = {};
   const includePiProviderEnv = inheritedEnv.SMARTPERFETTO_AGENT_RUNTIME === 'pi-agent-core';
   for (const [key, value] of Object.entries(inheritedEnv)) {
+    if (SUBPROCESS_DENIED_ENV_KEYS.has(key)) continue;
     if (
       SUBPROCESS_SYSTEM_ENV_KEYS.has(key) ||
       PROVIDER_ENV_KEYS.has(key) ||
@@ -166,6 +181,10 @@ export function clearProviderRuntimeEnv(
 
 export function isPiProviderEnvKey(key: string): boolean {
   return PI_PROVIDER_ENV_KEYS.has(key);
+}
+
+export function isQoderByokEnvKey(key: string): boolean {
+  return QODER_BYOK_ENV_KEYS.has(key);
 }
 
 export function mergeIsolatedProviderEnv(

--- a/backend/src/services/providerManager/providerService.ts
+++ b/backend/src/services/providerManager/providerService.ts
@@ -32,7 +32,7 @@ import type {
   ProviderMutationOwner,
   ProviderMutationScope,
 } from './providerMutationGeneration';
-import {isPiProviderEnvKey} from './envIsolation';
+import {isPiProviderEnvKey, isQoderByokEnvKey} from './envIsolation';
 
 const SENSITIVE_FIELDS: (keyof ProviderConfig['connection'])[] = [
   'apiKey',
@@ -86,10 +86,32 @@ function assertSafeCustomEnvOverrides(
   custom: ProviderConfig['custom'],
   runtime: AgentRuntimeKind,
 ): void {
-  for (const key of Object.keys(custom?.envOverrides ?? {})) {
+  for (const [key, value] of Object.entries(custom?.envOverrides ?? {})) {
     const piRuntimeOverride = runtime === 'pi-agent-core' && isPiProviderEnvKey(key);
-    if (!ALLOWED_CUSTOM_ENV_OVERRIDES.has(key) && !piRuntimeOverride) {
+    const qoderByokOverride = runtime === 'qoder-agent-sdk' && isQoderByokEnvKey(key);
+    if (!ALLOWED_CUSTOM_ENV_OVERRIDES.has(key) && !piRuntimeOverride && !qoderByokOverride) {
       throw new Error(`Custom provider env override is not allowed: ${key}`);
+    }
+    if (qoderByokOverride && key === 'QODER_BYOK_BASE_URL') {
+      let url: URL;
+      try {
+        url = new URL(value);
+      } catch {
+        throw new Error(
+          'QODER_BYOK_BASE_URL must be an HTTP(S) URL without credentials, query, or fragment',
+        );
+      }
+      if (
+        (url.protocol !== 'http:' && url.protocol !== 'https:')
+        || url.username
+        || url.password
+        || url.search
+        || url.hash
+      ) {
+        throw new Error(
+          'QODER_BYOK_BASE_URL must be an HTTP(S) URL without credentials, query, or fragment',
+        );
+      }
     }
   }
 }

--- a/backend/src/services/providerManager/providerSnapshot.ts
+++ b/backend/src/services/providerManager/providerSnapshot.ts
@@ -4,6 +4,7 @@
 
 import crypto from 'crypto';
 import {piRuntimeFingerprintInput} from '../../agentRuntime/engines/pi/piAgentCoreConfig';
+import {redactUrlForDiagnostics} from '../../agentRuntime/envCredentialSources';
 import { mergeIsolatedProviderEnv } from './envIsolation';
 import type { ProviderService } from './providerService';
 import type { AgentRuntimeKind, ProviderConfig, ProviderScope, ProviderTuning } from './types';
@@ -95,6 +96,8 @@ const OPENCODE_SECRET_ENV_KEYS = [
 
 const QODER_SECRET_ENV_KEYS = [
   'QODER_PERSONAL_ACCESS_TOKEN',
+  'QODER_BYOK_API_KEY',
+  'QODER_BYOK_BASE_URL',
   'SMARTPERFETTO_QODER_SYSTEM_PROMPT',
 ];
 
@@ -158,9 +161,13 @@ const OPENCODE_RUNTIME_ENV_KEYS = [
 
 const QODER_RUNTIME_ENV_KEYS = [
   'SMARTPERFETTO_AGENT_RUNTIME',
+  'SMARTPERFETTO_QODER_SDK_MODULE_PATH',
   'QODERCLI_PATH',
   'QODER_MODEL',
   'QODER_LIGHT_MODEL',
+  'QODER_BYOK_PROVIDER',
+  'QODER_BYOK_BASE_URL',
+  'QODER_BYOK_STYLE',
   'QODER_MAX_TURNS',
   'QODER_QUICK_MAX_TURNS',
   'QODER_FULL_PER_TURN_MS',
@@ -219,6 +226,27 @@ function pickEnv(env: Record<string, string | undefined>, keys: string[]): Recor
     const value = env[key];
     if (value !== undefined && value !== '') picked[key] = value;
   }
+  return picked;
+}
+
+function publicRuntimeEnvironment(
+  env: Record<string, string | undefined>,
+  runtimeKind: AgentRuntimeKind,
+): Record<string, string> {
+  const picked = pickEnv(env, runtimeEnvironmentKeys(runtimeKind));
+  if (runtimeKind !== 'qoder-agent-sdk' || !picked.QODER_BYOK_BASE_URL) return picked;
+
+  const redacted = redactUrlForDiagnostics(picked.QODER_BYOK_BASE_URL);
+  try {
+    const url = redacted ? new URL(redacted) : undefined;
+    if (url?.protocol === 'http:' || url?.protocol === 'https:') {
+      picked.QODER_BYOK_BASE_URL = url.toString();
+      return picked;
+    }
+  } catch {
+    // Invalid ambient values remain available to the runtime but not to public snapshots.
+  }
+  delete picked.QODER_BYOK_BASE_URL;
   return picked;
 }
 
@@ -303,6 +331,7 @@ function pickResolvedTimeouts(
 }
 
 function inferBaseUrl(runtimeKind: AgentRuntimeKind, env: Record<string, string>): string | undefined {
+  if (runtimeKind === 'qoder-agent-sdk') return env.QODER_BYOK_BASE_URL;
   if (runtimeKind === 'openai-agents-sdk' || runtimeKind === 'opencode') {
     return env.OPENAI_BASE_URL;
   }
@@ -347,7 +376,7 @@ function envRuntimeSnapshot(runtimeOverride?: AgentRuntimeKind): ProviderRuntime
       : runtimeKind === 'claude-agent-sdk'
         ? 'CLAUDE'
         : undefined;
-  const nonSecretEnv = pickEnv(env, runtimeEnvironmentKeys(runtimeKind));
+  const nonSecretEnv = publicRuntimeEnvironment(env, runtimeKind);
   const secretEntries = runtimeSecretEnvKeys(runtimeKind).map(
     (key) => [key, env[key]] as [string, string | undefined],
   );
@@ -399,7 +428,7 @@ function providerRuntimeSnapshot(
   const runtimeKind = providerService.resolveAgentRuntime(provider);
   const providerEnv = providerService.getEnvForProvider(provider.id, providerScope) ?? null;
   const env = mergeIsolatedProviderEnv(process.env, providerEnv);
-  const nonSecretEnv = pickEnv(env, runtimeEnvironmentKeys(runtimeKind));
+  const nonSecretEnv = publicRuntimeEnvironment(env, runtimeKind);
   const primaryModel = runtimeKind === 'qoder-agent-sdk'
     ? nonSecretEnv.QODER_MODEL
     : provider.models.primary;

--- a/docs/architecture/agent-runtime.en.md
+++ b/docs/architecture/agent-runtime.en.md
@@ -163,9 +163,21 @@ switching the custom provider or `SMARTPERFETTO_AGENT_RUNTIME` back to
 
 The Qoder path is custom-only in Provider Manager and also supports an explicit
 env selection. The SDK is not installed by default; users must review its terms
-and opt in. Public sessions may resume by Qoder SDK session id. A run authorized
-for private codebase or external knowledge never resumes or stores that opaque
-provider session, and its intermediate state is excluded from durable snapshots.
+and opt in through `qoder:install -- --accept-terms` or an explicit module path.
+The `resolveModel` BYOK policy combines `QODER_BYOK_API_KEY`,
+`QODER_BYOK_PROVIDER`, `QODER_MODEL`, and optional base URL, style, and light
+model values; partial configuration fails closed. BYOK changes the model
+provider only and never replaces Qoder PAT or local `qodercli` authentication.
+Provider Manager accepts the four BYOK values only through a Qoder custom
+profile's `custom.envOverrides`; it cannot override the CLI, SDK module, or
+worker path. The BYOK key reaches only the SDK `resolveModel` callback, not the
+SDK subprocess environment, diagnostics, or plaintext snapshots. Provider,
+base URL, and style remain non-secret snapshot inputs, while key changes update
+the secret fingerprint used by provider pinning, resume, external issue, and
+Self-Evolution proof boundaries. Public sessions may resume by Qoder SDK session
+id. A run authorized for private codebase or external knowledge never resumes
+or stores that opaque provider session, and its intermediate state is excluded
+from durable snapshots.
 
 ## Analysis Modes
 

--- a/docs/architecture/agent-runtime.md
+++ b/docs/architecture/agent-runtime.md
@@ -151,7 +151,7 @@ Pi Agent Core 的真实模型路径复用 SmartPerfetto 的 scene strategy、系
 
 OpenCode 路径同样只允许 custom provider。它可以使用带 `providerID` / `modelID` / `baseUrl` / `apiKey` 的 `SMARTPERFETTO_OPENCODE_MODEL_JSON`，也可以回退到 OpenAI-compatible 的 `OPENAI_*` env/provider 字段。SmartPerfetto 不复用用户自己的 OpenCode CLI 登录态、配置文件或 project extension；回滚路径是把 custom provider 或 `SMARTPERFETTO_AGENT_RUNTIME` 切回 `claude-agent-sdk` / `openai-agents-sdk`。
 
-Qoder 在 Provider Manager 中同样只允许 custom provider，也可以通过 env 显式选择。SDK 默认不安装，用户必须先审阅条款再 opt in。公开分析可按 Qoder SDK session id 恢复；一旦请求获准访问私有 codebase 或外部知识源，就不会恢复或保存该 provider opaque session，也不会把中间状态写入 durable snapshot。
+Qoder 在 Provider Manager 中同样只允许 custom provider，也可以通过 env 显式选择。SDK 默认不安装，用户必须先审阅条款，再通过 `qoder:install -- --accept-terms` 或显式 module path opt in。`resolveModel` BYOK 由 `QODER_BYOK_API_KEY`、`QODER_BYOK_PROVIDER`、`QODER_MODEL` 及可选 base URL/style/light model 组成；配置不完整时 fail closed。BYOK 只替换模型 provider，不替代 Qoder PAT 或本机 `qodercli` 登录认证。Provider Manager 仅允许 Qoder custom profile 的 `custom.envOverrides` 写入这四个 BYOK 值，不允许借此覆盖 CLI、SDK module 或 worker path。BYOK key 只进入 SDK 的 `resolveModel` 回调，不进入 SDK 子进程 env、诊断或明文快照；provider/base/style 进入非密钥快照，key 只参与 secret fingerprint，确保 provider pin、resume、外部 Issue 和 Self-Evolution proof 能检测配置变化。公开分析可按 Qoder SDK session id 恢复；一旦请求获准访问私有 codebase 或外部知识源，就不会恢复或保存该 provider opaque session，也不会把中间状态写入 durable snapshot。
 
 ## Final Result 与质量产物
 

--- a/docs/getting-started/configuration.en.md
+++ b/docs/getting-started/configuration.en.md
@@ -326,12 +326,22 @@ Qoder Agent SDK:
 ```bash
 # Review and accept the Qoder SDK/CLI terms before this opt-in install.
 # Set QODER_SKIP_DOWNLOAD=1 first when using a pre-installed compatible CLI.
-npm --prefix backend install --no-save @qoder-ai/qoder-agent-sdk
+npm --prefix backend run qoder:install -- --accept-terms
 SMARTPERFETTO_AGENT_RUNTIME=qoder-agent-sdk
 # Optional PAT; omit it to use the local qodercli login.
 # QODER_PERSONAL_ACCESS_TOKEN=your_qoder_pat
 # Optional pre-installed executable override.
 # QODERCLI_PATH=/absolute/path/to/qodercli
+# Optional compatible SDK entry loaded from an absolute path.
+# SMARTPERFETTO_QODER_SDK_MODULE_PATH=/absolute/path/to/qoder-sdk/dist/index.js
+# Optional BYOK: set all three required values together; base URL, style, and
+# light model are optional. BYOK does not replace Qoder PAT/qodercli auth.
+# QODER_MODEL=deepseek-chat
+# QODER_LIGHT_MODEL=deepseek-chat
+# QODER_BYOK_API_KEY=your_model_provider_api_key
+# QODER_BYOK_PROVIDER=deepseek
+# QODER_BYOK_BASE_URL=https://api.deepseek.com/v1
+# QODER_BYOK_STYLE=openai
 ```
 
 For the global npm CLI, install the peer beside SmartPerfetto with
@@ -341,7 +351,10 @@ The default Docker and portable artifacts do not install the Qoder SDK. To use
 this runtime there, build a deployment that explicitly installs the optional
 peer after accepting its terms. Provider Manager restricts Qoder to custom
 profiles and requires either `qoderAccessToken` or `qoderCliPath`; env mode can
-fall back to the local `qodercli` login.
+fall back to the local `qodercli` login. A custom Qoder profile may also set
+`QODER_BYOK_API_KEY`, `QODER_BYOK_PROVIDER`, `QODER_BYOK_BASE_URL`, and
+`QODER_BYOK_STYLE` through `custom.envOverrides`. Other runtimes reject these
+keys, and that entry point cannot override the CLI, SDK module, or worker path.
 
 Restart the backend after changing `.env`. Saving or activating a Provider Manager profile in the UI usually does not require a backend restart, but existing analysis sessions keep the provider source they were created with. Verify explicit env/proxy credentials with:
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -303,12 +303,22 @@ Qoder Agent SDK：
 ```bash
 # 显式安装前先审阅并接受 Qoder SDK/CLI 条款。
 # 使用预装兼容 CLI 时，可先设置 QODER_SKIP_DOWNLOAD=1。
-npm --prefix backend install --no-save @qoder-ai/qoder-agent-sdk
+npm --prefix backend run qoder:install -- --accept-terms
 SMARTPERFETTO_AGENT_RUNTIME=qoder-agent-sdk
 # 可选 PAT；不设置时使用本机 qodercli 登录态。
 # QODER_PERSONAL_ACCESS_TOKEN=your_qoder_pat
 # 可选预装 executable 路径。
 # QODERCLI_PATH=/absolute/path/to/qodercli
+# 可选：从绝对路径加载兼容 SDK entry。
+# SMARTPERFETTO_QODER_SDK_MODULE_PATH=/absolute/path/to/qoder-sdk/dist/index.js
+# 可选 BYOK：三项必须一起配置；base URL、style 和 light model 可省略。
+# BYOK 只配置模型 provider，不替代上面的 Qoder PAT/qodercli 认证。
+# QODER_MODEL=deepseek-chat
+# QODER_LIGHT_MODEL=deepseek-chat
+# QODER_BYOK_API_KEY=your_model_provider_api_key
+# QODER_BYOK_PROVIDER=deepseek
+# QODER_BYOK_BASE_URL=https://api.deepseek.com/v1
+# QODER_BYOK_STYLE=openai
 ```
 
 全局 npm CLI 需要把 peer 与 SmartPerfetto 一起安装：
@@ -317,7 +327,10 @@ SMARTPERFETTO_AGENT_RUNTIME=qoder-agent-sdk
 默认 Docker 和 portable 产物不会安装 Qoder SDK。若要在这些部署形态中
 使用，需要在接受条款后构建显式安装 optional peer 的自定义产物。Provider
 Manager 只允许 custom profile 选择 Qoder，并要求 `qoderAccessToken` 或
-`qoderCliPath`；env 模式可以回退到本机 `qodercli` 登录态。
+`qoderCliPath`；env 模式可以回退到本机 `qodercli` 登录态。custom Qoder
+profile 还可以通过 `custom.envOverrides` 设置 `QODER_BYOK_API_KEY`、
+`QODER_BYOK_PROVIDER`、`QODER_BYOK_BASE_URL` 和 `QODER_BYOK_STYLE`；这些键
+不会被其他 runtime 接受，CLI/module/worker path 也不能经此入口覆盖。
 
 接入 Gemini 等 provider 时，如果账号只提供 OpenAI-compatible API，可以直接使用 `openai-agents-sdk`；如果该接口的 streaming tool call 不稳定，再让代理层暴露 Anthropic Messages 兼容接口，然后配置：
 


### PR DESCRIPTION
## Summary

- forward-port the still-valid Qoder BYOK model policy onto current main
- keep Qoder authentication separate from model-provider credentials and isolate the BYOK API key from generic subprocesses
- add opt-in SDK installation, focused DeepSeek E2E wiring, Provider Manager custom env support, diagnostics, snapshots, tests, and bilingual docs

## Verification

- independent read-only review: OKAY
- focused Qoder/Provider Manager/critical downstream tests: 170 passed
- root governance, docs, i18n, rendering, quality, frontend prebuild, Rust, backend typecheck/build/package checks: passed
- backend core: 1071 passed, 2 skipped
- runtime resilience: 58 passed
- architecture: 607 passed, 2 skipped
- auth: 61 passed
- self-evolution: 745 passed
- external issue reporting: 25 passed
- Trace SQL regression and scene regression: passed; all 6 real scene traces passed
- full `npm run verify:pr`: baseline-only failure in `trace:validate` because six unchanged legacy publication exceptions on main expired on 2026-08-15
- real Qoder-authenticated DeepSeek startup: NOT AVAILABLE locally because no Qoder PAT, configured CLI path, or qodercli login is present; the DeepSeek credential and local SDK are available

No release is included.