### PR TITLE
ci(release): add npm trusted publishing

### DIFF
--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -52,30 +52,15 @@ should use WSL2; native Windows users should use the portable package.
    git commit -m "chore: release v<version>"
    git push origin main
    ```
-6. Publish the npm CLI:
+6. Preflight the npm CLI package without a publish credential:
    ```bash
-   npm whoami
    npm --prefix backend run cli:pack-check
-   cd backend
-   npm publish --access public
-   cd ..
-   npm view @gracker/smartperfetto version --json
+   npm --prefix backend run cli:e2e
    ```
-   For a new scope or org, verify scope permission first. Publishing can
-   return success before registry metadata is fully visible; wait and verify
-   both `npm view` and an isolated install before calling the npm release done.
-   Do not use `npm --prefix backend publish --access public`: npm can still
-   resolve the publish target as the repository root package, hit the root
-   `private` guard, and fail with `EPRIVATE` without publishing
-   `@gracker/smartperfetto`.
-7. Run isolated npm smoke in a temp directory:
-   ```bash
-   npm install @gracker/smartperfetto@<version>
-   ./node_modules/.bin/smp --version
-   ./node_modules/.bin/smartperfetto --help
-   ./node_modules/.bin/smp doctor --format json
-   ```
-8. Build portable GitHub assets from the exact clean release commit:
+   The normal npm publish path is the tokenless
+   `.github/workflows/npm-publish.yml` Trusted Publisher workflow. It repeats
+   these checks against the exact release tag before producing the tarball.
+7. Build portable GitHub assets from the exact clean release commit:
    ```bash
    npm run package:portable
    ```
@@ -117,7 +102,7 @@ should use WSL2; native Windows users should use the portable package.
    Hosted promotion also re-fetches repository metadata and rejects runs from
    any branch other than GitHub's current default branch. The run gate SHA must
    exactly equal the clean promotion checkout's `HEAD`.
-9. Publish those already-smoked portable assets:
+8. Publish those already-smoked portable assets:
    ```bash
    npm run release:portable -- <version> --skip-build --no-draft \
      --smoke-evidence-dir dist/portable/smoke-evidence
