### PR TITLE
fix(codebase): preserve metadata deadline semantics

### DIFF
--- a/backend/src/services/__tests__/sourceEnumerator.test.ts
+++ b/backend/src/services/__tests__/sourceEnumerator.test.ts
@@ -322,6 +322,33 @@ describe('SourceEnumerator', () => {
     }
   });
 
+  it('reports traversal failure for an unsafe .gitmodules path', async () => {
+    const root = path.join(tmpDir, 'gitmodules-unsafe-path');
+    fs.mkdirSync(root, {recursive: true});
+    fs.writeFileSync(path.join(root, 'Main.kt'), 'class Main\n');
+    fs.writeFileSync(path.join(root, '.gitmodules'), [
+      '[submodule "outside"]',
+      '  path = ../outside',
+      '  url = https://example.com/outside.git',
+      '',
+    ].join('\n'));
+    execFileSync('git', ['init', '-q'], {cwd: root});
+    execFileSync('git', ['add', 'Main.kt', '.gitmodules'], {cwd: root});
+
+    const result = await new SourceEnumerator({ripgrepPath: '__missing_rg__'}).enumerate({
+      rootRealpath: fs.realpathSync(root),
+      policy: buildSourceSelectionIR({kind: 'app_source'}),
+      gate: new PathSecurityGate({allowlistRoots: [root]}),
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      backend: 'git',
+      enumerationComplete: false,
+      deterministic: false,
+      incompleteReason: 'traversal_error',
+    }));
+  });
+
   it('enumerates initialized git submodules in a second bounded pass', async () => {
     const child = path.join(tmpDir, 'child');
     fs.mkdirSync(child, {recursive: true});

--- a/backend/src/services/__tests__/sourceEnumerator.test.ts
+++ b/backend/src/services/__tests__/sourceEnumerator.test.ts
@@ -193,6 +193,7 @@ describe('SourceEnumerator', () => {
     const guardFailure = new Promise<never>((_resolve, reject) => {
       guard = setTimeout(() => reject(new Error('test_guard_timeout')), 300);
     });
+    const now = jest.spyOn(Date, 'now').mockReturnValue(0);
 
     try {
       const result = await Promise.race([
@@ -211,6 +212,7 @@ describe('SourceEnumerator', () => {
       }));
     } finally {
       if (guard) clearTimeout(guard);
+      now.mockRestore();
       open.mockRestore();
     }
   });

--- a/backend/src/services/codebase/boundedMetadataFile.ts
+++ b/backend/src/services/codebase/boundedMetadataFile.ts
@@ -37,11 +37,18 @@ interface BoundedMetadataFileInput {
   platform?: NodeJS.Platform;
 }
 
+export class SourceMetadataDeadlineExceededError extends Error {
+  constructor() {
+    super('source_metadata_time_budget');
+    this.name = 'SourceMetadataDeadlineExceededError';
+  }
+}
+
 async function readBoundedMetadataFileOperation(input: BoundedMetadataFileInput): Promise<string> {
   const platform = input.platform ?? process.platform;
   const assertWithinDeadline = (): void => {
     if (input.deadline !== undefined && Date.now() >= input.deadline) {
-      throw new Error('source_metadata_time_budget');
+      throw new SourceMetadataDeadlineExceededError();
     }
   };
   assertWithinDeadline();
@@ -101,7 +108,7 @@ export async function readBoundedMetadataFile(input: BoundedMetadataFileInput): 
     return await Promise.race([
       operation,
       new Promise<never>((_resolve, reject) => {
-        timer = setTimeout(() => reject(new Error('source_metadata_time_budget')), remainingMs);
+        timer = setTimeout(() => reject(new SourceMetadataDeadlineExceededError()), remainingMs);
       }),
     ]);
   } finally {

--- a/backend/src/services/codebase/sourceEnumerator.ts
+++ b/backend/src/services/codebase/sourceEnumerator.ts
@@ -8,7 +8,10 @@ import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import type {PathSecurityGate} from './pathSecurityGate';
-import {readBoundedMetadataFile} from './boundedMetadataFile';
+import {
+  readBoundedMetadataFile,
+  SourceMetadataDeadlineExceededError,
+} from './boundedMetadataFile';
 import {
   hardenedGitEnvironment,
   hardenedGitPrefixArguments,
@@ -54,6 +57,7 @@ interface CollectedPaths {
 interface GitSubmodulePaths {
   paths: string[];
   complete: boolean;
+  reason?: 'time_budget' | 'traversal_error';
 }
 
 interface CandidateInspection {
@@ -183,7 +187,7 @@ export class SourceEnumerator {
     const submodules = await this.readGitSubmodulePaths(root, policy, startedAt + timeoutMs);
     const paths = [...rootPaths.paths];
     let complete = rootPaths.complete && submodules.complete;
-    let reason = rootPaths.reason ?? (submodules.complete ? undefined : 'traversal_error');
+    let reason = rootPaths.reason ?? submodules.reason;
     let stderrObserved = rootPaths.stderrObserved;
     for (const submodulePath of submodules.paths) {
       if (paths.length > this.maxVisitedEntries) {
@@ -283,7 +287,13 @@ export class SourceEnumerator {
       });
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {paths: [], complete: true};
-      return {paths: [], complete: false};
+      return {
+        paths: [],
+        complete: false,
+        reason: error instanceof SourceMetadataDeadlineExceededError
+          ? 'time_budget'
+          : 'traversal_error',
+      };
     }
     const paths: string[] = [];
     let complete = true;

--- a/backend/src/services/codebase/sourceEnumerator.ts
+++ b/backend/src/services/codebase/sourceEnumerator.ts
@@ -187,7 +187,9 @@ export class SourceEnumerator {
     const submodules = await this.readGitSubmodulePaths(root, policy, startedAt + timeoutMs);
     const paths = [...rootPaths.paths];
     let complete = rootPaths.complete && submodules.complete;
-    let reason = rootPaths.reason ?? submodules.reason;
+    let reason = rootPaths.reason ??
+      submodules.reason ??
+      (submodules.complete ? undefined : 'traversal_error');
     let stderrObserved = rootPaths.stderrObserved;
     for (const submodulePath of submodules.paths) {
       if (paths.length > this.maxVisitedEntries) {


### PR DESCRIPTION
## Summary

- Preserve the bounded metadata deadline as a typed error so `.gitmodules` timeout results remain `time_budget` even when the real timer wins just before the logical clock reaches the deadline.
- Keep non-timeout metadata failures and incomplete submodule parsing classified as `traversal_error`.
- Make both edge cases deterministic with frozen-clock and unsafe-path regression coverage.

## Test Coverage

Coverage audit: 94% semantic path coverage, 1 low-risk gap. The unlisted >256 valid-submodule limit uses the same fallback covered by the unsafe-path regression.

```text
hung .gitmodules open -> wall-clock timer -> typed deadline error -> time_budget
unsafe .gitmodules path -> incomplete parse -> traversal fallback -> traversal_error
```

## Pre-Landing Review

- Independent code review: SHIP, zero findings.
- Adversarial review: NO FINDINGS.
- GitNexus staged change detection: LOW risk, no affected execution flows.
- No frontend files changed; design review skipped.
- No prompt-related files changed; evals skipped.
- Perfetto-Skills impact: `not_required` because no Skill, Strategy, SQL, evidence/export contract, trace-processor pin, or Perfetto UI surface changed.

## Plan Completion

All implementation items are complete:

- [x] Typed metadata deadline error.
- [x] Timer and phase checks share the same error.
- [x] Timeout maps to `time_budget`.
- [x] Other metadata failures retain `traversal_error`.
- [x] Generic incomplete submodule parse retains its legacy fallback.
- [x] Hung-open and unsafe-path regression tests.

## Verification Results

Passed:

- `npm test -- src/services/__tests__/sourceEnumerator.test.ts src/services/__tests__/aospManifest.test.ts --runInBand`: 2 suites, 27 tests.
- `npm run typecheck`.
- `npm --prefix backend run verify:codebase-aware`, including source/dist heavy/light trace E2E.
- `npm run verify:docs` and `npm run verify:i18n`.
- `git diff --check`.
- Full `npm run verify:pr` passed after the primary deadline fix.

After the final fallback regression was added, two local full-gate retries each reached `test:core` with 1086/1089 passing and hit an unrelated pre-existing `traceProcessorProxyRoutes` socket reset/hang-up. That suite passes 11/11 in isolation. No trace-proxy files or dependencies are changed by this PR; GitHub CI on a clean runner is the final landing gate.

## Documentation

Documentation audit found no user, API, CLI, or architecture updates required. Existing bilingual Code-Aware docs already cover bounded enumeration behavior.

## Test plan

- [x] Reproduce the original timer-vs-logical-clock race as RED.
- [x] Verify typed timeout propagation as GREEN.
- [x] Verify unsafe submodule paths keep `traversal_error`.
- [x] Run related suites and typecheck.
- [x] Run codebase-aware source/dist E2E.
- [ ] Require all GitHub PR checks to pass before merge.

🤖 Generated with [Codex](https://Codex.com/Codex)
