### PR TITLE
fix: preserve UTF-8 trace filenames

### DIFF
--- a/backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts
+++ b/backend/src/routes/__tests__/enterpriseTraceMetadataRoutes.test.ts
@@ -907,6 +907,79 @@ describe('enterprise trace metadata routes', () => {
     });
   });
 
+  it('preserves UTF-8 upload names and repairs legacy mojibake in trace catalog responses', async () => {
+    const app = makeApp();
+    const filename = '直播跳转卡顿 修改后.perfetto';
+    const uploadRes = await ssoHeaders(
+      request(app)
+        .post('/api/traces/upload')
+        .attach('file', Buffer.from('trace-content'), filename),
+    );
+
+    expect(uploadRes.status).toBe(200);
+    expect(uploadRes.body.trace.filename).toBe(filename);
+    const traceId = uploadRes.body.trace.id as string;
+    expect(fakeTraceProcessorService.initializeUploadWithId).toHaveBeenCalledWith(
+      traceId,
+      filename,
+      'trace-content'.length,
+      expect.any(String),
+    );
+    expect(JSON.parse(readTraceAsset(traceId)!.metadata_json)).toEqual(
+      expect.objectContaining({filename}),
+    );
+
+    const legacyFilename = Buffer.from('对比基准.perfetto', 'utf8').toString('latin1');
+    await writeTraceMetadata({
+      id: 'legacy-mojibake-trace',
+      filename: legacyFilename,
+      size: 24,
+      uploadedAt: new Date().toISOString(),
+      status: 'ready',
+      path: path.join(
+        dataDir,
+        'tenant-a',
+        'workspace-a',
+        'traces',
+        'legacy-mojibake-trace.trace',
+      ),
+      tenantId: 'tenant-a',
+      workspaceId: 'workspace-a',
+      userId: 'user-a',
+    });
+    await writeTraceMetadata({
+      id: 'latin1-trace',
+      filename: 'café.perfetto',
+      size: 24,
+      uploadedAt: new Date().toISOString(),
+      status: 'ready',
+      path: path.join(
+        dataDir,
+        'tenant-a',
+        'workspace-a',
+        'traces',
+        'latin1-trace.trace',
+      ),
+      tenantId: 'tenant-a',
+      workspaceId: 'workspace-a',
+      userId: 'user-a',
+    });
+
+    const listRes = await ssoHeaders(request(app).get('/api/traces'));
+    expect(listRes.status).toBe(200);
+    expect(listRes.body.traces).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'legacy-mojibake-trace',
+        filename: '对比基准.perfetto',
+      }),
+      expect.objectContaining({
+        id: 'latin1-trace',
+        filename: 'café.perfetto',
+      }),
+      expect.objectContaining({id: traceId, filename}),
+    ]));
+  });
+
   it('reports trace_processor startup failures without creating a frontend lease', async () => {
     const app = makeApp();
     const sourceTracePath = path.join(tmpDir, 'tp-failure.trace');

--- a/backend/src/routes/simpleTraceRoutes.ts
+++ b/backend/src/routes/simpleTraceRoutes.ts
@@ -84,6 +84,26 @@ const MAX_TRACE_LIST_LIMIT = 200;
 // 2x covers the in-flight upload plus the .uploading temp file written alongside the final trace.
 const DISK_SAFETY_MULTIPLIER = 2;
 
+/**
+ * Multer/Busboy decodes multipart filename parameters as Latin-1 by default,
+ * while browsers send the filename bytes as UTF-8. Recover the original name
+ * only when the Latin-1 code units form a lossless UTF-8 byte sequence.
+ */
+function normalizeUtf8Filename(filename: string): string {
+  if ([...filename].some(character => (character.codePointAt(0) ?? 0) > 0xff)) {
+    return filename;
+  }
+  const decoded = Buffer.from(filename, 'latin1').toString('utf8');
+  return Buffer.from(decoded, 'utf8').toString('latin1') === filename
+    ? decoded
+    : filename;
+}
+
+function normalizeTraceCatalogFilename(metadata: TraceMetadata): TraceMetadata {
+  const filename = normalizeUtf8Filename(metadata.filename);
+  return filename === metadata.filename ? metadata : {...metadata, filename};
+}
+
 class TraceUploadTooLargeError extends Error {
   constructor(readonly maxBytes: number) {
     super(`Trace file too large. Maximum allowed size is ${maxBytes} bytes`);
@@ -848,6 +868,7 @@ router.post(
       }
 
       const file = req.file;
+      const filename = normalizeUtf8Filename(file.originalname);
       const tenantDecision = evaluateTenantMutationPolicy(context);
       if (!tenantDecision.allowed) {
         await cleanupFile(file.path);
@@ -867,10 +888,10 @@ router.post(
       const finalPath = path.join(tracesDir, `${traceId}.trace`);
       await renameTraceAtomically(file.path, finalPath);
 
-      console.log(`File uploaded successfully: ${file.originalname} -> ${traceId}`);
+      console.log(`File uploaded successfully: ${filename} -> ${traceId}`);
 
       // Get trace status and processor port from service
-      const traceInfo = await finalizeTraceUpload(traceId, file.originalname, file.size, finalPath, context, 'local');
+      const traceInfo = await finalizeTraceUpload(traceId, filename, file.size, finalPath, context, 'local');
       if (!traceUploadHasRpcTarget(traceInfo)) {
         sendTraceProcessorUnavailable(res, traceInfo);
         return;
@@ -880,7 +901,7 @@ router.post(
         success: true,
         trace: {
           id: traceId,
-          filename: file.originalname,
+          filename,
           size: file.size,
           uploadedAt: traceInfo?.uploadTime || new Date().toISOString(),
           status: traceInfo?.status || 'ready',
@@ -1039,7 +1060,10 @@ router.get('/', async (req, res) => {
       return sendForbidden(res, 'Listing traces requires trace:read permission');
     }
     const page = await listTraceMetadataPageForContext(context, traceListOptions(req));
-    res.json(page);
+    res.json({
+      ...page,
+      traces: page.traces.map(normalizeTraceCatalogFilename),
+    });
   } catch (error: any) {
     if (error instanceof InvalidTraceMetadataCursorError || error instanceof RangeError) {
       return res.status(400).json({


### PR DESCRIPTION
## Summary
- recover UTF-8 filenames that Multer/Busboy decoded as Latin-1 during multipart uploads
- persist correct names for new uploads and repair legacy mojibake at the trace catalog response boundary
- preserve valid non-mojibake Latin-1 names

## Root cause
Browsers send multipart filename bytes as UTF-8, while the upload parser decodes multipart parameters as Latin-1 by default. The decoded mojibake was stored unchanged and later rendered in the comparison trace selectors.

## Tests
- full repository PR verification components passed
- backend verify:pr passed
- enterpriseTraceMetadataRoutes.test.ts: 36 passed
- added coverage for a Chinese upload name, a legacy mojibake record, and café.perfetto