@@ -135,7 +120,39 @@ should use WSL2; native Windows users should use the portable package.
      --smoke-attestation <download-dir>/portable-smoke-attestation.json \
      --smoke-run-id <run-id>
    ```
-10. Re-check `git status --short --branch`. Generated `dist/portable/`,
+9. Wait for the public release's npm Trusted Publishing workflow, then verify
+   the registry:
+   ```bash
+   gh run list --workflow npm-publish.yml --limit 5
+   gh run watch <run-id> --exit-status
+   npm view @gracker/smartperfetto@<version> version dist.integrity --json
+   ```
+   The workflow accepts only a public, non-prerelease release with a full
+   target SHA that matches its tag, package versions, and a commit reachable
+   from `main`. It builds and tests without an OIDC credential, then gives
+   `id-token: write` only to a separate job that publishes the hash-bound
+   tarball. A rerun may skip an immutable version only when registry
+   `dist.integrity` exactly matches that tarball. If the release event was not
+   delivered, rerun the same path from the default branch by immutable public
+   release ID:
+   ```bash
+   gh workflow run npm-publish.yml --ref main -f release_id=<numeric-release-id>
+   ```
+   Interactive WebAuthn publishing is an emergency fallback only. When it is
+   required, publish from `backend/` with `npm publish --access public`; never
+   use `npm --prefix backend publish`, which can resolve the private root
+   package and fail with `EPRIVATE`.
+10. Run isolated npm smoke in a temp directory under supported Node.js 24:
+    ```bash
+    npm install @gracker/smartperfetto@<version>
+    ./node_modules/.bin/smp --version
+    ./node_modules/.bin/smartperfetto --help
+    ./node_modules/.bin/smp doctor --format json
+    ```
+    Publishing can return success before registry metadata is fully visible;
+    require both `npm view` and this isolated install before calling the npm
+    release done.
+11. Re-check `git status --short --branch`. Generated `dist/portable/`,
    `dist/windows-exe/`, and cache outputs must not be staged.
 
 ## npm CLI Invariants
@@ -144,12 +161,36 @@ should use WSL2; native Windows users should use the portable package.
 - The package must expose both `smp` and `smartperfetto` bins.
 - `npm --prefix backend run cli:pack-check` must verify package contents before
   publish.
-- Publish from the `backend/` working directory with `npm publish --access
-  public`; do not publish with `npm --prefix backend publish`.
+- Build the releasable package from `backend/`. Trusted Publishing publishes
+  the exact tarball produced by that package job. Interactive fallback must
+  run from the `backend/` working directory with `npm publish --access public`;
+  do not publish with `npm --prefix backend publish`.
 - The packed CLI must contain runtime assets needed by `doctor`, `query`,
   `skill`, `run`, `ask`, `repl`, `compare`, and `report export`.
 - Do not publish if dry-run or pack-check reports missing bin files,
   missing runtime assets, wrong version, or an unsupported Node engine.
+
+## npm Trusted Publishing Invariants
+
+- npmjs.com must bind `@gracker/smartperfetto` to repository
+  `Gracker/SmartPerfetto` and the exact workflow filename `npm-publish.yml`.
+- The workflow must use GitHub-hosted runners, Node.js 24, and an npm CLI that
+  supports Trusted Publishing. It must not contain `NPM_TOKEN`,
+  `NODE_AUTH_TOKEN`, registry auth material, or repository secrets.
+- Release packaging and tests run without `id-token: write`. Only the publish
+  job receives the OIDC permission, and that job must not check out or execute
+  release source; it may consume only the hash-bound tarball artifact.
+- Manual dispatch is recovery-only, takes a numeric public release ID, and
+  must fail when invoked from any ref other than the default branch.
+- Both event and recovery paths must reject drafts, prereleases, non-SemVer
+  tags, non-full target SHAs, tag/target/version mismatches, and release commits
+  that are not ancestors of `main`.
+- An already-published version is idempotent only when npm registry
+  `dist.integrity` exactly equals the generated tarball SRI. A mismatch is a
+  hard failure, never a skip.
+- Post-publish smoke must install the public exact version without user npm
+  credentials and verify the supported Node boundary, CLI bins, Knowledge
+  Pack, and packaged `trace_processor_shell`.
 
 ## Portable Release Invariants
 
@@ -248,8 +289,8 @@ complete unless the workflow or image tag is verified.
   files.
 - Do not echo tokens into logs, docs, commit messages, release notes, or final
   summaries.
-- Prefer environment variables or npm's normal auth store for one-off publish
-  work.
+- Prefer npm Trusted Publishing OIDC. Use environment variables or npm's
+  normal auth store only for explicitly accepted one-off fallback work.
 - If a token was pasted into a chat or terminal transcript, recommend rotation
   after the release is verified.
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,328 @@
+name: npm Trusted Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_id:
+        description: Numeric public GitHub release ID to verify or publish
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-publish-${{ github.event.release.id || inputs.release_id }}
+  cancel-in-progress: false
+
+jobs:
+  package:
+    name: Build immutable npm package
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    outputs:
+      artifact_name: npm-package-${{ steps.release.outputs.release_id }}
+      package_file: ${{ steps.pack.outputs.package_file }}
+      package_integrity: ${{ steps.pack.outputs.package_integrity }}
+      package_sha256: ${{ steps.pack.outputs.package_sha256 }}
+      release_sha: ${{ steps.release.outputs.release_sha }}
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - name: Resolve the immutable public release
+        id: release
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          DISPATCH_REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_RELEASE_ID: ${{ github.event.release.id }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID_INPUT: ${{ inputs.release_id }}
+        run: |
+          node <<'NODE'
+          const {spawnSync} = require('node:child_process');
+          const {appendFileSync} = require('node:fs');
+
+          if (process.env.EVENT_NAME === 'workflow_dispatch') {
+            const expectedRef = `refs/heads/${process.env.DEFAULT_BRANCH}`;
+            if (process.env.DISPATCH_REF !== expectedRef) {
+              throw new Error(`workflow dispatch must use ${expectedRef}`);
+            }
+          }
+
+          const releaseId = process.env.EVENT_NAME === 'release'
+            ? process.env.EVENT_RELEASE_ID
+            : process.env.RELEASE_ID_INPUT;
+          if (!/^[1-9][0-9]*$/.test(releaseId || '')) {
+            throw new Error(`invalid numeric release ID: ${releaseId || '<missing>'}`);
+          }
+
+          const result = spawnSync(
+            'gh',
+            ['api', `repos/${process.env.GITHUB_REPOSITORY}/releases/${releaseId}`],
+            {encoding: 'utf8', env: process.env},
+          );
+          if (result.status !== 0) {
+            process.stderr.write(result.stderr);
+            process.exit(result.status || 1);
+          }
+
+          const release = JSON.parse(result.stdout);
+          if (release.draft || release.prerelease) {
+            throw new Error('npm publishing requires a public, non-prerelease release');
+          }
+          if (!/^v[0-9]+\.[0-9]+\.[0-9]+$/.test(release.tag_name || '')) {
+            throw new Error(`invalid stable release tag: ${release.tag_name || '<missing>'}`);
+          }
+          if (!/^[0-9a-f]{40}$/.test(release.target_commitish || '')) {
+            throw new Error('release target_commitish must be a full commit SHA');
+          }
+
+          appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            [
+              `release_id=${releaseId}`,
+              `release_sha=${release.target_commitish}`,
+              `tag=${release.tag_name}`,
+              `version=${release.tag_name.slice(1)}`,
+              '',
+            ].join('\n'),
+          );
+          NODE
+
+      - name: Check out the exact release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ steps.release.outputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Bind tag, release target, version, and main ancestry
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_SHA: ${{ steps.release.outputs.release_sha }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          git fetch --no-tags origin "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/main"
+          test "$(git rev-parse HEAD)" = "${RELEASE_SHA}"
+          test "$(git rev-parse "${RELEASE_TAG}^{commit}")" = "${RELEASE_SHA}"
+          git merge-base --is-ancestor "${RELEASE_SHA}" origin/main
+          node <<'NODE'
+          const rootPackage = require('./package.json');
+          const backendPackage = require('./backend/package.json');
+          const expected = process.env.VERSION;
+          if (rootPackage.version !== expected || backendPackage.version !== expected) {
+            throw new Error(
+              `release ${expected} does not match package versions ` +
+                `${rootPackage.version}/${backendPackage.version}`,
+            );
+          }
+          NODE
+          test -z "$(git status --porcelain)"
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Pin the trusted-publishing npm CLI
+        run: npm install --global npm@11.12.1 && npm --version
+
+      - name: Verify synchronized release versions
+        run: npm run version:sync -- --check
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm ci
+
+      - name: Verify npm package contents
+        working-directory: backend
+        run: npm run cli:pack-check
+
+      - name: Verify installed CLI behavior
+        working-directory: backend
+        run: npm run cli:e2e
+
+      - name: Pack the immutable npm tarball
+        id: pack
+        working-directory: backend
+        run: |
+          mkdir -p "${RUNNER_TEMP}/npm-package"
+          npm pack --silent --pack-destination "${RUNNER_TEMP}/npm-package" > "${RUNNER_TEMP}/npm-pack.log"
+          if ! PACKAGE_PATH="$(node -e "const {readdirSync}=require('node:fs');const {join}=require('node:path');const dir=process.argv[1];const files=readdirSync(dir).filter((name)=>name.endsWith('.tgz'));if(files.length !== 1)throw new Error('expected exactly one npm tarball');process.stdout.write(join(dir,files[0]));" "${RUNNER_TEMP}/npm-package")"; then
+            cat "${RUNNER_TEMP}/npm-pack.log" >&2
+            exit 1
+          fi
+          PACKAGE_FILE="$(basename "${PACKAGE_PATH}")"
+          PACKAGE_SHA256="$(sha256sum "${PACKAGE_PATH}" | cut -d ' ' -f 1)"
+          PACKAGE_INTEGRITY="$(node -e "const {createHash}=require('node:crypto');const {readFileSync}=require('node:fs');process.stdout.write('sha512-'+createHash('sha512').update(readFileSync(process.argv[1])).digest('base64'))" "${PACKAGE_PATH}")"
+          {
+            echo "package_file=${PACKAGE_FILE}"
+            echo "package_sha256=${PACKAGE_SHA256}"
+            echo "package_integrity=${PACKAGE_INTEGRITY}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Preserve the exact npm tarball
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: npm-package-${{ steps.release.outputs.release_id }}
+          path: ${{ runner.temp }}/npm-package/${{ steps.pack.outputs.package_file }}
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  publish:
+    name: Publish through npm OIDC
+    needs: package
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      PACKAGE_FILE: ${{ needs.package.outputs.package_file }}
+      PACKAGE_INTEGRITY: ${{ needs.package.outputs.package_integrity }}
+      PACKAGE_SHA256: ${{ needs.package.outputs.package_sha256 }}
+      VERSION: ${{ needs.package.outputs.version }}
+    steps:
+      - name: Set up Node.js 24 for npm OIDC
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Pin the trusted-publishing npm CLI
+        run: npm install --global npm@11.12.1 && npm --version
+
+      - name: Restore the exact npm tarball
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.package.outputs.artifact_name }}
+          path: ${{ runner.temp }}/npm-package
+
+      - name: Verify the restored tarball
+        run: |
+          PACKAGE_PATH="${RUNNER_TEMP}/npm-package/${PACKAGE_FILE}"
+          test -f "${PACKAGE_PATH}"
+          test "$(sha256sum "${PACKAGE_PATH}" | cut -d ' ' -f 1)" = "${PACKAGE_SHA256}"
+          test "$(node -e "const {createHash}=require('node:crypto');const {readFileSync}=require('node:fs');process.stdout.write('sha512-'+createHash('sha512').update(readFileSync(process.argv[1])).digest('base64'))" "${PACKAGE_PATH}")" = "${PACKAGE_INTEGRITY}"
+          echo "PACKAGE_PATH=${PACKAGE_PATH}" >> "${GITHUB_ENV}"
+
+      - name: Check immutable registry state
+        id: registry
+        run: |
+          set +e
+          REGISTRY_RESULT="$(npm view "@gracker/smartperfetto@${VERSION}" dist.integrity --json 2>&1)"
+          REGISTRY_STATUS=$?
+          set -e
+          if [ "${REGISTRY_STATUS}" -eq 0 ]; then
+            REGISTRY_INTEGRITY="$(node -e "process.stdout.write(JSON.parse(process.argv[1]))" "${REGISTRY_RESULT}")"
+            if [ "${REGISTRY_INTEGRITY}" != "${PACKAGE_INTEGRITY}" ]; then
+              echo "Registry integrity mismatch for @gracker/smartperfetto@${VERSION}" >&2
+              exit 1
+            fi
+            echo "already_published=true" >> "${GITHUB_OUTPUT}"
+          elif printf '%s' "${REGISTRY_RESULT}" | grep -q 'E404'; then
+            echo "already_published=false" >> "${GITHUB_OUTPUT}"
+          else
+            printf '%s\n' "${REGISTRY_RESULT}" >&2
+            exit "${REGISTRY_STATUS}"
+          fi
+
+      - name: Publish the immutable tarball
+        if: ${{ steps.registry.outputs.already_published == 'false' }}
+        run: npm publish "${PACKAGE_PATH}" --access public
+
+      - name: Wait for matching registry integrity
+        run: |
+          for ATTEMPT in $(seq 1 12); do
+            REGISTRY_INTEGRITY="$(npm view "@gracker/smartperfetto@${VERSION}" dist.integrity --json 2>/dev/null | sed -e 's/^"//' -e 's/"$//' || true)"
+            if [ "${REGISTRY_INTEGRITY}" = "${PACKAGE_INTEGRITY}" ]; then
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "npm registry did not expose the matching ${VERSION} integrity" >&2
+          exit 1
+
+  smoke:
+    name: Smoke the public npm package without credentials
+    needs:
+      - package
+      - publish
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      NPM_CONFIG_USERCONFIG: /dev/null
+      VERSION: ${{ needs.package.outputs.version }}
+    steps:
+      - name: Set up supported Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Install and verify the public package
+        run: |
+          mkdir -p "${RUNNER_TEMP}/npm-smoke"
+          cd "${RUNNER_TEMP}/npm-smoke"
+          npm init -y >/dev/null
+          npm install --no-audit --no-fund "@gracker/smartperfetto@${VERSION}"
+          node <<'NODE'
+          const {spawnSync} = require('node:child_process');
+          const {readFileSync} = require('node:fs');
+          const {join} = require('node:path');
+
+          const installRoot = join(process.env.RUNNER_TEMP, 'npm-smoke');
+          const packageRoot = join(
+            installRoot,
+            'node_modules',
+            '@gracker',
+            'smartperfetto',
+          );
+          const packageJson = JSON.parse(
+            readFileSync(join(packageRoot, 'package.json'), 'utf8'),
+          );
+          const commands = [
+            ['smp', ['--version']],
+            ['smartperfetto', ['--help']],
+            ['smp', ['doctor', '--format', 'json']],
+          ];
+          const outputs = new Map();
+          for (const [binName, args] of commands) {
+            const relativeBin = packageJson.bin[binName];
+            if (typeof relativeBin !== 'string') {
+              throw new Error(`public package is missing the ${binName} bin`);
+            }
+            const result = spawnSync(
+              process.execPath,
+              [join(packageRoot, relativeBin), ...args],
+              {cwd: installRoot, encoding: 'utf8', env: process.env},
+            );
+            if (result.status !== 0) {
+              process.stderr.write(result.stderr);
+              throw new Error(`${binName} ${args.join(' ')} failed`);
+            }
+            outputs.set(`${binName}:${args.join(' ')}`, result.stdout);
+          }
+
+          const version = outputs.get('smp:--version')?.trim();
+          if (version !== process.env.VERSION) {
+            throw new Error(`public CLI version mismatch: ${version}`);
+          }
+          const doctor = JSON.parse(outputs.get('smp:doctor --format json'));
+          if (!doctor.node?.ok) throw new Error('public CLI does not accept Node.js 24');
+          if (!doctor.traceProcessor?.exists || !doctor.traceProcessor?.executable) {
+            throw new Error('public CLI trace_processor_shell is unavailable');
+          }
+          if (doctor.knowledgePack?.availability !== 'available') {
+            throw new Error('public CLI Knowledge Pack is unavailable');
+          }
+          NODE

--- a/docs/reference/release.en.md
+++ b/docs/reference/release.en.md
@@ -47,26 +47,19 @@ git commit -m "chore: release v<version>"
 git push origin main
 ```
 
