### PR TITLE
chore: release v1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Commit prefixes follow [Conventional Commits](https://www.conventionalcommits.org/).
 Detailed commit-level history is available via `git log`.
 
+## [1.8.2] - 2026-08-26
+
+### Fixed
+- Source enumeration now preserves `time_budget` when a bounded `.gitmodules`
+  metadata read reaches its real wall-clock deadline, while unsafe or malformed
+  submodule declarations continue to report `traversal_error`.
+
 ## [1.8.1] - 2026-08-26
 
 ### Added

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gracker/smartperfetto",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gracker/smartperfetto",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.153",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gracker/smartperfetto",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "SmartPerfetto CLI and backend runtime",
   "main": "dist/index.js",
   "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smart-perfetto",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smart-perfetto",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "devDependencies": {
         "@biomejs/biome": "^2.5.7",
         "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-perfetto",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "AI-powered Perfetto analysis platform",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump root and npm package versions from 1.8.1 to 1.8.2.
- Document the metadata deadline classification fix merged in PR #267.
- Publish a fresh patch so npm, portable assets, GitHub Release, and Docker all point to code containing the fix.

## Verification

- [x] `npm run version:sync -- --check`
- [x] `npm run verify:docs`
- [x] `npm run verify:pr`
- [x] `git diff --check`
- [x] Independent release review: SHIP
- [x] No existing npm 1.8.2, remote v1.8.2 tag, or GitHub Release collision
- [x] Perfetto-Skills impact: `not_required` (version/changelog only)

## Post-merge release sequence

1. Publish `@gracker/smartperfetto@1.8.2` from `backend/`.
2. Verify registry propagation and an isolated install smoke.
3. Build/sign/notarize Windows, macOS, and Linux portable archives once.
4. Upload a draft and run exact-archive target-native smoke on all three platforms.
5. Promote with the hosted attestation.
6. Wait for Docker publish and verify `1.8.2`, `latest`, and `sha-*` multi-arch manifests.
