### PR TITLE
chore: release v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Commit prefixes follow [Conventional Commits](https://www.conventionalcommits.org/).
 Detailed commit-level history is available via `git log`.
 
+## [1.8.1] - 2026-08-26
+
+### Added
+- Code-aware analysis can preview and register bounded app, AOSP/OEM, and
+  kernel source trees, search or read selected files without a prebuilt index,
+  and build optional indexed generations with explicit coverage metadata.
+- The AI Assistant now exposes codebase scope suggestions, language-consent
+  changes, active and pending generation status, downgrade confirmation,
+  maintenance warnings, audit details, and accessible operation feedback.
+
+### Changed
+- Trace-corpus verification now binds executable SQL to source-pinned
+  provenance, realistic constructed evidence, and semantic result assertions
+  instead of treating registration or row-only execution as correctness.
+- Local source selection, provider disclosure, Git/ripgrep/Node discovery, and
+  generation activation now share canonical policy and consent contracts across
+  CLI, API, MCP, reports, and the committed Perfetto frontend.
+
+### Fixed
+- Codebase reindex, candidate replacement, expiry, cleanup, deletion, and
+  provider-consent changes are fenced against stale generations and concurrent
+  requests without deleting active or in-flight source chunks.
+- Metadata reads, Git provenance, subprocess output, directory traversal, and
+  local RAG persistence now have bounded cross-platform deadlines and capacity;
+  Windows path casing, open flags, and Trace CLI expectations are portable.
+
 ## [1.8.0] - 2026-08-25
 
 ### Added

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gracker/smartperfetto",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gracker/smartperfetto",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.153",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gracker/smartperfetto",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "SmartPerfetto CLI and backend runtime",
   "main": "dist/index.js",
   "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smart-perfetto",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smart-perfetto",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "devDependencies": {
         "@biomejs/biome": "^2.5.7",
         "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-perfetto",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "AI-powered Perfetto analysis platform",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump SmartPerfetto from 1.8.0 to 1.8.1 across the root and npm package manifests and lockfiles.
- Add release notes for the Trace SQL semantic-correctness hardening and bounded codebase import/search delivery now on main.

## Verification

- `npm run version:sync -- --check`: PASS.
- `npm run verify:docs`: PASS.
- `npm run verify:pr`: PASS on the exact release diff.
- An unrelated SSE/RBAC timing case failed once during the first local run; isolated full-file rerun passed 40/40, and the clean second full `verify:pr` run passed.
- `git diff --check`: PASS.
- Independent release diff review: SHIP.

## Post-merge release sequence

1. Publish `@gracker/smartperfetto@1.8.1` from `backend/`, verify registry propagation, and run isolated CLI smoke.
2. Build signed/notarized macOS plus Windows and Linux portable archives from the exact clean release commit and create a draft GitHub Release.
3. Run default-branch exact-archive native smoke for all three targets and promote the unchanged draft bytes.
4. Verify the tag-triggered Docker release, SemVer/latest/sha tags, and amd64/arm64 manifest.

The local Developer ID and `SmartPerfetto-notary` profile are verified. The current npm CLI session returns E401 and will be reauthenticated before npm publish; this PR does not claim publication.