-Publish the npm CLI:
+Preflight the npm CLI before the public release without exposing a publish
+credential:
 
 ```bash
-npm whoami
 npm --prefix backend run cli:pack-check
-cd backend
-npm publish --access public
-cd ..
-npm view @gracker/smartperfetto version --json
+npm --prefix backend run cli:e2e
 ```
 
-After npm publish succeeds, run a real install smoke from an empty directory:
-
-```bash
-npm install @gracker/smartperfetto@<version>
-./node_modules/.bin/smp --version
-./node_modules/.bin/smartperfetto --help
-./node_modules/.bin/smp doctor --format json
-./node_modules/.bin/smp knowledge-pack status --format json
-```
+Normal npm publication is handled by the OIDC Trusted Publisher workflow at
+`.github/workflows/npm-publish.yml`, without `NPM_TOKEN`. The workflow repeats
+the version, pack, and CLI gates at the exact release tag, builds the tarball in
+a job without OIDC, then gives a separate publish job only the hash-bound
+tarball.
 
 Publish the GitHub portable assets:
 
@@ -93,6 +86,37 @@ npm run release:portable -- <version> --skip-build --no-draft \
   --smoke-run-id <run-id>
 gh release view v<version> --json tagName,isDraft,assets
 ```
+
+Publishing the GitHub Release automatically triggers npm Trusted Publishing.
+Wait for the workflow and verify the registry. If the release event was not
+delivered, recover idempotently from the default branch with the same public
+release ID:
+
+```bash
+gh run list --workflow npm-publish.yml --limit 5
+gh run watch <run-id> --exit-status
+# recovery only
+gh workflow run npm-publish.yml --ref main -f release_id=<numeric-release-id>
+npm view @gracker/smartperfetto@<version> version dist.integrity --json
+```
+
+The workflow accepts only a public, non-prerelease stable SemVer release with a
+full target SHA. Its tag, target, all four version fields, and `main` ancestry
+must agree. An existing version is an idempotent skip only when registry
+`dist.integrity` exactly matches the generated tarball. Finally, run a
+credential-free install smoke in an empty directory under Node.js 24:
+
+```bash
+npm install @gracker/smartperfetto@<version>
+./node_modules/.bin/smp --version
+./node_modules/.bin/smartperfetto --help
+./node_modules/.bin/smp doctor --format json
+./node_modules/.bin/smp knowledge-pack status --format json
+```
+
+Local `npm publish` is an emergency fallback only and requires WebAuthn. Run
+`npm publish --access public` from `backend/`; do not invoke publish from the
+root through `--prefix`, which can target the private root package.
 
 Portable packages use a build-once rule: test and upload the same final archive
 bytes, and never rebuild after smoke. Cross-compilation, manifest/structure
@@ -141,6 +165,12 @@ git status --short --branch
 
 - Root `package.json` is the version source; `npm run version:set -- <version>` must synchronize all four version files.
 - The npm package name is `@gracker/smartperfetto`, and it must expose both `smp` and `smartperfetto`.
+- npmjs.com must bind the Trusted Publisher exactly to
+  `Gracker/SmartPerfetto` and `npm-publish.yml`. Only the publish job may have
+  `id-token: write`, and it must not check out or execute release source.
+- `workflow_dispatch` is default-branch recovery only and takes a numeric
+  public release ID. An immutable-version skip must compare registry
+  `dist.integrity`, not only the version string.
 - Published npm versions are immutable. If package contents or runtime behavior are wrong, fix and publish the next patch version.
 - Public portable releases must not use `--allow-dirty`.
 - `--skip-build` is only valid for packages just built from the same version and commit.

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -45,26 +45,16 @@ git commit -m "chore: release v<version>"
 git push origin main
 ```
 
