### PR TITLE
fix(portable): honor writable upload directory

### DIFF
--- a/backend/src/routes/perfettoLocalRoutes.ts
+++ b/backend/src/routes/perfettoLocalRoutes.ts
@@ -6,14 +6,19 @@ import express from 'express';
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs/promises';
+import fsSync from 'fs';
 import { perfettoLocalService } from '../services/perfettoLocalService';
 import { resolveTraceUploadLimitBytes } from '../services/traceUploadLimit';
 
 const router = express.Router();
 
 // Configure multer for file uploads
+// Portable launchers provide a writable user-data directory through UPLOAD_DIR.
+// Keep the package-local path as the source/development fallback.
+const uploadDir = process.env.UPLOAD_DIR || path.join(__dirname, '../../uploads');
+fsSync.mkdirSync(uploadDir, { recursive: true });
 const upload = multer({
-  dest: path.join(__dirname, '../../uploads'),
+  dest: uploadDir,
   limits: {
     fileSize: resolveTraceUploadLimitBytes(),
   },

--- a/docs/reference/portable-packaging.en.md
+++ b/docs/reference/portable-packaging.en.md
@@ -200,6 +200,18 @@ AI analysis should normally use Provider profiles configured in the UI. For env
 credentials, create an `env` file in the platform user data directory and
 restart the launcher.
 
+At startup, the portable package passes the writable upload directory to the
+backend through `UPLOAD_DIR` and creates `uploads/` under the user data root.
+Do not rely on package-local `backend/uploads`; this avoids readiness failures
+when the app is launched from a macOS `AppTranslocation` path or the app bundle
+is not writable. If a downloaded app starts under `AppTranslocation`, move it
+to `/Applications` before opening it. For a trusted, non-notarized package, you
+can also remove its quarantine attribute:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/SmartPerfetto.app
+```
+
 When a new Windows package selects the D-drive default and non-empty
 `%LOCALAPPDATA%\SmartPerfetto` data exists, the launcher safely copies it into staging for
 an absent or empty D target, writes a migration receipt, and atomically activates it. The C

--- a/docs/reference/portable-packaging.md
+++ b/docs/reference/portable-packaging.md
@@ -175,6 +175,16 @@ Windows 用户操作以 [Windows 配置与运行指南](../getting-started/windo
 AI 分析推荐在 UI 里配置 Provider profile。需要 env 凭证时，在对应用户数据目录
 创建 `env` 文件后重启启动器。
 
+便携包启动时会将可写的上传目录通过 `UPLOAD_DIR` 传给后端，并在用户数据根目录下
+创建 `uploads/`。不要依赖包内的 `backend/uploads`；这可以避免 App 位于 macOS
+`AppTranslocation` 临时路径或应用包不可写时，后端因上传目录不存在而无法通过 readiness
+检查。若从下载目录启动出现 `AppTranslocation`，请将 App 移到 `/Applications` 后再打开；
+可信的未公证包也可以移除隔离属性：
+
+```bash
+xattr -dr com.apple.quarantine /Applications/SmartPerfetto.app
+```
+
 Windows 新包选择 D 盘默认目录时，如果 `%LOCALAPPDATA%\SmartPerfetto` 非空而 D 盘
 目标不存在或为空，会把 C 盘数据安全复制到 staging，写入迁移回执后原子切换；C 盘
 原目录保持不变。D 盘目标非空时不合并、不覆盖。复制或激活失败会清理 staging、打印


### PR DESCRIPTION
## Summary
- use the launcher-provided UPLOAD_DIR for Perfetto local uploads
- create the upload directory recursively before multer initialization
- document macOS portable upload paths and AppTranslocation troubleshooting

## Verification
- `npm --prefix backend run typecheck`
- `npm --prefix backend run build`
- `GO111MODULE=off go test ./scripts/portable-launcher`
- portable script syntax checks
- compiled route upload-dir smoke

Existing unrelated test failure: workspaceResourceRoutes expects an English error while the current environment returns Chinese (`缺少 traceId`).