-发布 npm CLI：
+在公开 release 前预检 npm CLI；这里不接触发布凭证：
 
 ```bash
-npm whoami
 npm --prefix backend run cli:pack-check
-cd backend
-npm publish --access public
-cd ..
-npm view @gracker/smartperfetto version --json
+npm --prefix backend run cli:e2e
 ```
 
-npm 发布成功后，在空目录做真实安装 smoke：
-
-```bash
-npm install @gracker/smartperfetto@<version>
-./node_modules/.bin/smp --version
-./node_modules/.bin/smartperfetto --help
-./node_modules/.bin/smp doctor --format json
-./node_modules/.bin/smp knowledge-pack status --format json
-```
+正常 npm 发布由 `.github/workflows/npm-publish.yml` 的 OIDC Trusted Publisher
+完成，不使用 `NPM_TOKEN`。workflow 会从精确 release tag 重跑版本、pack 和 CLI
+门禁，在无 OIDC 的 job 中构建 tarball，再由独立发布 job 只消费哈希绑定的 tarball。
 
 发布 GitHub 免安装包：
 
@@ -91,6 +81,34 @@ npm run release:portable -- <version> --skip-build --no-draft \
   --smoke-run-id <run-id>
 gh release view v<version> --json tagName,isDraft,assets
 ```
+
+GitHub Release 公开后会自动触发 npm Trusted Publishing。等待 workflow 并验证
+registry；如果 release event 未送达，可从默认分支按同一公开 release ID 幂等恢复：
+
+```bash
+gh run list --workflow npm-publish.yml --limit 5
+gh run watch <run-id> --exit-status
+# recovery only
+gh workflow run npm-publish.yml --ref main -f release_id=<numeric-release-id>
+npm view @gracker/smartperfetto@<version> version dist.integrity --json
+```
+
+workflow 只接受 public、非 prerelease、完整 target SHA 的稳定 SemVer release；tag、
+target、四个版本字段和 `main` 祖先关系必须一致。已有版本只有 registry
+`dist.integrity` 与本次 tarball 完全一致时才会幂等跳过。最后在空目录、Node.js 24
+下做无凭证真实安装 smoke：
+
+```bash
+npm install @gracker/smartperfetto@<version>
+./node_modules/.bin/smp --version
+./node_modules/.bin/smartperfetto --help
+./node_modules/.bin/smp doctor --format json
+./node_modules/.bin/smp knowledge-pack status --format json
+```
+
+本地 `npm publish` 只作应急回退；它会要求 WebAuthn。必须从 `backend/` 执行
+`npm publish --access public`，不能从根目录通过 `--prefix` 形式调用 publish，
+否则可能误命中 private 根包。
 
 免安装包必须 build once：测试并上传同一份最终归档字节，通过 smoke 后不得重新构建。
 交叉编译、manifest/结构检查和静态签名校验不等于目标系统真实启动。Windows、macOS
@@ -128,6 +146,11 @@ git status --short --branch
 
 - 根目录 `package.json` 是版本源；`npm run version:set -- <version>` 必须同步四个版本文件。
 - npm 包名是 `@gracker/smartperfetto`，必须同时提供 `smp` 和 `smartperfetto` 两个 bin。
+- npmjs.com 的 Trusted Publisher 必须精确绑定 `Gracker/SmartPerfetto` 和
+  `npm-publish.yml`；只有 publish job 拥有 `id-token: write`，且该 job 不 checkout
+  或执行 release 源码。
+- `workflow_dispatch` 仅用于默认分支恢复，输入 numeric public release ID；公开版本
+  的幂等 skip 必须校验 registry `dist.integrity`，不能只比较版本号。
 - npm 已发布版本不可变；如果发现包内容或运行时 bug，修复后发布下一个 patch 版本。
 - 公开 portable release 不允许 `--allow-dirty`。
 - `--skip-build` 只能用于刚刚在同一版本、同一 commit 上构建出的包。

--- a/scripts/__tests__/runtime-distribution-assets.test.mjs
+++ b/scripts/__tests__/runtime-distribution-assets.test.mjs
@@ -416,6 +416,70 @@ test('Docker publishing keeps stable and nightly tags separate', () => {
   );
 });
 
+test('npm trusted publishing isolates release packaging from the OIDC publish credential', () => {
+  const workflowPath = join(root, '.github/workflows/npm-publish.yml');
+  assert.equal(
+    existsSync(workflowPath),
+    true,
+    'the npm trusted publishing workflow must exist',
+  );
+
+  const workflow = readFileSync(workflowPath, 'utf8');
+  const packageStart = workflow.indexOf('  package:');
+  const publishStart = workflow.indexOf('  publish:');
+  const smokeStart = workflow.indexOf('  smoke:');
+  assert.ok(packageStart >= 0 && publishStart > packageStart && smokeStart > publishStart);
+
+  const packageJob = workflow.slice(packageStart, publishStart);
+  const publishJob = workflow.slice(publishStart, smokeStart);
+  const smokeJob = workflow.slice(smokeStart);
+
+  assert.match(workflow, /release:\s+types:\s+\[published\]/);
+  assert.match(workflow, /workflow_dispatch:[\s\S]*?release_id:/);
+  assert.match(workflow, /cancel-in-progress: false/);
+  assert.match(packageJob, /refs\/heads\/\$\{DEFAULT_BRANCH\}/);
+  assert.match(packageJob, /merge-base --is-ancestor "\$\{RELEASE_SHA\}" origin\/main/);
+  assert.ok(packageJob.includes('/^[0-9a-f]{40}$/.test(release.target_commitish'));
+  assert.ok(packageJob.includes('/^v[0-9]+\\.[0-9]+\\.[0-9]+$/.test(release.tag_name'));
+  assert.match(packageJob, /npm run version:sync -- --check/);
+  assert.match(packageJob, /npm run cli:pack-check/);
+  assert.match(packageJob, /npm run cli:e2e/);
+  assert.match(packageJob, /npm pack --silent --pack-destination/);
+  assert.match(packageJob, /readdirSync/);
+  assert.match(packageJob, /files\.length !== 1/);
+  assert.doesNotMatch(packageJob, /PACKAGE_FILE="\$\(npm pack/);
+  assert.match(packageJob, /createHash\('sha512'\)/);
+  assert.match(packageJob, /actions\/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a/);
+  assert.doesNotMatch(packageJob, /id-token:\s*write/);
+
+  assert.equal((workflow.match(/id-token:\s*write/g) || []).length, 1);
+  assert.match(publishJob, /id-token:\s*write/);
+  assert.match(
+    publishJob,
+    /actions\/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c/,
+  );
+  assert.match(publishJob, /dist\.integrity/);
+  assert.match(publishJob, /REGISTRY_INTEGRITY/);
+  assert.match(publishJob, /PACKAGE_INTEGRITY/);
+  assert.match(publishJob, /npm publish "\$\{PACKAGE_PATH\}" --access public/);
+  assert.doesNotMatch(publishJob, /actions\/checkout|npm ci|npm run|scripts\//);
+
+  assert.match(smokeJob, /NPM_CONFIG_USERCONFIG:\s*\/dev\/null/);
+  assert.match(smokeJob, /npm install --no-audit --no-fund "@gracker\/smartperfetto@\$\{VERSION\}"/);
+  assert.match(smokeJob, /packageJson\.bin\[binName\]/);
+  assert.match(smokeJob, /spawnSync\(\s+process\.execPath/);
+  assert.ok(smokeJob.includes("['smp', ['--version']]"));
+  assert.ok(smokeJob.includes("['smartperfetto', ['--help']]"));
+  assert.ok(smokeJob.includes("['smp', ['doctor', '--format', 'json']]"));
+  assert.doesNotMatch(smokeJob, /node_modules\/\.bin/);
+  assert.doesNotMatch(smokeJob, /id-token:\s*write/);
+
+  assert.doesNotMatch(
+    workflow,
+    /NPM_TOKEN|NODE_AUTH_TOKEN|_authToken|secrets\.|npm --prefix backend publish/,
+  );
+});
+
 test('backend gate installs every dependency tree consumed by verify:pr', () => {
   const workflow = readFileSync(
     join(root, '.github/workflows/backend-agent-regression-gate.yml'),


### PR DESCRIPTION
## Summary

- add a tokenless npm Trusted Publishing workflow for public, stable GitHub Releases
- build and test the npm tarball without OIDC, then isolate `id-token: write` in a publish-only job that never checks out release source
- bind release ID, tag, full target SHA, package versions, `main` ancestry, artifact SHA-256, and npm SRI before publishing or idempotently skipping
- install the public exact version without npm credentials and verify both CLI bins plus doctor runtime assets
- update the project release rules and bilingual maintainer runbook; keep local WebAuthn publishing as emergency fallback only

## Test Coverage

- TDD contract added to the already-registered `runtime-distribution-assets.test.mjs`
- RED: missing workflow; GREEN: 16/16 governance contract tests
- regression caught and fixed `npm pack --silent` stdout contamination by enumerating the unique tarball instead of parsing stdout
- real `@gracker/smartperfetto@1.8.2` pack SHA-512 SRI matched npm registry `dist.integrity`

## Pre-Landing Review

Independent plan review findings were incorporated: require `main` ancestry and integrity-bound idempotency. Fresh final read-only review returned `SHIP` with no Critical or Important findings.

## Design Review

No frontend files changed; design review skipped.

## Eval Results

No prompt, Skill, or Strategy content changed; provider evals skipped.

## Plan Completion

Repository implementation is complete. npm Trusted Publisher registration and the idempotent v1.8.2 workflow dispatch will run after this PR lands on `main`, because npm binds an exact default-branch workflow filename.

## Verification Results

- `volta run --node 24.15.0 npm run verify:pr`: PASS
- governance: 248 tests, including the new workflow contract
- backend core: 1,087 passed; analysis accuracy: 642 passed; architecture: 741 passed; self-evolution: 786 passed
- Trace corpus: 664 SQL contracts, 262 expectations, 0 skipped/unavailable
- scene trace regression: 6/6 passed
- `npm run verify:docs`, i18n, rendering pipelines, quality, frontend prebuild, Rust checks: PASS
- `git diff --cached --check`: PASS
- GitNexus staged detection: LOW, 5 files, 0 affected execution flows
- `actionlint`: NOT AVAILABLE; GitHub PR CI is the authoritative workflow parser

## Test plan

- [x] `node --test scripts/__tests__/runtime-distribution-assets.test.mjs`
- [x] `npm run verify:docs`
- [x] `npm run quality`
- [x] `npm run verify:pr`
- [ ] GitHub Actions PR matrix passes
- [ ] post-merge `npm trust github` registration and `npm trust list` readback
- [ ] post-merge manual dispatch against public release ID `377117401` passes integrity idempotency and tokenless install smoke
